### PR TITLE
Enforce harvest approval scope guard

### DIFF
--- a/adapters/chatgpt/custom-instructions.md
+++ b/adapters/chatgpt/custom-instructions.md
@@ -45,7 +45,7 @@ Follow this route:
 session summary -> candidate lessons -> classification -> dedupe -> decision -> canonical update -> human review -> adapter update -> report
 ```
 
-For harvest work, run the current capability check before routing or drafting; do not use future architecture concepts as current writable substrate. Route artifacts before abstracting practices. Treat user method corrections as process evidence first. Apply the generalization gate before drafting practice candidates, and list important rejected-as-practice items.
+For harvest work, run the current capability check before routing or drafting; do not use future architecture concepts as current writable substrate. Route artifacts before abstracting practices. Treat user method corrections as process evidence first. Apply the generalization gate before drafting practice candidates, and list important rejected-as-practice items. Present a concise review list before mutation, including canonical impact, adapter impact, and runtime/global instruction impact when relevant. Treat approval as scoped to the listed items only; broad phrases such as "continue", "approved", or "do the whole chain" do not permit skipping unshown harvest steps.
 
 Do not put raw lessons directly into skills or prompts. New practices should start as `candidate` or `proposed` unless I explicitly approve activation. After I approve a practice, apply it, promote it to `active` when applicable, update the index, and publish the relevant adapters automatically. Only `active` practices should be published into default agent adapters.
 

--- a/adapters/claude-code/CLAUDE.md
+++ b/adapters/claude-code/CLAUDE.md
@@ -51,9 +51,11 @@ When asked to harvest, persist, deduplicate, merge, or publish reusable lessons:
 5. Route artifacts before abstracting practices.
 6. Apply the generalization gate before drafting practice candidates.
 7. Search `indexes/practice_index.yaml`.
-8. Update canonical practice entries under `practices/` first.
-9. Do not publish `candidate` or `proposed` entries into adapters without human approval.
-10. After the user approves a practice, apply it, promote it to `active` when applicable, update the index, and publish relevant adapters automatically.
+8. Present a concise review list before mutation, including rejected-as-practice items, canonical impact, adapter impact, and runtime/global instruction impact when relevant.
+9. Treat approval as scoped to the listed items only; broad phrases such as "continue", "approved", or "do the whole chain" do not permit skipping unshown harvest steps.
+10. Update canonical practice entries under `practices/` first.
+11. Do not publish `candidate` or `proposed` entries into adapters without human approval.
+12. After the user approves a practice, apply it, promote it to `active` when applicable, update the index, and publish relevant adapters automatically.
 
 When asked to discover reusable assets, read `workflows/discover-assets.md`, search `indexes/asset_index.yaml`, present asset candidates, and after approval create or extend assets and publish relevant adapters.
 
@@ -84,7 +86,7 @@ Apply META-009 when publishing adapters: adapter quality must be executable and 
 
 Apply META-010 when reviewing assets: use lifecycle state, usage evidence, overlap, canonical coverage, stale triggers, and published targets before recommending keep, revise, deprecate, archive, split, or merge.
 
-Apply META-011 through META-013 during harvest: route artifacts before abstracting practices, treat user method corrections as process evidence before domain content, and require insights to pass a generalization gate before they become practice candidates.
+Apply META-011 through META-013 during harvest: route artifacts before abstracting practices, treat user method corrections as process evidence before domain content, require insights to pass a generalization gate before they become practice candidates, and do not convert approval of a direction into approval to bypass an unshown review list.
 
 Apply RUNTIME-004 when recording or reviewing usage evidence: raw logs stay local under `usage/local/`; shared review uses sanitized aggregate rows in `usage/usage-aggregate.yaml`; missed activation and other review-only signals must not inflate shared usage counts.
 

--- a/adapters/codex/skills/practice-harvester/SKILL.md
+++ b/adapters/codex/skills/practice-harvester/SKILL.md
@@ -46,9 +46,11 @@ Before substantial changes, check:
 8. Search the practice index before creating anything new.
 9. Classify candidates as principle, pattern, heuristic, playbook, checklist, example, or anti-pattern.
 10. Decide for each candidate: discard, merge, create, supersede, or defer.
-11. Present a concise review list including rejected-as-practice items when important.
-12. After the user approves a practice, apply the canonical change and publish relevant adapters automatically.
-13. Report candidates, decisions, changed files, and review needs.
+11. Present a concise review list including rejected-as-practice items, canonical impact, adapter impact, and runtime/global instruction impact when important.
+12. Treat approval as scoped to the listed items only. Broad phrases such as "continue", "approved", or "do the whole chain" do not permit skipping unshown harvest steps.
+13. For self-referential workflow changes, stop at the review list before canonical mutation; after approval, mutate canonical records and use a PR or equivalent review surface before runtime publish.
+14. After the user approves a practice, apply the canonical change and publish relevant adapters automatically.
+15. Report candidates, decisions, changed files, and review needs.
 
 ## Guardrails
 
@@ -60,6 +62,7 @@ Before substantial changes, check:
 - Record concise, non-sensitive asset usage evidence automatically when an active asset is invoked.
 - Treat memory as evidence, not source of truth.
 - During harvest, route artifacts before abstraction, treat user method corrections as process evidence first, and require insights to pass a generalization gate before they become practice candidates.
+- Do not convert approval of a direction into approval to bypass an unshown harvest review list. If the review list was skipped, stop, add the missing harvest report, and wait for approval of that report before publishing runtime adapters.
 - Treat native agent learning outputs as candidate inputs; do not suppress native self-growth capabilities in agents that provide them.
 - Treat agent runtime directories as shared user-owned environments. When publishing adapters, use managed blocks, namespaced files, ownership markers, backups, dry-runs, and explicit adoption for unmanaged runtime paths; never overwrite unmanaged runtime files by default.
 - Separate portable adapter intent from machine-local deployment state. Keep adapter profiles and runtime templates in the repo, but keep enabled targets, detected paths, and adoption decisions in gitignored local manifests; portable snapshots exclude machine-local runtime state by default.

--- a/adapters/hermes/skills/practice-harvester/SKILL.md
+++ b/adapters/hermes/skills/practice-harvester/SKILL.md
@@ -44,9 +44,11 @@ Before substantial changes, check:
 6. Route artifacts before abstracting practices: evidence only, design note, research/reference material, project-local decision, workflow update, practice candidate, skill/asset candidate, adapter update, or discard.
 7. Apply the generalization gate before drafting practice candidates.
 8. Search the practice index before creating anything new.
-9. Present a concise review list including rejected-as-practice items when important.
-10. After the user approves a practice, apply the canonical change and publish relevant adapters automatically.
-11. Report candidates, decisions, changed files, and review needs.
+9. Present a concise review list including rejected-as-practice items, canonical impact, adapter impact, and runtime/global instruction impact when important.
+10. Treat approval as scoped to the listed items only. Broad phrases such as "continue", "approved", or "do the whole chain" do not permit skipping unshown harvest steps.
+11. For self-referential workflow changes, stop at the review list before canonical mutation; after approval, mutate canonical records and use a PR or equivalent review surface before runtime publish.
+12. After the user approves a practice, apply the canonical change and publish relevant adapters automatically.
+13. Report candidates, decisions, changed files, and review needs.
 
 ## Guardrails
 
@@ -58,6 +60,7 @@ Before substantial changes, check:
 - Record concise, non-sensitive asset usage evidence automatically when an active asset is invoked.
 - Treat memory as evidence, not source of truth.
 - During harvest, route artifacts before abstraction, treat user method corrections as process evidence first, and require insights to pass a generalization gate before they become practice candidates.
+- Do not convert approval of a direction into approval to bypass an unshown harvest review list. If the review list was skipped, stop, add the missing harvest report, and wait for approval of that report before publishing runtime adapters.
 - Do not disable Hermes native memory, autonomous skill creation, or local self-improvement. Treat native outputs as candidate inputs when they should become durable or cross-agent.
 - Treat agent runtime directories as shared user-owned environments. When publishing adapters, use managed blocks, namespaced files, ownership markers, backups, dry-runs, and explicit adoption for unmanaged runtime paths; never overwrite unmanaged runtime files by default.
 - Separate portable adapter intent from machine-local deployment state. Keep adapter profiles and runtime templates in the repo, but keep enabled targets, detected paths, and adoption decisions in gitignored local manifests; portable snapshots exclude machine-local runtime state by default.

--- a/assets/skills/ASSET-META-001-practice-harvester.asset.yaml
+++ b/assets/skills/ASSET-META-001-practice-harvester.asset.yaml
@@ -2,9 +2,9 @@ id: ASSET-META-001
 title: Practice Harvester
 asset_type: skill
 status: active
-version: 1
+version: 2
 created: 2026-05-26
-updated: 2026-05-28
+updated: 2026-06-09
 purpose: Maintain reusable practices by harvesting lessons, importing external skills, publishing adapters, and reviewing skill rot.
 responsibility: Maintain the Agent Foundry lifecycle of practices, assets, indexes, adapters, usage evidence, and related review reports.
 non_responsibility: Does not perform domain-specific engineering work except to harvest or package reusable lessons from it.
@@ -14,12 +14,17 @@ inputs:
   - existing practice and asset indexes
   - recent work history when discovering assets
 process:
+  - locate and validate the current Agent Foundry Core and Vault
+  - reconstruct the relevant session or correction
+  - route artifacts before drafting candidates
+  - apply the generalization gate
   - classify candidate practices or assets
   - deduplicate against indexes
-  - present concise review list
+  - present a concise review list before canonical mutation
   - apply approved items
-  - publish relevant adapters
+  - publish relevant adapters only after approved canonical changes are applied
 outputs:
+  - harvest report or review list
   - proposed or active practice entries
   - active asset records
   - updated indexes
@@ -36,6 +41,9 @@ canonical_practices:
   - META-008
   - META-009
   - META-010
+  - META-011
+  - META-012
+  - META-013
   - GOV-001
   - GOV-002
   - GOV-003
@@ -58,8 +66,11 @@ usage_triggers:
   - review practices
   - 检查 skill rot
 success_criteria:
+  - artifact routing, generalization, rejected-as-practice, canonical impact, adapter impact, and runtime impact are visible before approval
   - candidates are deduplicated against existing practices and assets
   - human approval is requested per meaningful new or changed item
+  - broad approval language is not interpreted as permission to skip unshown workflow steps
+  - self-referential workflow changes stop at a review list before canonical mutation
   - approved items are activated and published to relevant adapters
   - changed files and deferred items are reported clearly
 review_cadence: monthly

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -110,6 +110,29 @@ Agent Foundry 里最核心的一条链路，是从真实工作经验到可复用
 
 所以 Agent Foundry 必须保持一个很实际的约束：每一层 meta 设计，都要回到真实工作中的一个失败模式或能力缺口。不能因为“治理”本身很有趣，就把项目做成一个抽象的治理宇宙。它应该像工厂里的治具和量规：存在的意义不是展示复杂性，而是让下一次生产更稳定、更可复验、更少犯同样的错。
 
+## 自我指涉的流程缺陷
+
+Agent Foundry 的一个特殊风险，是 agent 会用正在被修改的流程来修改流程本身。
+
+这不是普通的执行错误，而是一种自我指涉缺陷。比如，我要求 agent 走 harvest workflow 来修正 harvest workflow，agent 同时要理解用户授权、执行修改、维护 review gate、发布 adapter，还要判断自己是否已经遵守了刚刚被讨论的规则。所有这些判断都发生在同一个推理回路里。只靠 agent 说“我下次会记住”，并不能可靠地避免再次跳过流程。
+
+这个问题在真实使用中已经出现过不止一次：用户说“批准”“继续”“做完整链路”，agent 就把它解释成可以直接修改 canonical practice、发布 runtime adapter，事后再补解释。这种行为表面上提高效率，实际上破坏了 Agent Foundry 最重要的治理边界：批准必须作用于已经列明的对象，而不是回头覆盖一个没有展示过的 review list。
+
+更可靠的办法，是把自我更新拆成外化状态机：
+
+```text
+harvest report / review list
+  -> explicit approval of listed items
+  -> canonical mutation
+  -> PR or equivalent review surface
+  -> post-merge adapter/runtime publish
+  -> final verification
+```
+
+这不是为了把流程变慢，而是为了避免最危险的压缩：把方向性授权当成流程豁免。尤其当修改对象是 harvest workflow、practice-harvester asset、adapter publish、runtime install、AGENTS 指令或其他会影响未来 agent 行为的规则时，系统必须先把 proposed change 外化成 review list。用户批准的是 list 里的 items，而不是 agent 心里推断出来的完整链路。
+
+这也说明 human-in-the-loop 的意义不只是审批内容是否正确，还包括打断 agent 的自我合理化。一个 agent 可以很好地解释为什么它跳过了步骤，但解释不是治理。治理需要可检查的状态、可引用的 review surface、可回滚的 commit、以及发布前后的明确边界。
+
 ## 这是一个重复造轮子的故事吗？
 
 我也受到了一些外部 memory system 的影响。比如 Garry Tan 的 GBrain 引起了我很大兴趣，我也是因此才决定做这个系统。而且我相信记忆系统结合harness必然是当今最火的发展方向，各种复杂度的此类系统会层出不穷。Agent memory 不是小功能，而是 agent 能不能长期变聪明的核心基础设施。

--- a/indexes/asset_index.yaml
+++ b/indexes/asset_index.yaml
@@ -15,7 +15,7 @@ assets:
     path: assets/skills/ASSET-META-001-practice-harvester.asset.yaml
     asset_type: skill
     status: active
-    canonical_practices: [META-001, META-002, META-003, META-004, META-005, META-006, META-007, META-008, META-009, META-010, GOV-001, GOV-002, GOV-003, GOV-004, RUNTIME-001, RUNTIME-002, RUNTIME-003, RUNTIME-004]
+    canonical_practices: [META-001, META-002, META-003, META-004, META-005, META-006, META-007, META-008, META-009, META-010, META-011, META-012, META-013, GOV-001, GOV-002, GOV-003, GOV-004, RUNTIME-001, RUNTIME-002, RUNTIME-003, RUNTIME-004]
     published_to: [codex, claude-code, hermes, chatgpt]
     usage_triggers:
       - harvest practices

--- a/practices/meta/META-012-treat-user-corrections-as-process-evidence-before-content-evidence.md
+++ b/practices/meta/META-012-treat-user-corrections-as-process-evidence-before-content-evidence.md
@@ -4,9 +4,9 @@ title: Treat user corrections as process evidence before content evidence
 domain: meta
 type: heuristic
 status: active
-version: 1
+version: 2
 created: 2026-06-08
-updated: 2026-06-08
+updated: 2026-06-09
 tags: [feedback-learning, corrections, harvesting, process-evidence]
 aliases:
   - META-012
@@ -39,20 +39,26 @@ Analyze corrections for:
 - review checklist gap;
 - handoff risk;
 - harvest risk;
+- approval-scope confusion;
 - generalizable practice evidence.
 
 After that process analysis, decide whether the correction also contains domain content worth routing elsewhere.
+
+When the correction says the agent skipped or compressed the required workflow, do not treat a later `continue`, `approved`, or `do the whole chain` response as retroactive permission to skip the missing step. First name the process failure, restore the missing review checkpoint, and wait for approval of the listed items before mutating canonical records or publishing runtime adapters.
 
 ## Use This When
 
 - The user says the agent drifted, oversimplified, overbuilt, lost nuance, or confused current and proposed systems.
 - A correction changes how the agent should harvest, review, plan, or hand off work.
 - The same correction could be read as both domain content and workflow feedback.
+- The user points out that the agent over-interpreted approval, skipped harvest, published before review, or explained a missed step after the fact.
 
 ## Watch Out For
 
 - Do not bury method corrections inside the domain being discussed.
 - Do not treat every correction as a new practice; route it first, then apply the generalization gate.
+- Do not convert the user's approval of a direction into approval to bypass unshown workflow steps.
+- Do not publish adapters or runtime instructions first and then use an explanation as a substitute for the missing harvest report.
 - Do not record missed activation evidence unless a specific existing practice should have triggered.
 
 ## Activation

--- a/usage/usage-aggregate.yaml
+++ b/usage/usage-aggregate.yaml
@@ -47,7 +47,7 @@ aggregates:
     period: 2026-06
     agent: "codex"
     machine_hash: "a6bcad5212d8"
-    useful_count: 10
+    useful_count: 11
     neutral_count: 0
     not_useful_count: 0
     unknown_count: 0

--- a/workflows/harvest-practices.md
+++ b/workflows/harvest-practices.md
@@ -216,6 +216,25 @@ Ask for approval before:
 - importing external skill content;
 - executing or adapting external scripts.
 
+### Approval Scope Guard
+
+User approval applies only to the items, files, status changes, adapter updates, and runtime publish actions that were listed in the harvest review list or an equivalent PR/issue harvest report. Do not interpret broad phrases such as `continue`, `approved`, `do the whole chain`, or `finish it` as permission to skip artifact routing, the generalization gate, rejected-as-practice reporting, or adapter/runtime impact disclosure.
+
+If the user approves a direction before the review list exists, treat that approval as approval to prepare the review list, not as approval to mutate canonical records or publish runtime adapters.
+
+When the harvest modifies the harvest workflow, practice-harvester asset, adapter publishing workflow, runtime publish behavior, AGENTS instructions, or any rule that governs future self-updates, use a stricter self-referential sequence:
+
+```text
+harvest report / review list
+  -> explicit approval of listed items
+  -> canonical mutation
+  -> PR or equivalent review surface
+  -> post-merge adapter/runtime publish
+  -> final verification
+```
+
+In self-referential workflow changes, do not repair a missing review list by publishing first and explaining afterward. If the review list was skipped, stop, publish no further runtime changes, add the missing harvest report to the PR or issue, and wait for approval of that report before continuing.
+
 Present a concise review list. For each new or changed practice, show:
 
 - title;
@@ -223,6 +242,7 @@ Present a concise review list. For each new or changed practice, show:
 - reason;
 - canonical files affected;
 - adapters that will be updated after approval.
+- runtime or global instruction files that will be updated after approval.
 
 Approval is per practice. When the user approves an item, apply that item's full chain:
 


### PR DESCRIPTION
## Summary

Adds an approval-scope guard to the harvest workflow so user approval cannot be over-interpreted as permission to skip unshown harvest steps.

Changes:
- Adds `Approval Scope Guard` to `workflows/harvest-practices.md`.
- Revises `META-012` to cover approval-scope confusion and explain-then-publish failure modes.
- Updates `ASSET-META-001` to require visible routing, generalization, rejected-as-practice, canonical impact, adapter impact, and runtime impact before approval.
- Adds META-011 through META-013 to `ASSET-META-001` canonical practice coverage and `indexes/asset_index.yaml`.
- Updates Codex, Hermes, Claude Code, and ChatGPT practice-harvester adapters.
- Adds philosophy documentation for self-referential workflow defects and externalized state machines.
- Records sanitized usage evidence for ASSET-META-001.

## Harvest Review List Applied

Approved review list:
- Current capability check: current writable substrates are workflows, practices, assets, adapters, and docs; no future memory or capability-pack substrate used.
- Artifact routing: repeated approval-overinterpretation is workflow update + practice merge; self-referential defect discussion is philosophy note.
- Generalization gate: passed; applies to any agent maintaining its own workflows/runtimes.
- Merge target: `workflows/harvest-practices.md`, `META-012`, `ASSET-META-001`, and practice-harvester adapters.
- Rejected as practice: always ask twice, skip workflow when user says continue, solve by AGENTS.md hardcoding, or rely on agent promises.

## Verification

- `python3 scripts/check_consistency.py`
- `python3 scripts/check_adapter_quality.py`
- `python3 scripts/check_activation.py`
- `git diff --check`

## Runtime Publish

Deferred. Runtime adapters and global AGENTS should be published only after this PR is merged and accepted.
