### PR TITLE
Define AF-2 Core/Vault split

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -72,13 +72,13 @@ Agent Foundry should use maturity stages for planning and release versions for d
 | AF-0 | Personal Bootstrap | Early personal repo built through direct iteration before strict planning and multi-agent workflow. | Historical stage; no need to retroactively perfect it. |
 | AF-1 | Governed Foundry | Practices, assets, workflows, review gates, adapter publishing, and current/proposed boundaries are governed explicitly. | Harvest/review/publish lifecycle is coherent; roadmap and hygiene work are tracked. |
 | AF-2 | Productizable Foundry | Repository layers and user/product boundaries are clear enough to support a reusable system. | Core, User Vault, Generated, Runtime, Local Private, and Proposed Design Evidence are separated by policy and implementation plan. |
-| AF-3 | External-User Ready | A new user can initialize and operate a clean vault without inheriting personal records. | Blank vault initialization, user-local config, examples/templates, and setup docs are usable. |
+| AF-3 | Split Vault Migration | Core and the maintainer's User Vault are physically separated without breaking existing local runtimes. | Public Core no longer requires maintainer vault content; maintainer Vault is private by default; existing Codex, Claude Code, Hermes, and ChatGPT setups are migrated or given a tested migration path; clean new-user setup is tested. |
 | AF-4 | Memory-System Ready | Future memory-system records, evidence policy, routing, privacy, and MCP boundaries are designed but not necessarily implemented. | Memory-system implementation home can be chosen with clear tradeoffs. |
 | AF-5 | Memory-System Implementation | A reviewed memory/knowledge system is implemented according to the chosen architecture. | MVP validates the main memory lifecycle without bypassing Agent Foundry governance. |
 
-Current planning stage: AF-1.
+Current planning stage: AF-2.
 
-AF-0 explains the existing mixed history. AF-1 starts the stricter planning and multi-agent coordination era. AF-2 and AF-3 are prerequisites for broad reuse. AF-4 is the decision gate for memory-system architecture. AF-5 is intentionally future work.
+AF-0 explains the existing mixed history. AF-1 starts the stricter planning and multi-agent coordination era. AF-2 designs the productization boundary. AF-3 executes the Core/Vault split needed for broad reuse. AF-4 is the decision gate for memory-system architecture. AF-5 is intentionally future work.
 
 ## Release Version Mapping
 
@@ -90,7 +90,7 @@ Suggested mapping:
 | --- | --- |
 | AF-1 | `v0.1.0`: governed personal foundry baseline. |
 | AF-2 | `v0.2.0`: productizable architecture and repo hygiene baseline. |
-| AF-3 | `v0.3.0`: external-user-ready vault/core setup. |
+| AF-3 | `v0.3.0`: split Core/Vault migration baseline. |
 | AF-4 | `v0.4.0`: memory-system-ready design baseline. |
 | AF-5 MVP | `v0.5.0` or later: memory-system MVP, not automatically `v1.0`. |
 | Post-AF-5 | Future: capability pack discovery/export after the core lifecycle and memory decisions are stable. |
@@ -143,7 +143,7 @@ Multi-agent rule:
 - Reviewer checks against the Epic exit criteria and relevant practices.
 - Harvester extracts reusable practices or asset candidates after meaningful work, using the harvest workflow.
 
-For now, create GitHub Project/Epic items only for AF-1 and AF-2 unless a later discussion explicitly opens AF-4 memory-system readiness work. AF-5 implementation issues should remain placeholders until M5 resolves the implementation home.
+For now, create GitHub Project/Epic items only for AF-1 through AF-3 unless a later discussion explicitly opens AF-4 memory-system readiness work. AF-5 implementation issues should remain placeholders until M6 resolves the implementation home.
 
 ## Milestones
 
