### PR TITLE
Align Git workflow autonomy with collaboration practice

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ This repository is Agent Foundry, the canonical source of truth for reusable age
 - After the user approves a new or changed practice, apply the approved item and publish relevant adapters automatically.
 - Record ordinary asset usage evidence automatically when an active asset is invoked and the note can be kept concise and non-sensitive.
 - Treat memories, session summaries, and activity logs as evidence only. Memory can suggest; Agent Foundry decides.
+- For GitHub issue, branch, and PR work, follow `COLLAB-001`: verified task commits, task-branch pushes, and PR creation are normal workflow steps; direct commits to `main`, merges, issue closure, destructive Git operations, deletion, data migration, and privacy/security boundary changes still require explicit authorization.
 
 ## Default Workflow
 

--- a/adapters/chatgpt/custom-instructions.md
+++ b/adapters/chatgpt/custom-instructions.md
@@ -67,7 +67,8 @@ When recording or reviewing usage evidence, apply RUNTIME-004: keep raw logs loc
 
 For GitHub and multi-agent collaboration, use the Agent Collaboration asset ASSET-COLLAB-001. It applies COLLAB-001 through COLLAB-012 and COLLAB-014:
 
-- Code work for a GitHub issue should use a feature branch and PR unless I explicitly approve skipping the PR.
+- For work already authorized through an issue, branch, and PR workflow, create verified task commits, push the task branch, and open or update the PR without a separate commit-permission round trip.
+- Direct commits to `main`, PR merges, issue closure, force pushes, resets, deletions, data migrations, and privacy/security boundary changes still require explicit authorization.
 - Issues moved to review or closure need a durable comment with completion scope, linked PR or commit, verification method, verification results, and residual risks.
 - If I have authorized auto-merge, merge validated PRs by default unless I ask for review or a hold.
 - Before issue work in a multi-agent repo, fetch or pull and verify local/remote sync when another machine may have pushed.