@@ -241,8 +241,77 @@ Execution order:
 1. Complete Core/Vault split design (#6).
 2. Use that boundary to design blank vault initialization (#7) and configuration boundary (#8).
 3. Use #6, #7, and #8 together to write the external-user quickstart (#9).
+4. Do not claim external-user readiness until AF-3 physically separates the maintainer Vault from public Core.
 
-### M3: Existing Foundry Lifecycle Completion
+### M3: Physical Core/Vault Split And Migration
+
+Goal: split the reusable public Core from the maintainer's User Vault without breaking already-installed runtimes or losing reliable vault discovery.
+
+Decision baseline:
+
+- Target direction: public Core plus user-owned Vaults.
+- The maintainer's current User Vault belongs to Jinghu and should become private by default.
+- Existing single-repo operation is a staging state, not the final multi-user deployment model.
+- Physical split should happen after #6, #7, #8, and #9 are reviewed, and before claiming external-user readiness.
+
+Epics:
+
+- **Split execution plan**
+  - Choose final repo/directory names for Core and the maintainer Vault.
+  - Decide whether the maintainer Vault is a private GitHub repo, private local repo, or another private remote-backed location.
+  - Define a reversible migration sequence before moving files.
+  - Define rollback points and backups.
+
+- **Maintainer Vault extraction**
+  - Move the maintainer's `practices/`, `assets/`, `indexes/`, `usage/usage-aggregate.yaml`, vault-local docs, and reviewed imports into the private Vault.
+  - Keep raw local evidence ignored and local.
+  - Preserve history where practical, but prioritize correctness and privacy over perfect file history.
+  - Confirm no maintainer Vault content remains required by public Core defaults.
+
+- **Public Core cleanup**
+  - Keep reusable `workflows/`, `schemas/`, `scripts/`, `templates/`, runtime templates, adapter profiles, adapter quality rules, and product docs in Core.
+  - Replace personal defaults with templates, examples, empty indexes, or documented starter packs.
+  - Ensure Core does not publish the maintainer's active practices/assets as default product state.
+
+- **Locator and config migration**
+  - Update `~/.agent-foundry/config.yaml` semantics so `core_root` and `vault_root` may be different paths.
+  - Keep `repo_root` only as a compatibility alias or derived field when appropriate.
+  - Ensure agents can locate Core and Vault reliably from another project.
+  - Define precedence for `AGENT_FOUNDRY_HOME`, explicit Core/Vault environment variables, local config, and current-directory markers.
+  - Add clear failure messages when Core is found but Vault is missing, or Vault is found but Core tooling is missing.
+
+- **Runtime deployment migration**
+  - Inventory installed Codex, Claude Code, Hermes, and ChatGPT adapter targets before migration.
+  - Reinstall managed runtime files from the split Core plus maintainer Vault.
+  - Preserve managed-block and managed-directory ownership markers.
+  - Do not overwrite unmanaged runtime files.
+  - Provide a migration check that reports old path references, stale runtime files, adapter drift, and manual ChatGPT import requirements.
+
+- **Compatibility and validation**
+  - Update scripts to accept separate `core_root` and `vault_root`.
+  - Update consistency checks to validate the active Vault against Core schemas and workflows.
+  - Update adapter publishing so generated outputs can be derived from an arbitrary Vault.
+  - Verify blank-vault and maintainer-vault scenarios separately.
+  - Verify offline sync and usage aggregate behavior after split.
+
+- **External-user readiness gate**
+  - Test a clean setup using public Core plus a blank or new user Vault.
+  - Confirm setup does not require maintainer-specific paths, private records, or personal adapters.
+  - Confirm a user can choose a suitable Vault location: private Git repo, local-only repo, or other explicitly supported storage.
+  - Document where the Vault should live and how agents remember or rediscover it.
+
+Acceptance criteria:
+
+- Public Core can be cloned without exposing or requiring the maintainer's private Vault.
+- The maintainer's Vault is separate and private by default.
+- Existing local Codex, Claude Code, Hermes, and ChatGPT workflows have a tested migration path.
+- `core_root` and `vault_root` can be different paths and are both validated before canonical writes.
+- A blank Vault can be initialized and checked without personal practices/assets.
+- Adapter generation and runtime install work from both the maintainer Vault and a blank/new user Vault.
+- Rollback instructions exist for the split migration.
+- No future memory-system storage is introduced as part of the split.
+
+### M4: Existing Foundry Lifecycle Completion
 
 Goal: finish the practice/asset/adapter loop before adding memory record types.
 
@@ -274,7 +343,7 @@ Acceptance criteria:
 - Candidate/proposed entries do not publish into default adapters.
 - Active entries have either Activation guidance or explicit asset coverage/reference-only intent.
 
-### M4: Memory-System Readiness Design
+### M5: Memory-System Readiness Design
 
 Goal: define memory as an adjacent future capability without implementing storage yet.
 
@@ -309,9 +378,9 @@ Acceptance criteria:
 - Open questions remain visible.
 - No automatic memory writing exists.
 
-### M5: Fork vs Extension Decision
+### M6: Fork vs Extension Decision
 
-Goal: decide the implementation home for memory-system work using evidence from M1 through M4.
+Goal: decide the implementation home for memory-system work using evidence from M1 through M5.
 
 Decision options:
 
@@ -349,11 +418,11 @@ Acceptance criteria:
 - Decision record names the chosen option and rejected alternatives.
 - Future implementation plan has file boundaries, data flow, validation, privacy policy, and rollback path.
 
-### M6: Capability Pack Discovery and Lifecycle
+### M7: Capability Pack Discovery and Lifecycle
 
 Goal: define whether Agent Foundry can recognize, maintain, and export higher-level capability packs that emerge from repeated work.
 
-This is intentionally later than repository hygiene, productization, lifecycle completion, memory readiness, and the fork-vs-extension decision. Do not use this milestone to delay AF-1 through AF-5.
+This is intentionally later than repository hygiene, productization, physical split migration, lifecycle completion, memory readiness, and the fork-vs-extension decision. Do not use this milestone to delay AF-1 through AF-6.
 
 Capability packs are not the same as individual assets. A future capability pack may bundle practices, assets, workflows, templates, adapter snippets, examples, configuration profiles, dependency metadata, and export/install behavior around a recurring user goal such as multi-agent collaboration or technical documentation writing.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -213,6 +213,7 @@ Epics:
   - Define Core responsibilities.
   - Define User Vault responsibilities.
   - Decide whether Core and Vault remain in one repo for now or become separately installable later.
+  - Current design location: `docs/system-design.md` section "Core And User Vault Split".
 
 - **Blank vault initialization**
   - Design `init-vault` semantics before implementation.
@@ -234,6 +235,12 @@ Acceptance criteria:
 - A new user can create an empty vault conceptually without inheriting personal records.
 - Config and local runtime state are not confused with canonical knowledge.
 - The setup story does not require knowing the maintainer's machine or personal workflow.
+
+Execution order:
+
+1. Complete Core/Vault split design (#6).
+2. Use that boundary to design blank vault initialization (#7) and configuration boundary (#8).
+3. Use #6, #7, and #8 together to write the external-user quickstart (#9).
 
 ### M3: Existing Foundry Lifecycle Completion
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -224,6 +224,7 @@ Epics:
   - Separate portable config from machine-local config.
   - Confirm `~/.agent-foundry/config.yaml` remains a locator, not canonical knowledge.
   - Define where enabled runtimes, paths, privacy defaults, and sync remotes live.
+  - Define how agents distinguish product project context, Foundry Vault operations, and Foundry Core maintenance before writing.
 
 - **External-user quickstart**
   - Document what a new user clones or installs.
@@ -279,6 +280,7 @@ Epics:
   - Ensure agents can locate Core and Vault reliably from another project.
   - Define precedence for `AGENT_FOUNDRY_HOME`, explicit Core/Vault environment variables, local config, and current-directory markers.
   - Add clear failure messages when Core is found but Vault is missing, or Vault is found but Core tooling is missing.
+  - Add context checks that identify whether the current operation is product project work, Foundry Vault operation, or Foundry Core maintenance.
 
 - **Runtime deployment migration**
   - Inventory installed Codex, Claude Code, Hermes, and ChatGPT adapter targets before migration.
@@ -299,6 +301,7 @@ Epics:
   - Confirm setup does not require maintainer-specific paths, private records, or personal adapters.
   - Confirm a user can choose a suitable Vault location: private Git repo, local-only repo, or other explicitly supported storage.
   - Document where the Vault should live and how agents remember or rediscover it.
+  - Test nested usage: running harvest/refresh from inside a product project must locate the correct Core and Vault without confusing the product project with either.
 
 Acceptance criteria:
 
@@ -306,6 +309,7 @@ Acceptance criteria:
 - The maintainer's Vault is separate and private by default.
 - Existing local Codex, Claude Code, Hermes, and ChatGPT workflows have a tested migration path.
 - `core_root` and `vault_root` can be different paths and are both validated before canonical writes.
+- Product project, Foundry Vault operation, and Foundry Core maintenance contexts are distinguishable before writes or runtime installs.
 - A blank Vault can be initialized and checked without personal practices/assets.
 - Adapter generation and runtime install work from both the maintainer Vault and a blank/new user Vault.
 - Rollback instructions exist for the split migration.

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -172,6 +172,44 @@ AF-2 follow-up implications:
 - #9 should describe external-user setup without requiring the maintainer's Vault records.
 - AF-3 should execute the physical split and migration: public Core, maintainer private Vault, updated locators, runtime migration, and compatibility checks.
 
+## Operating Context Separation
+
+Agent Foundry must remain safe when it is used inside another software project. Users and agents regularly operate in nested contexts:
+
+1. **Product project context**: the user's actual software project, such as `token-panic`. This project is the evidence source and work target.
+2. **Foundry Vault context**: harvest, refresh, review, asset discovery, and adapter publishing for the user's Agent Foundry capability records.
+3. **Foundry Core maintenance context**: changing Agent Foundry's workflows, schemas, scripts, templates, adapter generation, install behavior, or roadmap.
+
+These contexts must not be inferred only from the current working directory or from a recent chat message. Before writing files, installing adapters, recording evidence, or updating GitHub issues, an agent should identify:
+
+```text
+work context: product project | foundry vault operation | foundry core maintenance
+evidence source: <project/session/import path>
+canonical vault root: <path>
+core root: <path>
+write target: <repo/path/runtime>
+review target: current session | user | separate reviewer | batch checkpoint
+```
+
+Context rules:
+
+1. Product project work may generate evidence for Agent Foundry, but the product project is not the canonical Foundry Vault unless it validates as one.
+2. Foundry Vault operations may read product project evidence, but canonical practice/asset/index writes go to the active Vault.
+3. Foundry Core maintenance changes reusable machinery and should go through Core review, even when prompted by a product project session.
+4. Runtime adapter install writes to user-owned runtime directories and must be derived from Core plus the selected Vault.
+5. `refresh practices and assets` is a Vault/Core synchronization command, not a product project dependency install.
+6. `harvest practices` must route artifacts before writing: product facts stay with the product project, reusable practices/assets go to the Vault, and Core workflow defects become Core maintenance.
+7. After the physical split, agents must validate both `core_root` and `vault_root` before canonical writes. If either is missing or ambiguous, stop and ask instead of guessing.
+
+Failure modes this prevents:
+
+- writing product project notes into the Foundry Core repo;
+- harvesting a project-local decision as a general Foundry practice;
+- modifying Core scripts when the user intended only to refresh a Vault;
+- installing stale adapters from the wrong Vault;
+- treating the maintainer's Vault as a default public starter pack;
+- using future memory-system paths as current writable destinations.
+
 Machine-local locator:
 
 ```text

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -89,7 +89,9 @@ Core and Vault currently live in one repository for maintainability. They are se
 
 ## Core And User Vault Split
 
-AF-2 keeps Agent Foundry in a single repository while making the Core/Vault split explicit. This is a logical split first, not a physical repository split. The goal is to make future external-user setup possible without requiring file movement before the boundaries are stable.
+The target product direction is a reusable public Core with user-owned Vaults. A user's Vault is private by default unless that user explicitly chooses to publish it. In the current repository, the maintainer's User Vault belongs to the maintainer, Jinghu, and should not remain bundled into a public Core distribution before Agent Foundry claims external-user readiness.
+
+AF-2 documents and validates the boundary before moving files. This is a staging step, not a final architecture. Physical Core/Vault separation should happen during the AF-3 migration work, after blank-vault initialization and configuration boundaries are designed well enough to avoid breaking existing local runtimes.
 
 Core contains reusable system capability:
 
@@ -136,18 +138,19 @@ Current repository mapping:
 | `Agent Foundry.md` | User Vault navigation | Maintainer hub, not required for external users. |
 | `.claude/settings.json` | Maintainer/runtime-specific setting | Boundary-sensitive; should not be product setup guidance without review. |
 
-Near-term packaging decision:
+Staged split decision:
 
-1. Keep Core and User Vault in one repository through AF-2.
-2. Treat the split as a documented boundary enforced by policy, checks, and future initialization design.
-3. Do not create a separate package, fork, or repository until AF-3 proves the blank-vault and external-user setup path.
-4. Design scripts so future `--core-root` and `--vault-root` separation is possible, but do not require it in current commands.
+1. Keep Core and User Vault in one repository only until the AF-2 design gates are reviewed.
+2. Treat the current split as a documented boundary enforced by policy, checks, and initialization design.
+3. Plan the physical split as AF-3 migration work, not as distant memory-system work.
+4. Design scripts so `core_root` and `vault_root` can point to different repositories or directories.
+5. Do not claim external-user readiness while the maintainer's Vault remains required inside the public Core repository.
 
 Future split options:
 
 | Option | Use when | Tradeoff |
 | --- | --- | --- |
-| Single repo with logical split | Current AF-2 path | Simple and low migration cost, but personal Vault remains physically adjacent to Core. |
+| Single repo with logical split | AF-2 design staging only | Simple and low migration cost, but personal Vault remains physically adjacent to Core and cannot be the external-user-ready endpoint. |
 | Monorepo with `core/` and `vault/` packages | Core and Vault need separate installs but shared development | More structure and migration work; still one remote. |
 | Core repo plus user vault repo | External-user distribution needs clean separation | Best product boundary, but requires install/init tooling and version compatibility. |
 | Template repository / starter vault | Blank-vault setup becomes the main adoption path | Easier onboarding, but template drift must be managed. |
@@ -167,6 +170,7 @@ AF-2 follow-up implications:
 - #7 should define a blank vault that starts with empty indexes, templates, and no personal practices/assets.
 - #8 should define portable Core config separately from machine-local runtime and adoption state.
 - #9 should describe external-user setup without requiring the maintainer's Vault records.
+- AF-3 should execute the physical split and migration: public Core, maintainer private Vault, updated locators, runtime migration, and compatibility checks.
 
 Machine-local locator:
 
@@ -174,7 +178,7 @@ Machine-local locator:
 ~/.agent-foundry/config.yaml
 ```
 
-This file records `repo_root`, `core_root`, `vault_root`, and canonical markers. It is written during install and is not canonical knowledge. Agents working in another repository should locate Agent Foundry through this config or `AGENT_FOUNDRY_HOME`, then validate the markers before writing canonical records.
+This file records `repo_root`, `core_root`, `vault_root`, and canonical markers. It is written during install and is not canonical knowledge. Agents working in another repository should locate Agent Foundry through this config or `AGENT_FOUNDRY_HOME`, then validate the markers before writing canonical records. After the physical split, `core_root` and `vault_root` may intentionally point to different repositories or directories; agents must validate both instead of assuming one repo root.
 
 ## Generated Artifact Policy
 

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -87,6 +87,87 @@ Downstream:
 
 Core and Vault currently live in one repository for maintainability. They are separate logical units so agents can distinguish the canonical destination from the current project they are harvesting from.
 
+## Core And User Vault Split
+
+AF-2 keeps Agent Foundry in a single repository while making the Core/Vault split explicit. This is a logical split first, not a physical repository split. The goal is to make future external-user setup possible without requiring file movement before the boundaries are stable.
+
+Core contains reusable system capability:
+
+- workflow definitions and command procedures;
+- schemas and templates for canonical records;
+- deterministic scripts for validation, generation, sync, install, and review;
+- adapter profiles and adapter quality rules;
+- runtime templates;
+- product documentation that describes how Agent Foundry works for any user.
+
+User Vault contains a user's governed capability records and review evidence:
+
+- canonical practices;
+- reusable assets;
+- practice and asset indexes;
+- sanitized usage aggregate evidence;
+- user-specific long-form docs, hubs, and planning evidence;
+- reviewed imports or staged external material that belongs to that user's capability base.
+
+Generated outputs are neither Core nor Vault. They are projections from Core tooling plus Vault records. Runtime copies are installed downstream and are never canonical.
+
+Current repository mapping:
+
+| Path or content | Split classification | Notes |
+| --- | --- | --- |
+| `workflows/` | Core | Agent-operable procedures. |
+| `schemas/` | Core | Canonical shape definitions. |
+| `scripts/` | Core | Deterministic tooling; must avoid personal defaults. |
+| `templates/` | Core | Starter record shapes, not personal content. |
+| `runtime/templates/` | Core | Portable runtime manifest template. |
+| `adapters/adapter_profiles.yaml` | Core | Describes target adapter behavior. |
+| `adapters/quality/` | Core | Adapter fidelity rules. |
+| `README.md`, `docs/usage.md`, `docs/deployment.md`, `docs/system-design.md`, `docs/lifecycle-compatibility.md`, `docs/offline-sync.md`, `docs/standards-and-sources.md` | Core-oriented docs with some current-repo context | External-user wording should be reviewed during AF-3. |
+| `docs/roadmap.md` | Mixed planning doc | Current maintainer roadmap; useful evidence, not required for a blank vault. |
+| `docs/memory-system-handoff-dump.md` | Proposed Design Evidence | Not Core runtime capability and not current memory architecture. |
+| `docs/obsidian.md` | User Vault / local workflow docs | Obsidian-oriented usage is not required Core behavior. |
+| `practices/` | User Vault | The maintainer's active governed practice base. |
+| `assets/` | User Vault | The maintainer's approved reusable assets. |
+| `indexes/` | User Vault | Registry for the current vault's records. |
+| `usage/usage-aggregate.yaml` | User Vault shared aggregate | Sanitized, but still specific to this vault. |
+| `imports/` | User Vault staging machinery plus tracked instructions | Directory convention may become Core; staged content is Vault/evidence. |
+| `adapters/codex/`, `adapters/claude-code/`, `adapters/hermes/`, `adapters/chatgpt/` | Generated distribution outputs | Tracked for install/manual import; regenerate from Core plus target Vault. |
+| `runtime/local/`, `sync/local/`, `usage/local/` | Local Private | Gitignored machine-local state. |
+| `Agent Foundry.md` | User Vault navigation | Maintainer hub, not required for external users. |
+| `.claude/settings.json` | Maintainer/runtime-specific setting | Boundary-sensitive; should not be product setup guidance without review. |
+
+Near-term packaging decision:
+
+1. Keep Core and User Vault in one repository through AF-2.
+2. Treat the split as a documented boundary enforced by policy, checks, and future initialization design.
+3. Do not create a separate package, fork, or repository until AF-3 proves the blank-vault and external-user setup path.
+4. Design scripts so future `--core-root` and `--vault-root` separation is possible, but do not require it in current commands.
+
+Future split options:
+
+| Option | Use when | Tradeoff |
+| --- | --- | --- |
+| Single repo with logical split | Current AF-2 path | Simple and low migration cost, but personal Vault remains physically adjacent to Core. |
+| Monorepo with `core/` and `vault/` packages | Core and Vault need separate installs but shared development | More structure and migration work; still one remote. |
+| Core repo plus user vault repo | External-user distribution needs clean separation | Best product boundary, but requires install/init tooling and version compatibility. |
+| Template repository / starter vault | Blank-vault setup becomes the main adoption path | Easier onboarding, but template drift must be managed. |
+
+Migration risks:
+
+- scripts may assume repo-relative paths that currently point to both Core and Vault;
+- consistency checks may assume one combined index/practice/asset tree;
+- adapters may encode the maintainer's current Vault content as if it were default product content;
+- docs may mix product instructions with maintainer planning evidence;
+- tracked workspace affordances such as `Agent Foundry.md` and `.claude/settings.json` may confuse external users;
+- usage aggregates are sanitized but still belong to the current user's Vault;
+- future memory-system evidence could accidentally be promoted into Core if capability state is not marked.
+
+AF-2 follow-up implications:
+
+- #7 should define a blank vault that starts with empty indexes, templates, and no personal practices/assets.
+- #8 should define portable Core config separately from machine-local runtime and adoption state.
+- #9 should describe external-user setup without requiring the maintainer's Vault records.
+
 Machine-local locator:
 
 ```text


### PR DESCRIPTION
## Summary

Implements the AF-2 Core/User Vault split design baseline for #6.

Changes:
- Adds `Core And User Vault Split` to `docs/system-design.md`.
- Maps current repository paths into Core, User Vault, Generated, Runtime/Local Private, and Proposed Design Evidence classifications.
- Records the near-term packaging decision: keep Core and Vault in one repo through AF-2 as a logical split, not a physical split.
- Lists future split options and migration risks.
- Updates `docs/roadmap.md` with the #6 design location and AF-2 execution order.

## Acceptance Criteria Coverage

- Core/Vault boundary is documented.
- Current repository directories are mapped into the boundary model.
- The design supports future external users without inheriting personal content by making blank-vault and external-user quickstart work depend on this boundary.
- The design does not implement memory-system storage and does not create future memory directories.

## Verification

- `python3 scripts/check_consistency.py` passed.
- `python3 scripts/check_adapter_quality.py` passed.
- `python3 scripts/check_activation.py` passed.
- `git diff --check` passed.
- Verified no `memory/`, `knowledge/`, `research_memos/`, or `project_memory/` directories were introduced.

## Review Handoff

Review target: current Architect session structured self-review, with user review available through this PR.
Review surface: PR plus #6 issue handoff.
Independent review required: no by default, because this is a documentation/design baseline with no file movement, no install behavior change, and no memory-system storage implementation.
Residual risks: #7/#8/#9 must still design blank-vault initialization, config boundary, and external-user quickstart before AF-2 is complete.