--- a/adapters/claude-code/CLAUDE.md
+++ b/adapters/claude-code/CLAUDE.md
@@ -96,7 +96,8 @@ When asked to borrow or evaluate external skills, read `workflows/import-externa
 
 Use the Agent Collaboration asset ASSET-COLLAB-001 for GitHub issue, PR, GitHub Project/Epic scheduling, multi-agent sync, CLI comment, document conversion, and resume workflows. It applies canonical collaboration practices COLLAB-001 through COLLAB-012 and COLLAB-014:
 
-- For code work tied to a GitHub issue, use a feature branch and PR unless the user explicitly approves skipping the PR.
+- For work already authorized through an issue, branch, and PR workflow, create verified task commits, push the task branch, and open or update the PR without a separate commit-permission round trip.
+- Direct commits to `main`, PR merges, issue closure, force pushes, resets, deletions, data migrations, and privacy/security boundary changes still require explicit authorization.
 - Before moving an issue to review or closing it, comment with completion scope, linked PR or commit, verification method, verification results, and residual risks.
 - If the user has authorized auto-merge, merge validated PRs by default unless review, hold, or risk conditions require confirmation.
 - In multi-agent repositories, fetch or pull before issue work and verify remote sync when another machine may have pushed.

--- a/adapters/codex/skills/agent-collaboration/SKILL.md
+++ b/adapters/codex/skills/agent-collaboration/SKILL.md
@@ -15,7 +15,7 @@ This skill is an asset that performs a repeatable workflow. During execution, it
 
 ## Core Rules
 
-- COLLAB-001: Code changes made to complete a GitHub issue should go through a feature branch and PR unless the user explicitly approves skipping the PR.
+- COLLAB-001: In authorized issue/branch/PR workflow, create verified task commits, push task branches, and open PRs without a separate commit-permission round trip; direct `main` commits, merges, issue closure, destructive Git operations, deletion, data migration, and privacy/security boundary changes still require explicit authorization.
 - COLLAB-002: Before marking an issue ready for review or closed, comment with completion scope, linked PR or commit, verification method, verification results, and residual risks.
 - COLLAB-003: If the user has authorized auto-merge, merge validated PRs by default unless review, hold, failed checks, or high-risk changes require confirmation.
 - COLLAB-004: In multi-agent repositories, fetch or pull before issue work and verify remote sync when another machine may have pushed.
@@ -36,18 +36,20 @@ This skill is an asset that performs a repeatable workflow. During execution, it
 1. Identify whether the task touches an issue, PR, GitHub Project/Epic workflow, multi-agent sync, document conversion, or CLI comment publishing.
 2. Apply the matching canonical rule above.
 3. For multi-agent projects, locate the repo-local workflow contract and active issue Execution Contracts before choosing branch or PR behavior.
-4. Check issue role fit before pickup or release; split mixed work or constrain Implementers to evidence, preliminary classification, implementation, or verification when final decisions remain Architect-owned.
-5. Check completion handoff before work starts; if it says `batch checkpoint`, do not turn each child PR into a blocking Architect review unless a high-risk trigger or failed verification appears.
-6. Bind task, owner role, current session, and reviewer target explicitly when work moves between scheduler states; `needs:*` labels route roles, not necessarily different sessions.
-7. When a set of related issues has clear dependency gates, treat it as a batch queue instead of forcing one handoff per child issue.
-8. Before reviewing an individual child PR, check whether the issue belongs to an Epic batch queue, whether its completion handoff is `batch checkpoint`, whether a reviewer target is named, and whether a high-risk trigger exists.
-9. Preserve durable traceability in GitHub issues, PRs, labels, Project state, and comments.
-10. Validate with the checks appropriate to the artifact or code path, using batch or Epic review checkpoints when appropriate.
-11. Continue from the newest user request after interruptions or context transitions.
+4. If the work is authorized for branch/PR execution, do not leave verified changes as local-only state: commit, push the task branch, and open or update the PR with traceable evidence.
+5. Check issue role fit before pickup or release; split mixed work or constrain Implementers to evidence, preliminary classification, implementation, or verification when final decisions remain Architect-owned.
+6. Check completion handoff before work starts; if it says `batch checkpoint`, do not turn each child PR into a blocking Architect review unless a high-risk trigger or failed verification appears.
+7. Bind task, owner role, current session, and reviewer target explicitly when work moves between scheduler states; `needs:*` labels route roles, not necessarily different sessions.
+8. When a set of related issues has clear dependency gates, treat it as a batch queue instead of forcing one handoff per child issue.
+9. Before reviewing an individual child PR, check whether the issue belongs to an Epic batch queue, whether its completion handoff is `batch checkpoint`, whether a reviewer target is named, and whether a high-risk trigger exists.
+10. Preserve durable traceability in GitHub issues, PRs, labels, Project state, and comments.
+11. Validate with the checks appropriate to the artifact or code path, using batch or Epic review checkpoints when appropriate.
+12. Continue from the newest user request after interruptions or context transitions.
 
 ## Guardrails
 
-- Do not create direct commits for issue code work unless explicitly approved.
+- Do not stop for separate permission before normal task commits, task-branch pushes, or PR creation when issue/branch/PR workflow is already authorized and checks have passed.
+- Do not direct-commit to `main`, merge PRs, close issues, force push, reset, delete files or branches, migrate data, or change privacy/security boundaries without explicit authorization.
 - Do not close or move an issue without a completion and verification comment.
 - Do not auto-merge failed, risky, destructive, or explicitly held PRs.
 - Do not run destructive sync commands without user confirmation.

--- a/adapters/hermes/skills/agent-collaboration/SKILL.md
+++ b/adapters/hermes/skills/agent-collaboration/SKILL.md
@@ -15,7 +15,7 @@ This skill is an asset that performs a repeatable workflow. During execution, it
 
 ## Core Rules
 
-- COLLAB-001: Code changes made to complete a GitHub issue should go through a feature branch and PR unless the user explicitly approves skipping the PR.
+- COLLAB-001: In authorized issue/branch/PR workflow, create verified task commits, push task branches, and open PRs without a separate commit-permission round trip; direct `main` commits, merges, issue closure, destructive Git operations, deletion, data migration, and privacy/security boundary changes still require explicit authorization.
 - COLLAB-002: Before marking an issue ready for review or closed, comment with completion scope, linked PR or commit, verification method, verification results, and residual risks.
 - COLLAB-003: If the user has authorized auto-merge, merge validated PRs by default unless review, hold, failed checks, or high-risk changes require confirmation.
 - COLLAB-004: In multi-agent repositories, fetch or pull before issue work and verify remote sync when another machine may have pushed.
@@ -36,18 +36,20 @@ This skill is an asset that performs a repeatable workflow. During execution, it
 1. Identify whether the task touches an issue, PR, GitHub Project/Epic workflow, multi-agent sync, document conversion, or CLI comment publishing.
 2. Apply the matching canonical rule above.
 3. For multi-agent projects, locate the repo-local workflow contract and active issue Execution Contracts before choosing branch or PR behavior.
-4. Check issue role fit before pickup or release; split mixed work or constrain Implementers to evidence, preliminary classification, implementation, or verification when final decisions remain Architect-owned.
-5. Check completion handoff before work starts; if it says `batch checkpoint`, do not turn each child PR into a blocking Architect review unless a high-risk trigger or failed verification appears.
-6. Bind task, owner role, current session, and reviewer target explicitly when work moves between scheduler states; `needs:*` labels route roles, not necessarily different sessions.
-7. When a set of related issues has clear dependency gates, treat it as a batch queue instead of forcing one handoff per child issue.
-8. Before reviewing an individual child PR, check whether the issue belongs to an Epic batch queue, whether its completion handoff is `batch checkpoint`, whether a reviewer target is named, and whether a high-risk trigger exists.
-9. Preserve durable traceability in GitHub issues, PRs, labels, Project state, and comments.
-10. Validate with the checks appropriate to the artifact or code path, using batch or Epic review checkpoints when appropriate.
-11. Continue from the newest user request after interruptions or context transitions.
+4. If the work is authorized for branch/PR execution, do not leave verified changes as local-only state: commit, push the task branch, and open or update the PR with traceable evidence.
+5. Check issue role fit before pickup or release; split mixed work or constrain Implementers to evidence, preliminary classification, implementation, or verification when final decisions remain Architect-owned.
+6. Check completion handoff before work starts; if it says `batch checkpoint`, do not turn each child PR into a blocking Architect review unless a high-risk trigger or failed verification appears.
+7. Bind task, owner role, current session, and reviewer target explicitly when work moves between scheduler states; `needs:*` labels route roles, not necessarily different sessions.
+8. When a set of related issues has clear dependency gates, treat it as a batch queue instead of forcing one handoff per child issue.
+9. Before reviewing an individual child PR, check whether the issue belongs to an Epic batch queue, whether its completion handoff is `batch checkpoint`, whether a reviewer target is named, and whether a high-risk trigger exists.
+10. Preserve durable traceability in GitHub issues, PRs, labels, Project state, and comments.
+11. Validate with the checks appropriate to the artifact or code path, using batch or Epic review checkpoints when appropriate.
+12. Continue from the newest user request after interruptions or context transitions.
 
 ## Guardrails
 
-- Do not create direct commits for issue code work unless explicitly approved.
+- Do not stop for separate permission before normal task commits, task-branch pushes, or PR creation when issue/branch/PR workflow is already authorized and checks have passed.
+- Do not direct-commit to `main`, merge PRs, close issues, force push, reset, delete files or branches, migrate data, or change privacy/security boundaries without explicit authorization.
 - Do not close or move an issue without a completion and verification comment.
 - Do not auto-merge failed, risky, destructive, or explicitly held PRs.
 - Do not run destructive sync commands without user confirmation.

--- a/assets/skills/ASSET-COLLAB-001-agent-collaboration.asset.yaml
+++ b/assets/skills/ASSET-COLLAB-001-agent-collaboration.asset.yaml
@@ -2,7 +2,7 @@ id: ASSET-COLLAB-001
 title: Agent Collaboration
 asset_type: skill
 status: active
-version: 8
+version: 9
 created: 2026-05-28
 updated: 2026-06-09
 purpose: Guide GitHub issue, pull request, Project/Epic scheduling, multi-agent synchronization, CLI comment, document conversion, and interruption-resume workflows.
@@ -23,6 +23,7 @@ process:
   - split mixed issues or constrain Implementers to evidence, preliminary classification, implementation, or verification when final decisions remain Architect-owned
   - apply the matching collaboration, implementation, or testing practice
   - for Implementer pickup, read Project/label state plus issue execution contracts before creating branches or PRs
+  - when issue/branch/PR workflow is authorized, create verified task commits, push task branches, and open PRs without a separate commit-permission round trip
   - require completion handoff state in execution contracts before releasing another agent to work
   - bind task, owner role, current session, and review target explicitly when moving work between scheduler states
   - prefer dependency-gated batch handoff when related child issues can be released safely under one Epic checkpoint
@@ -47,6 +48,7 @@ outputs:
   - dual-surface review handoff and batch review guidance
   - child PR review trigger decisions
   - safe merge or hold decisions
+  - commit, push, and PR creation autonomy guidance
   - synchronization guidance
   - safe CLI comment handling
   - render-verified document conversion results
@@ -86,6 +88,7 @@ usage_triggers:
   - resume after interruption or compaction
 success_criteria:
   - issue work has branch, PR, or explicit direct-change approval
+  - authorized issue/branch/PR work is not left as uncommitted local state when verification has passed
   - multi-agent repositories have a discovered or bootstrapped repo-local workflow contract
   - Project status, labels, issue comments, and PRs have clear roles in the handoff
   - Ready queues are sorted by explicit dependency gates before Implementers start coding
@@ -103,6 +106,7 @@ success_criteria:
   - review handoff appears on both issue and PR surfaces when changes are requested
   - related low-risk issues are reviewed at meaningful batch or Epic checkpoints rather than through unnecessary per-issue churn
   - completion comments include scope, linked artifacts, verification, and residual risks
+  - direct commits to `main`, PR merges, issue closures, force pushes, resets, deletions, data migrations, and privacy/security boundary changes still require explicit authorization
   - merge decisions respect validation state and user hold/review requests
   - repository sync is checked before multi-agent issue work
   - Markdown comments avoid shell interpretation hazards

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -230,10 +230,12 @@ Epics:
   - Define how agents distinguish product project context, Foundry Vault operations, and Foundry Core maintenance before writing.
   - Current design location: `docs/system-design.md` section "Configuration Boundary".
 
-- **External-user quickstart**
-  - Document what a new user clones or installs.
+- **External-user setup boundary design**
+  - Document the pre-split setup narrative for a user who is not the repository maintainer.
+  - Identify what a new user would eventually clone, initialize, or install.
   - Document what remains private.
   - Document how adapters are installed and updated.
+  - Identify which parts cannot be completed until AF-3 split migration and AF-4 onboarding.
 
 Acceptance criteria:
 
@@ -245,7 +247,7 @@ Execution order:
 
 1. Complete Core/Vault split design (#6).
 2. Use that boundary to design blank vault initialization (#7) and configuration boundary (#8).
-3. Use #6, #7, and #8 together to write the external-user quickstart (#9).
+3. Use #6, #7, and #8 together to write the external-user setup boundary design (#9).
 4. Do not claim external-user readiness until AF-3 physically separates the maintainer Vault from public Core.
 5. Treat onboarding modes such as starter capability packs or runtime-asset imports as AF-4 design work unless needed as constraints for #7/#8.
 

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -427,7 +427,7 @@ Current repository classification:
 | `workflows/`, `schemas/`, `scripts/`, `templates/`, `runtime/templates/` | Core | Candidate for reusable distribution after AF-2 boundary work |
 | `practices/`, `assets/`, `indexes/`, `usage/usage-aggregate.yaml` | User Vault in this repository | Must not be copied wholesale into a blank external-user vault by default |
 | `adapters/` | Generated distribution outputs plus source-maintained adapter profiles/quality material | Regenerate from the target user's vault; tracked here for current runtime install and manual imports |
-| `docs/` | Mixed Core documentation, User Vault documentation, and proposed design evidence | External quickstart must distinguish product docs from maintainer planning evidence |
+| `docs/` | Mixed Core documentation, User Vault documentation, and proposed design evidence | External-user setup guidance must distinguish product docs from maintainer planning evidence |
 | `docs/memory-system-handoff-dump.md` | Proposed Design Evidence | Do not treat as implemented memory-system architecture |
 | `Agent Foundry.md` | User Vault navigation/hub for the maintainer's Obsidian-style workspace | Not a required Core file for external users |
 | `.claude/settings.json` | Maintainer/runtime-specific workspace setting | Should not become product setup guidance without AF-2 review |
@@ -441,7 +441,7 @@ Example conventions:
 5. Adapter outputs for an external user should be generated from that user's approved vault records, not copied from this repository's personal vault unless explicitly chosen as a starter pack.
 6. Proposed memory-system material must stay in docs/imports/evidence form until reviewed architecture creates implemented memory directories, schemas, and workflows.
 
-AF-2 should use this policy to design a blank vault initialization path, a Core/Vault split, and external-user quickstart. AF-1 does not move files yet; it marks the boundary so future movement is deliberate.
+AF-2 should use this policy to design a blank vault initialization path, a Core/Vault split, and external-user setup boundaries. AF-1 does not move files yet; it marks the boundary so future movement is deliberate.
 
 ## Practice Types
 

--- a/indexes/practice_index.yaml
+++ b/indexes/practice_index.yaml
@@ -329,7 +329,7 @@ practices:
     aliases: [failed assumption before patch, search the blast radius before fixing a bug, current error gone is not completion]
 
   - id: COLLAB-001
-    title: Issue code work uses PRs
+    title: Git autonomy follows workflow state
     path: practices/agent-collaboration/COLLAB-001-issue-code-work-uses-prs.md
     domain: agent-collaboration
     type: playbook

--- a/practices/agent-collaboration/COLLAB-001-issue-code-work-uses-prs.md
+++ b/practices/agent-collaboration/COLLAB-001-issue-code-work-uses-prs.md
@@ -1,20 +1,23 @@
 ---
 id: COLLAB-001
-title: Issue code work uses PRs
+title: Git autonomy follows workflow state
 domain: agent-collaboration
 type: playbook
 status: active
-version: 1
+version: 2
 created: 2026-05-26
-updated: 2026-05-26
-tags: [github, issues, pull-requests, traceability]
+updated: 2026-06-09
+tags: [github, issues, pull-requests, traceability, commits, workflow-state]
 aliases:
   - COLLAB-001
   - issue code changes go through pull requests
   - bind issue work to PRs
+  - commit autonomy follows workflow state
+  - issue work may commit and open PRs
 related: [COLLAB-002, COLLAB-003, COLLAB-004]
 applies_when:
   - implementing code for a GitHub issue
+  - making documentation or configuration changes for a GitHub issue
   - handing code work between local and remote agents
   - preparing an issue for review or closure
 review_required: false
@@ -23,30 +26,48 @@ provenance: "Harvested from 2026AgentApp session involving issue #71/#73 traceab
 
 ## Principle
 
-Code changes made to complete a GitHub issue should go through a feature branch and pull request unless the user explicitly approves skipping the PR.
+When work is explicitly inside an issue, branch, and PR workflow, the agent may create commits, push the task branch, and open a PR after appropriate verification. Higher-risk transitions still require explicit approval: direct commits to `main`, PR merge, issue closure, force push, reset, deletion, data migration, or privacy-sensitive changes.
 
 ## Rationale
 
-Direct commits make it hard for reviewers and other agents to see which code belongs to which issue. If history is later rewritten, squashed, or synchronized across machines, the issue can lose its visible connection to the implementation.
+Blanket "do not commit unless explicitly asked" rules slow down issue-driven collaboration and leave useful work as uncommitted local state that other agents cannot review or continue. At the same time, direct commits to protected branches, merge decisions, destructive Git operations, and issue closure change shared project state and need a clearer approval boundary.
+
+The durable rule should follow workflow state rather than a hardcoded local preference. Once the user or Architect has authorized a task through a GitHub issue, branch strategy, and PR target, commit/push/PR creation are normal execution steps. Acceptance, merge, closure, and destructive operations remain governed review points.
 
 ## Guidance
 
-Before coding for an issue, create a branch named for the issue or task. Open a PR that references the issue, include the completion summary and verification results, and merge only after the relevant checks pass. If the user explicitly asks for direct commits, record the affected commit and file locations in the issue comments.
+Before editing for an issue, read the issue scope, dependencies, branch strategy, PR target, and completion handoff. If the task is authorized for branch/PR work:
+
+1. create or use the task branch;
+2. make the focused changes;
+3. run appropriate checks;
+4. commit the verified changes with a task-relevant message;
+5. push the branch;
+6. open or update a PR that references the issue;
+7. post completion scope, verification, and residual risks on the issue or PR.
+
+Do not stop for separate permission merely to create the normal task commit, push the task branch, or open the PR. Do stop for approval before merging, closing the issue, committing directly to `main`, force pushing, resetting, deleting files or branches, migrating private data, or changing privacy/security boundaries.
+
+For exploratory changes that are not tied to an issue/branch/PR workflow, show the diff before committing unless the user has explicitly authorized commit-and-PR handling for that work.
 
 ## Use This When
 
 - The user says to start work on a numbered GitHub issue.
-- The task requires code changes that should be reviewed, merged, or audited later.
+- The task requires code, documentation, configuration, or workflow changes that should be reviewed, merged, or audited later.
 - Multiple agents or machines are collaborating on the same repository.
+- A local preference says not to commit unless explicitly asked, but the current work has already entered a governed issue/PR workflow.
 
 ## Watch Out For
 
 - Do not treat a local commit message as enough traceability.
-- Avoid closing or moving the issue without linking the PR or final commit.
+- Do not direct-commit to `main` merely because branch creation is inconvenient.
+- Do not merge the PR or close the issue unless the completion handoff, user instruction, or repository policy authorizes that transition.
+- Do not use commit autonomy to bypass human review for architecture, taxonomy, privacy, security, harvest, or activation decisions.
+- Avoid closing or moving the issue without linking the PR or final commit and recording verification evidence.
 
 ## Example
 
-For an issue that adds a static demo adapter, create a branch such as `issue-71-static-demo-job`, open a PR that references `#71`, run validation, merge the PR, and comment on `#71` with the PR, commit, and verification results.
+For an issue that adds a static demo adapter, create a branch such as `issue-71-static-demo-job`, run validation, commit the change, push the branch, open a PR that references `#71`, and comment on `#71` with the PR, commit, verification results, and residual risks. Merge and close only when the review/acceptance rule for that issue allows it.
 
 ## Related Practices
 

--- a/usage/usage-aggregate.yaml
+++ b/usage/usage-aggregate.yaml
@@ -27,11 +27,11 @@ aggregates:
     period: 2026-06
     agent: "codex"
     machine_hash: "a6bcad5212d8"
-    useful_count: 2
+    useful_count: 3
     neutral_count: 0
     not_useful_count: 0
     unknown_count: 0
-    last_used: 2026-06-08
+    last_used: 2026-06-09
   - subject_type: asset
     subject_id: ASSET-META-001
     period: 2026-05
@@ -47,7 +47,7 @@ aggregates:
     period: 2026-06
     agent: "codex"
     machine_hash: "a6bcad5212d8"
-    useful_count: 9
+    useful_count: 10
     neutral_count: 0
     not_useful_count: 0
     unknown_count: 0


### PR DESCRIPTION
## Summary

Updates Agent Foundry's Git workflow autonomy rule so commit behavior is governed by canonical collaboration practice instead of hardcoded local preference.

Changes:
- Revises `COLLAB-001` from a narrow PR traceability rule to `Git autonomy follows workflow state`.
- Updates `ASSET-COLLAB-001` to include commit/push/PR creation autonomy for authorized issue workflows.
- Publishes the updated rule into Codex, Hermes, Claude Code, and ChatGPT adapters.
- Adds a thin repo `AGENTS.md` pointer to `COLLAB-001` instead of duplicating the full policy.
- Renames AF-2 #9 wording from external-user quickstart to external-user setup boundary design.
- Records sanitized usage evidence for the active harvester and collaboration assets.

Runtime updates already applied locally:
- Codex skill copied to `~/.codex/skills/agent-collaboration/SKILL.md`.
- Hermes skill copied to `~/.hermes/skills/agent-collaboration/SKILL.md`.
- Claude Code managed file copied to `~/.claude/agent-foundry/CLAUDE.md` and managed block refreshed.
- ChatGPT remains manual import.
- Global Codex preference file `~/.codex/AGENTS.md` was updated outside this repo to reference `COLLAB-001` instead of a blanket no-commit rule.

## Verification

- `python3 scripts/check_consistency.py`
- `python3 scripts/check_adapter_quality.py`
- `python3 scripts/check_activation.py`
- `git diff --check`
- `python3 scripts/install_foundry.py --apply`

## Review notes

This PR does not authorize automatic PR merge or issue closure. It only lets agents complete normal task-branch commit/push/PR creation once an issue/branch/PR workflow is already authorized and verified.
