### PR TITLE
Harvest session asset updates

### DIFF
--- a/adapters/chatgpt/knowledge/assets.md
+++ b/adapters/chatgpt/knowledge/assets.md
@@ -16,7 +16,9 @@ Published asset IDs:
 - ASSET-COLLAB-001 Agent Collaboration
 - ASSET-IMPL-001 Provider Integration Playbook
 
-ASSET-COLLAB-001 currently maps to COLLAB-001 through COLLAB-012, COLLAB-014, IMPL-001, and TEST-001. It covers GitHub issue/PR traceability, repository sync, repo-local multi-agent workflow contracts, issue role-fit gates, GitHub Project/Epic scheduling, issue Execution Contracts with Architect-owned decision boundaries, completion handoff state, current owner role, reviewer target, coherent Project/status/label/session routing, Ready queues with dependency gates and batch handoff, Epic integration branch defaults, dual-surface review handoff, structured self-review marking, batch/Epic checkpoint review, safe CLI Markdown comments, complex handoff continuity, and render-verified document conversion. Proposed practices such as COLLAB-013 are not published into default adapters until approved active.
+ASSET-COLLAB-001 currently maps to COLLAB-001 through COLLAB-012, COLLAB-014, IMPL-001, and TEST-001. It covers GitHub issue/PR traceability, repository sync, repo-local multi-agent workflow contracts, roadmap-to-Project issue planning, issue role-fit gates, GitHub Project/Epic scheduling, built-in Status versus Roadmap Status separation, issue Execution Contracts with Architect-owned decision boundaries, completion handoff state, current owner role, reviewer target, coherent Project/status/label/session routing, Ready queues with dependency gates and batch handoff, Epic integration branch defaults, dual-surface review handoff, structured self-review marking, batch/Epic checkpoint review, safe CLI Markdown comments, complex handoff continuity, and render-verified document conversion. Proposed practices such as COLLAB-013 are not published into default adapters until approved active.
+
+ASSET-ARCH-001 covers architecture design and review, including layer taxonomy and boundary inventory before file movement or migration. For mixed systems, classify paths, modules, records, generated outputs, runtime state, private state, and proposed design evidence by ownership and change behavior, and mark ambiguous areas as `Mixed` or `Needs Architect Classification` instead of forcing premature final taxonomy.
 
 Assets are user-facing reusable tools discovered from repeated work:
 
@@ -24,7 +26,7 @@ Assets are user-facing reusable tools discovered from repeated work:
 - `subagent`: bounded delegable role or investigation task.
 - `automation`: scheduled or recurring check, report, reminder, or monitor.
 
-Discovery outputs asset candidates, not canonical practices. Workflows and adapters are internal maintenance machinery, not user-facing asset types.
+Discovery outputs asset candidates, not canonical practices. Workflows and adapters are internal maintenance machinery, not user-facing asset types. `harvest skills` and `harvest assets` are asset discovery triggers; for whole-session or phase-level harvests, review the requested evidence window, including earlier phases, linked issues, PRs, and commits, rather than only the latest discussion topic.
 
 Memory, session summaries, and activity logs are evidence sources only. Memory can suggest; Agent Foundry decides.
 

--- a/adapters/claude-code/CLAUDE.md
+++ b/adapters/claude-code/CLAUDE.md
@@ -33,7 +33,7 @@ Before substantial changes, check:
 Short commands:
 
 - `harvest practices` / `做一次 harvest practice`
-- `discover assets` / `发现可打包资产`
+- `discover assets` / `harvest skills` / `harvest assets` / `发现可打包资产`
 - `import skill <source>` / `导入这个 skill <source>`
 - `publish practices` / `发布 practices`
 - `review practices` / `检查 skill rot`
@@ -57,7 +57,7 @@ When asked to harvest, persist, deduplicate, merge, or publish reusable lessons:
 11. Update canonical practice entries under `practices/` first.
 12. Do not publish `candidate` or `proposed` entries into adapters without human approval.
 
-When asked to discover reusable assets, read `workflows/discover-assets.md`, search `indexes/asset_index.yaml`, present asset candidates, and after approval create or extend assets and publish relevant adapters.
+When asked to discover reusable assets or harvest skills, read `workflows/discover-assets.md`, search `indexes/asset_index.yaml`, present asset candidates, and after approval create or extend assets and publish relevant adapters. For whole-session or phase-level skill harvests, set an explicit evidence window that includes earlier phases, linked issues, PRs, and commits rather than only the latest discussion topic.
 
 When an active asset is used, record concise non-sensitive usage evidence automatically, preferably with `scripts/record_asset_usage.py`.
 
@@ -98,6 +98,8 @@ When asked to borrow or evaluate external skills, read `workflows/import-externa
 
 Use the Agent Collaboration asset ASSET-COLLAB-001 for GitHub issue, PR, GitHub Project/Epic scheduling, multi-agent sync, CLI comment, document conversion, and resume workflows. It applies canonical collaboration practices COLLAB-001 through COLLAB-012 and COLLAB-014:
 
+- When turning a roadmap stage or milestone into GitHub work, create or update issues with Stage, Epic, Owner Role, Risk, Depends On, Roadmap Status, labels, and durable issue bodies before releasing tasks.
+- Distinguish GitHub built-in `Status` from custom `Roadmap Status`; use labels and durable comments as the agent inbox surface.
 - For work already authorized through an issue, branch, and PR workflow, create verified task commits, push the task branch, and open or update the PR without a separate commit-permission round trip.
 - Direct commits to `main`, PR merges, issue closure, force pushes, resets, deletions, data migrations, and privacy/security boundary changes still require explicit authorization.
 - Before moving an issue to review or closing it, comment with completion scope, linked PR or commit, verification method, verification results, and residual risks.
@@ -109,6 +111,7 @@ Use the Agent Collaboration asset ASSET-COLLAB-001 for GitHub issue, PR, GitHub 
 - Use GitHub Project status for human-visible state and `needs:*` labels plus comments as the agent inbox/message layer; keep built-in Status, Roadmap Status, issue state, labels, comments, and session-role-task binding semantically coherent.
 - Ready issues should carry an Execution Contract with branch strategy, base branch, PR target, dependencies, role fit, current owner role, Architect-owned decisions, Implementer boundary, completion handoff, reviewer target, merge rule, and verification; completion handoff controls when Architect review is requested.
 - Before moving work into an Implementer inbox, classify role fit; split mixed work or constrain Implementers to evidence, preliminary classification, implementation, or verification when final taxonomy, architecture, policy, harvest, privacy, or security decisions remain Architect-owned.
+- If an Implementer evidence pass exposes taxonomy, architecture, privacy, or policy questions, route to Architect review before releasing downstream batches.
 - If Architect-owned decisions remain after evidence or preliminary classification, the producing agent moves the issue to Review and keeps it open rather than closing it.
 - `Ready + needs:implementer` may be an ordered queue; related low-risk child issues in the same Epic integration branch default to dependency-gated batch execution/review, and obey `Depends on` gates before starting code.
 - `Ready` is pickup state, `Review` is validation state, and `Done` requires acceptance or closure; do not leave one status surface saying `Ready` while another says `Done`. `needs:*` labels route roles, not necessarily different sessions.
@@ -145,6 +148,8 @@ Use canonical architecture practices ARCH-001 through ARCH-009, and DEBUG-001 wh
 
 - Boundaries before tools; if a design is mostly a current tool pipeline, run a boundary rewrite and substitution test.
 - Separate independent axes of change.
+- For mixed or maturing systems, inventory current layers before designing target movement; classify paths, modules, records, generated outputs, runtime state, private state, and proposed design evidence by ownership and change behavior.
+- Mark ambiguous areas as `Mixed` or `Needs Architect Classification` instead of forcing premature final taxonomy.
 - Unify protocol while preserving semantics.
 - Model inevitable failures as state.
 - Let UI consume domain summaries.

--- a/adapters/codex/skills/agent-collaboration/SKILL.md
+++ b/adapters/codex/skills/agent-collaboration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-collaboration
-description: Use when working on GitHub issues, pull requests, multi-agent repository synchronization, issue completion comments, CLI-posted Markdown comments, converted document deliverables, or resuming after interruption/compaction.
+description: Use when working on GitHub issues, pull requests, GitHub Project/Epic roadmap planning, multi-agent repository synchronization, issue completion comments, CLI-posted Markdown comments, converted document deliverables, or resuming after interruption/compaction.
 ---
 
 # Agent Collaboration
@@ -33,18 +33,21 @@ This skill is an asset that performs a repeatable workflow. During execution, it
 
 ## Workflow
 
-1. Identify whether the task touches an issue, PR, GitHub Project/Epic workflow, multi-agent sync, document conversion, or CLI comment publishing.
+1. Identify whether the task touches an issue, PR, GitHub Project/Epic workflow, roadmap-to-issue planning, multi-agent sync, document conversion, or CLI comment publishing.
 2. Apply the matching canonical rule above.
-3. For multi-agent projects, locate the repo-local workflow contract and active issue Execution Contracts before choosing branch or PR behavior.
-4. If the work is authorized for branch/PR execution, do not leave verified changes as local-only state: commit, push the task branch, and open or update the PR with traceable evidence.
-5. Check issue role fit before pickup or release; split mixed work or constrain Implementers to evidence, preliminary classification, implementation, or verification when final decisions remain Architect-owned.
-6. Check completion handoff before work starts; if it says `batch checkpoint`, do not turn each child PR into a blocking Architect review unless a high-risk trigger or failed verification appears.
-7. Bind task, owner role, current session, and reviewer target explicitly when work moves between scheduler states; `needs:*` labels route roles, not necessarily different sessions.
-8. When a set of related issues has clear dependency gates, treat it as a batch queue instead of forcing one handoff per child issue.
-9. Before reviewing an individual child PR, check whether the issue belongs to an Epic batch queue, whether its completion handoff is `batch checkpoint`, whether a reviewer target is named, and whether a high-risk trigger exists.
-10. Preserve durable traceability in GitHub issues, PRs, labels, Project state, and comments.
-11. Validate with the checks appropriate to the artifact or code path, using batch or Epic review checkpoints when appropriate.
-12. Continue from the newest user request after interruptions or context transitions.
+3. When turning a roadmap stage or milestone into GitHub work, create or update issues with Stage, Epic, Owner Role, Risk, Depends On, Roadmap Status, labels, and durable bodies before releasing tasks.
+4. Distinguish GitHub built-in `Status` from custom `Roadmap Status`; use labels and durable comments as the agent inbox surface.
+5. For multi-agent projects, locate the repo-local workflow contract and active issue Execution Contracts before choosing branch or PR behavior.
+6. If the work is authorized for branch/PR execution, do not leave verified changes as local-only state: commit, push the task branch, and open or update the PR with traceable evidence.
+7. Check issue role fit before pickup or release; split mixed work or constrain Implementers to evidence, preliminary classification, implementation, or verification when final decisions remain Architect-owned.
+8. If an Implementer evidence pass exposes taxonomy, architecture, privacy, or policy questions, route to Architect review before releasing downstream batches.
+9. Check completion handoff before work starts; if it says `batch checkpoint`, do not turn each child PR into a blocking Architect review unless a high-risk trigger or failed verification appears.
+10. Bind task, owner role, current session, and reviewer target explicitly when work moves between scheduler states; `needs:*` labels route roles, not necessarily different sessions.
+11. When a set of related issues has clear dependency gates, treat it as a batch queue instead of forcing one handoff per child issue.
+12. Before reviewing an individual child PR, check whether the issue belongs to an Epic batch queue, whether its completion handoff is `batch checkpoint`, whether a reviewer target is named, and whether a high-risk trigger exists.
+13. Preserve durable traceability in GitHub issues, PRs, labels, Project state, and comments.
+14. Validate with the checks appropriate to the artifact or code path, using batch or Epic review checkpoints when appropriate.
+15. Continue from the newest user request after interruptions or context transitions.
 
 ## Guardrails
 
@@ -57,6 +60,7 @@ This skill is an asset that performs a repeatable workflow. During execution, it
 - Do not let Implementers infer missing repo workflow, branch base, PR target, or dependency gates; route unclear issues back to Architect.
 - Do not let Implementers make final taxonomy, architecture boundary, policy, harvest, privacy, or security decisions unless the Execution Contract explicitly assigns that authority.
 - Do not let status surfaces contradict each other; `Ready` is pickup state, `Review` is validation state, and `Done` requires acceptance or closure.
+- Do not treat GitHub built-in `Status` as a complete roadmap state machine when custom `Roadmap Status`, labels, dependencies, and issue comments carry scheduling semantics.
 - Do not leave `Review` without a reviewer target: current-session structured self-review, user, separate Reviewer agent, CI/automation, or batch/Epic checkpoint.
 - Do not imply self-review is independent review; if the same session switches roles, name structured self-review and residual risks.
 - Do not treat an open child PR as automatic `needs:architect`; review ownership follows completion handoff, high-risk triggers, failed verification, or the batch/Epic checkpoint.

--- a/adapters/codex/skills/architecture-design/SKILL.md
+++ b/adapters/codex/skills/architecture-design/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: architecture-design
-description: Use when designing, reviewing, or refactoring software architecture; especially when choosing system boundaries, domain models, adapter layers, storage, UI separation, failure states, MVP scope, or technology choices.
+description: Use when designing, reviewing, or refactoring software architecture; especially when choosing system boundaries, layer taxonomy, domain models, adapter layers, storage, UI separation, failure states, MVP scope, or technology choices.
 ---
 
 # Architecture Design
 
 Asset ID: ASSET-ARCH-001.
 
-Use this skill to guide architecture proposals and reviews, including serviceability design when a system needs diagnostics, failure taxonomy, debug bundles, or agent handoff for fragile workflows.
+Use this skill to guide architecture proposals and reviews, including layer taxonomy inventory for mixed systems and serviceability design when a system needs diagnostics, failure taxonomy, debug bundles, or agent handoff for fragile workflows.
 
 ## Asset vs Practice
 
@@ -18,15 +18,18 @@ This skill is an asset that performs a repeatable workflow. During execution, it
 1. Identify stable domain objects and states.
 2. Identify independent axes of change.
 3. Define boundaries before choosing tools.
-4. If the design is centered on the current implementation path, run a boundary rewrite and substitution test.
-5. Preserve meaningful domain differences instead of over-normalizing.
-6. Model inevitable failures as explicit state.
-7. Keep UI dependent on domain summaries, not raw integration data.
-8. Scope MVP around the main path and key boundaries.
-9. Maintain lightweight design docs as context contracts when boundaries, contracts, runtime behavior, or user experience change.
-10. Before coding, write a reviewed implementation plan with concrete detail for the current phase (file structure, data flow, IPC contracts, acceptance criteria) and a directional sketch for future phases; review it adversarially to surface gaps.
-11. When UI actions depend on multiple domain or workflow states, introduce a small interaction ViewModel and tests before reaching for a larger frontend framework.
-12. For fragile integrations or parser/capture/import workflows, design diagnostics as agent-actionable reproduction artifacts: trace the flow, define stable failure reasons, avoid default raw-data persistence, and provide a debug bundle path to fixtures/tests.
-13. Choose technologies as boundary implementations.
+4. For mixed or maturing systems, inventory current layers before designing target movement.
+5. Classify paths, modules, records, generated outputs, runtime state, private state, and proposed design evidence by ownership and change behavior.
+6. Mark ambiguous areas as `Mixed` or `Needs Architect Classification` instead of forcing premature final taxonomy.
+7. If the design is centered on the current implementation path, run a boundary rewrite and substitution test.
+8. Preserve meaningful domain differences instead of over-normalizing.
+9. Model inevitable failures as explicit state.
+10. Keep UI dependent on domain summaries, not raw integration data.
+11. Scope MVP around the main path and key boundaries.
+12. Maintain lightweight design docs as context contracts when boundaries, contracts, runtime behavior, or user experience change.
+13. Before coding, write a reviewed implementation plan with concrete detail for the current phase (file structure, data flow, IPC contracts, acceptance criteria) and a directional sketch for future phases; review it adversarially to surface gaps.
+14. When UI actions depend on multiple domain or workflow states, introduce a small interaction ViewModel and tests before reaching for a larger frontend framework.
+15. For fragile integrations or parser/capture/import workflows, design diagnostics as agent-actionable reproduction artifacts: trace the flow, define stable failure reasons, avoid default raw-data persistence, and provide a debug bundle path to fixtures/tests.
+16. Choose technologies as boundary implementations.
 
 Read `references/principles.md` for the compact rules and `references/checklist.md` before producing a design.

--- a/adapters/codex/skills/practice-harvester/SKILL.md
+++ b/adapters/codex/skills/practice-harvester/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: practice-harvester
-description: Use when the user says "harvest practices", "做一次 harvest practice", "discover assets", "发现可打包资产", "提炼实践", "沉淀经验", "import skill", "导入这个 skill", "review practices", "检查 skill rot", "review assets", "检查 asset rot", "publish practices", "发布 practices", "refresh practices and assets", "刷新practices和assets", or asks to extract, persist, deduplicate, merge, review, import, borrow, approve, publish, or refresh reusable engineering practices or assets.
+description: Use when the user says "harvest practices", "harvest skills", "harvest assets", "做一次 harvest practice", "discover assets", "发现可打包资产", "提炼实践", "沉淀经验", "import skill", "导入这个 skill", "review practices", "检查 skill rot", "review assets", "检查 asset rot", "publish practices", "发布 practices", "refresh practices and assets", "刷新practices和assets", or asks to extract, persist, deduplicate, merge, review, import, borrow, approve, publish, or refresh reusable engineering practices or assets.
 ---
 
 # Practice Harvester
@@ -27,7 +27,7 @@ Before substantial changes, check:
 ## Short Commands
 
 - `harvest practices` / `做一次 harvest practice`: run the harvest workflow and present a concise review list.
-- `discover assets` / `发现可打包资产`: find repeated workflows that should become skills, subagents, automations, or extensions.
+- `discover assets` / `harvest skills` / `harvest assets` / `发现可打包资产`: find repeated workflows that should become skills, subagents, automations, or extensions.
 - `import skill <source>` / `导入这个 skill <source>`: run the external skill import workflow.
 - `publish practices` / `发布 practices`: publish adapters from current active practices.
 - `review practices` / `检查 skill rot`: review for duplicates, stale entries, weak rules, and adapter drift.
@@ -40,17 +40,19 @@ Before substantial changes, check:
 2. Select the workflow from the short command or user intent.
 3. Read `references/harvest-workflow.md` for harvesting, `references/import-policy.md` for imports, `references/asset-policy.md` for assets, `workflows/refresh.md` from the repo for refresh, or the repository workflow file for publish/review.
 4. Read `references/schema.md`.
-5. Run the current capability check before routing or drafting; do not use future architecture concepts as current writable substrate.
-6. Route artifacts before abstracting practices: evidence only, design note, research/reference material, project-local decision, workflow update, practice candidate, skill/asset candidate, adapter update, or discard.
-7. Apply the generalization gate before drafting practice candidates.
-8. Search the practice index before creating anything new.
-9. Classify candidates as principle, pattern, heuristic, playbook, checklist, example, or anti-pattern.
-10. Decide for each candidate: discard, merge, create, supersede, or defer.
-11. Present a concise review list including rejected-as-practice items, canonical impact, adapter impact, and runtime/global instruction impact when important.
-12. Treat approval as scoped to the listed items only. Broad phrases such as "continue", "approved", or "do the whole chain" do not permit skipping unshown harvest steps.
-13. For self-referential workflow changes, stop at the review list before canonical mutation. After approval, continue through the listed canonical changes, checks, PR/traceability, merge/apply, and adapter/runtime publish automatically unless the diff departs from the approved list, checks fail, risk increases, or a new unlisted runtime/global target appears.
-14. After the user approves a practice, apply the canonical change and publish relevant adapters automatically.
-15. Report candidates, decisions, changed files, and review needs.
+5. When harvesting skills or assets from a long session, set an explicit evidence window that includes earlier phases, linked issues, PRs, and commits rather than only the latest discussion topic.
+6. Run the current capability check before routing or drafting; do not use future architecture concepts as current writable substrate.
+7. Route artifacts before abstracting practices: evidence only, design note, research/reference material, project-local decision, workflow update, practice candidate, skill/asset candidate, adapter update, or discard.
+8. Apply the generalization gate before drafting practice candidates.
+9. Search the practice and asset indexes before creating anything new.
+10. For asset discovery, choose create, extend, skip, or defer using the smallest suitable asset rule.
+11. Classify practice candidates as principle, pattern, heuristic, playbook, checklist, example, or anti-pattern.
+12. Decide for each candidate: discard, merge, create, supersede, extend, skip, or defer.
+13. Present a concise review list including rejected-as-practice items, asset decisions, canonical impact, adapter impact, and runtime/global instruction impact when important.
+14. Treat approval as scoped to the listed items only. Broad phrases such as "continue", "approved", or "do the whole chain" do not permit skipping unshown harvest steps.
+15. For self-referential workflow changes, stop at the review list before canonical mutation. After approval, continue through the listed canonical changes, checks, PR/traceability, merge/apply, and adapter/runtime publish automatically unless the diff departs from the approved list, checks fail, risk increases, or a new unlisted runtime/global target appears.
+16. After the user approves a practice or asset change, apply the canonical change and publish relevant adapters automatically.
+17. Report candidates, decisions, changed files, and review needs.
 
 ## Guardrails
 
@@ -63,6 +65,7 @@ Before substantial changes, check:
 - Treat memory as evidence, not source of truth.
 - During harvest, route artifacts before abstraction, treat user method corrections as process evidence first, and require insights to pass a generalization gate before they become practice candidates.
 - Do not convert approval of a direction into approval to bypass an unshown harvest review list. If the review list was skipped, stop and add the missing harvest report; after approval of that report, continue through the approved chain without adding another approval gate unless an escalation condition appears.
+- Do not narrow `harvest skills` or session-level asset discovery to only the latest subtopic when the user asks to review the whole session or earlier phases.
 - Treat native agent learning outputs as candidate inputs; do not suppress native self-growth capabilities in agents that provide them.
 - Treat agent runtime directories as shared user-owned environments. When publishing adapters, use managed blocks, namespaced files, ownership markers, backups, dry-runs, and explicit adoption for unmanaged runtime paths; never overwrite unmanaged runtime files by default.
 - Separate portable adapter intent from machine-local deployment state. Keep adapter profiles and runtime templates in the repo, but keep enabled targets, detected paths, and adoption decisions in gitignored local manifests; portable snapshots exclude machine-local runtime state by default.

--- a/adapters/hermes/skills/agent-collaboration/SKILL.md
+++ b/adapters/hermes/skills/agent-collaboration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-collaboration
-description: Use when working on GitHub issues, pull requests, multi-agent repository synchronization, issue completion comments, CLI-posted Markdown comments, converted document deliverables, or resuming after interruption/compaction.
+description: Use when working on GitHub issues, pull requests, GitHub Project/Epic roadmap planning, multi-agent repository synchronization, issue completion comments, CLI-posted Markdown comments, converted document deliverables, or resuming after interruption/compaction.
 ---
 
 # Agent Collaboration
@@ -33,18 +33,21 @@ This skill is an asset that performs a repeatable workflow. During execution, it
 
 ## Workflow
 
-1. Identify whether the task touches an issue, PR, GitHub Project/Epic workflow, multi-agent sync, document conversion, or CLI comment publishing.
+1. Identify whether the task touches an issue, PR, GitHub Project/Epic workflow, roadmap-to-issue planning, multi-agent sync, document conversion, or CLI comment publishing.
 2. Apply the matching canonical rule above.
-3. For multi-agent projects, locate the repo-local workflow contract and active issue Execution Contracts before choosing branch or PR behavior.
-4. If the work is authorized for branch/PR execution, do not leave verified changes as local-only state: commit, push the task branch, and open or update the PR with traceable evidence.
-5. Check issue role fit before pickup or release; split mixed work or constrain Implementers to evidence, preliminary classification, implementation, or verification when final decisions remain Architect-owned.
-6. Check completion handoff before work starts; if it says `batch checkpoint`, do not turn each child PR into a blocking Architect review unless a high-risk trigger or failed verification appears.
-7. Bind task, owner role, current session, and reviewer target explicitly when work moves between scheduler states; `needs:*` labels route roles, not necessarily different sessions.
-8. When a set of related issues has clear dependency gates, treat it as a batch queue instead of forcing one handoff per child issue.
-9. Before reviewing an individual child PR, check whether the issue belongs to an Epic batch queue, whether its completion handoff is `batch checkpoint`, whether a reviewer target is named, and whether a high-risk trigger exists.
-10. Preserve durable traceability in GitHub issues, PRs, labels, Project state, and comments.
-11. Validate with the checks appropriate to the artifact or code path, using batch or Epic review checkpoints when appropriate.
-12. Continue from the newest user request after interruptions or context transitions.
+3. When turning a roadmap stage or milestone into GitHub work, create or update issues with Stage, Epic, Owner Role, Risk, Depends On, Roadmap Status, labels, and durable bodies before releasing tasks.
+4. Distinguish GitHub built-in `Status` from custom `Roadmap Status`; use labels and durable comments as the agent inbox surface.
+5. For multi-agent projects, locate the repo-local workflow contract and active issue Execution Contracts before choosing branch or PR behavior.
+6. If the work is authorized for branch/PR execution, do not leave verified changes as local-only state: commit, push the task branch, and open or update the PR with traceable evidence.
+7. Check issue role fit before pickup or release; split mixed work or constrain Implementers to evidence, preliminary classification, implementation, or verification when final decisions remain Architect-owned.
+8. If an Implementer evidence pass exposes taxonomy, architecture, privacy, or policy questions, route to Architect review before releasing downstream batches.
+9. Check completion handoff before work starts; if it says `batch checkpoint`, do not turn each child PR into a blocking Architect review unless a high-risk trigger or failed verification appears.
+10. Bind task, owner role, current session, and reviewer target explicitly when work moves between scheduler states; `needs:*` labels route roles, not necessarily different sessions.
+11. When a set of related issues has clear dependency gates, treat it as a batch queue instead of forcing one handoff per child issue.
+12. Before reviewing an individual child PR, check whether the issue belongs to an Epic batch queue, whether its completion handoff is `batch checkpoint`, whether a reviewer target is named, and whether a high-risk trigger exists.
+13. Preserve durable traceability in GitHub issues, PRs, labels, Project state, and comments.
+14. Validate with the checks appropriate to the artifact or code path, using batch or Epic review checkpoints when appropriate.
+15. Continue from the newest user request after interruptions or context transitions.
 
 ## Guardrails
 
@@ -57,6 +60,7 @@ This skill is an asset that performs a repeatable workflow. During execution, it
 - Do not let Implementers infer missing repo workflow, branch base, PR target, or dependency gates; route unclear issues back to Architect.
 - Do not let Implementers make final taxonomy, architecture boundary, policy, harvest, privacy, or security decisions unless the Execution Contract explicitly assigns that authority.
 - Do not let status surfaces contradict each other; `Ready` is pickup state, `Review` is validation state, and `Done` requires acceptance or closure.
+- Do not treat GitHub built-in `Status` as a complete roadmap state machine when custom `Roadmap Status`, labels, dependencies, and issue comments carry scheduling semantics.
 - Do not leave `Review` without a reviewer target: current-session structured self-review, user, separate Reviewer agent, CI/automation, or batch/Epic checkpoint.
 - Do not imply self-review is independent review; if the same session switches roles, name structured self-review and residual risks.
 - Do not treat an open child PR as automatic `needs:architect`; review ownership follows completion handoff, high-risk triggers, failed verification, or the batch/Epic checkpoint.

--- a/adapters/hermes/skills/architecture-design/SKILL.md
+++ b/adapters/hermes/skills/architecture-design/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: architecture-design
-description: Use when designing, reviewing, or refactoring software architecture; especially when choosing system boundaries, domain models, adapter layers, storage, UI separation, failure states, MVP scope, or technology choices.
+description: Use when designing, reviewing, or refactoring software architecture; especially when choosing system boundaries, layer taxonomy, domain models, adapter layers, storage, UI separation, failure states, MVP scope, or technology choices.
 ---
 
 # Architecture Design
 
 Asset ID: ASSET-ARCH-001.
 
-Use this skill to guide architecture proposals and reviews, including serviceability design when a system needs diagnostics, failure taxonomy, debug bundles, or agent handoff for fragile workflows.
+Use this skill to guide architecture proposals and reviews, including layer taxonomy inventory for mixed systems and serviceability design when a system needs diagnostics, failure taxonomy, debug bundles, or agent handoff for fragile workflows.
 
 ## Asset vs Practice
 
@@ -18,15 +18,18 @@ This skill is an asset that performs a repeatable workflow. During execution, it
 1. Identify stable domain objects and states.
 2. Identify independent axes of change.
 3. Define boundaries before choosing tools.
-4. If the design is centered on the current implementation path, run a boundary rewrite and substitution test.
-5. Preserve meaningful domain differences instead of over-normalizing.
-6. Model inevitable failures as explicit state.
-7. Keep UI dependent on domain summaries, not raw integration data.
-8. Scope MVP around the main path and key boundaries.
-9. Maintain lightweight design docs as context contracts when boundaries, contracts, runtime behavior, or user experience change.
-10. Before coding, write a reviewed implementation plan with concrete detail for the current phase (file structure, data flow, IPC contracts, acceptance criteria) and a directional sketch for future phases; review it adversarially to surface gaps.
-11. When UI actions depend on multiple domain or workflow states, introduce a small interaction ViewModel and tests before reaching for a larger frontend framework.
-12. For fragile integrations or parser/capture/import workflows, design diagnostics as agent-actionable reproduction artifacts: trace the flow, define stable failure reasons, avoid default raw-data persistence, and provide a debug bundle path to fixtures/tests.
-13. Choose technologies as boundary implementations.
+4. For mixed or maturing systems, inventory current layers before designing target movement.
+5. Classify paths, modules, records, generated outputs, runtime state, private state, and proposed design evidence by ownership and change behavior.
+6. Mark ambiguous areas as `Mixed` or `Needs Architect Classification` instead of forcing premature final taxonomy.
+7. If the design is centered on the current implementation path, run a boundary rewrite and substitution test.
+8. Preserve meaningful domain differences instead of over-normalizing.
+9. Model inevitable failures as explicit state.
+10. Keep UI dependent on domain summaries, not raw integration data.
+11. Scope MVP around the main path and key boundaries.
+12. Maintain lightweight design docs as context contracts when boundaries, contracts, runtime behavior, or user experience change.
+13. Before coding, write a reviewed implementation plan with concrete detail for the current phase (file structure, data flow, IPC contracts, acceptance criteria) and a directional sketch for future phases; review it adversarially to surface gaps.
+14. When UI actions depend on multiple domain or workflow states, introduce a small interaction ViewModel and tests before reaching for a larger frontend framework.
+15. For fragile integrations or parser/capture/import workflows, design diagnostics as agent-actionable reproduction artifacts: trace the flow, define stable failure reasons, avoid default raw-data persistence, and provide a debug bundle path to fixtures/tests.
+16. Choose technologies as boundary implementations.
 
 Read `references/principles.md` for the compact rules and `references/checklist.md` before producing a design.

--- a/adapters/hermes/skills/practice-harvester/SKILL.md
+++ b/adapters/hermes/skills/practice-harvester/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: practice-harvester
-description: Use when the user says "harvest practices", "做一次 harvest practice", "discover assets", "发现可打包资产", "提炼实践", "沉淀经验", "import skill", "导入这个 skill", "review practices", "检查 skill rot", "review assets", "检查 asset rot", "publish practices", "发布 practices", "refresh practices and assets", "刷新practices和assets", or asks to extract, persist, deduplicate, merge, review, import, borrow, approve, publish, or refresh reusable engineering practices or assets.
+description: Use when the user says "harvest practices", "harvest skills", "harvest assets", "做一次 harvest practice", "discover assets", "发现可打包资产", "提炼实践", "沉淀经验", "import skill", "导入这个 skill", "review practices", "检查 skill rot", "review assets", "检查 asset rot", "publish practices", "发布 practices", "refresh practices and assets", "刷新practices和assets", or asks to extract, persist, deduplicate, merge, review, import, borrow, approve, publish, or refresh reusable engineering practices or assets.
 ---
 
 # Practice Harvester
@@ -27,7 +27,7 @@ Before substantial changes, check:
 ## Short Commands
 
 - `harvest practices` / `做一次 harvest practice`: run the harvest workflow and present a concise review list.
-- `discover assets` / `发现可打包资产`: find repeated workflows that should become skills, subagents, automations, or extensions.
+- `discover assets` / `harvest skills` / `harvest assets` / `发现可打包资产`: find repeated workflows that should become skills, subagents, automations, or extensions.
 - `import skill <source>` / `导入这个 skill <source>`: run the external skill import workflow.
 - `publish practices` / `发布 practices`: publish adapters from current active practices.
 - `review practices` / `检查 skill rot`: review for duplicates, stale entries, weak rules, and adapter drift.
@@ -38,17 +38,21 @@ Before substantial changes, check:
 
 1. Locate Agent Foundry Core and Vault. Use `AGENT_FOUNDRY_HOME`, then `~/.agent-foundry/config.yaml`, then the current directory only if canonical markers exist. The current project is evidence source, not canonical destination.
 2. Select the workflow from the short command or user intent.
-3. Read `references/harvest-workflow.md` for harvesting, `references/import-policy.md` for imports, `references/asset-policy.md` for assets, or the repository workflow file for publish/review.
+3. Read `references/harvest-workflow.md` for harvesting, `references/import-policy.md` for imports, `references/asset-policy.md` for assets, `workflows/refresh.md` from the repo for refresh, or the repository workflow file for publish/review.
 4. Read `references/schema.md`.
-5. Run the current capability check before routing or drafting; do not use future architecture concepts as current writable substrate.
-6. Route artifacts before abstracting practices: evidence only, design note, research/reference material, project-local decision, workflow update, practice candidate, skill/asset candidate, adapter update, or discard.
-7. Apply the generalization gate before drafting practice candidates.
-8. Search the practice index before creating anything new.
-9. Present a concise review list including rejected-as-practice items, canonical impact, adapter impact, and runtime/global instruction impact when important.
-10. Treat approval as scoped to the listed items only. Broad phrases such as "continue", "approved", or "do the whole chain" do not permit skipping unshown harvest steps.
-11. For self-referential workflow changes, stop at the review list before canonical mutation. After approval, continue through the listed canonical changes, checks, PR/traceability, merge/apply, and adapter/runtime publish automatically unless the diff departs from the approved list, checks fail, risk increases, or a new unlisted runtime/global target appears.
-12. After the user approves a practice, apply the canonical change and publish relevant adapters automatically.
-13. Report candidates, decisions, changed files, and review needs.
+5. When harvesting skills or assets from a long session, set an explicit evidence window that includes earlier phases, linked issues, PRs, and commits rather than only the latest discussion topic.
+6. Run the current capability check before routing or drafting; do not use future architecture concepts as current writable substrate.
+7. Route artifacts before abstracting practices: evidence only, design note, research/reference material, project-local decision, workflow update, practice candidate, skill/asset candidate, adapter update, or discard.
+8. Apply the generalization gate before drafting practice candidates.
+9. Search the practice and asset indexes before creating anything new.
+10. For asset discovery, choose create, extend, skip, or defer using the smallest suitable asset rule.
+11. Classify practice candidates as principle, pattern, heuristic, playbook, checklist, example, or anti-pattern.
+12. Decide for each candidate: discard, merge, create, supersede, extend, skip, or defer.
+13. Present a concise review list including rejected-as-practice items, asset decisions, canonical impact, adapter impact, and runtime/global instruction impact when important.
+14. Treat approval as scoped to the listed items only. Broad phrases such as "continue", "approved", or "do the whole chain" do not permit skipping unshown harvest steps.
+15. For self-referential workflow changes, stop at the review list before canonical mutation. After approval, continue through the listed canonical changes, checks, PR/traceability, merge/apply, and adapter/runtime publish automatically unless the diff departs from the approved list, checks fail, risk increases, or a new unlisted runtime/global target appears.
+16. After the user approves a practice or asset change, apply the canonical change and publish relevant adapters automatically.
+17. Report candidates, decisions, changed files, and review needs.
 
 ## Guardrails
 
@@ -61,6 +65,7 @@ Before substantial changes, check:
 - Treat memory as evidence, not source of truth.
 - During harvest, route artifacts before abstraction, treat user method corrections as process evidence first, and require insights to pass a generalization gate before they become practice candidates.
 - Do not convert approval of a direction into approval to bypass an unshown harvest review list. If the review list was skipped, stop and add the missing harvest report; after approval of that report, continue through the approved chain without adding another approval gate unless an escalation condition appears.
+- Do not narrow `harvest skills` or session-level asset discovery to only the latest subtopic when the user asks to review the whole session or earlier phases.
 - Do not disable Hermes native memory, autonomous skill creation, or local self-improvement. Treat native outputs as candidate inputs when they should become durable or cross-agent.
 - Treat agent runtime directories as shared user-owned environments. When publishing adapters, use managed blocks, namespaced files, ownership markers, backups, dry-runs, and explicit adoption for unmanaged runtime paths; never overwrite unmanaged runtime files by default.
 - Separate portable adapter intent from machine-local deployment state. Keep adapter profiles and runtime templates in the repo, but keep enabled targets, detected paths, and adoption decisions in gitignored local manifests; portable snapshots exclude machine-local runtime state by default.

--- a/assets/skills/ASSET-ARCH-001-architecture-design.asset.yaml
+++ b/assets/skills/ASSET-ARCH-001-architecture-design.asset.yaml
@@ -2,10 +2,10 @@ id: ASSET-ARCH-001
 title: Architecture Design
 asset_type: skill
 status: active
-version: 2
+version: 3
 created: 2026-05-26
 updated: 2026-06-02
-purpose: Guide architecture design and review around boundaries, domain models, failure states, UI/domain separation, interaction contracts, and MVP scope.
+purpose: Guide architecture design and review around boundaries, domain models, layer taxonomy, failure states, UI/domain separation, interaction contracts, and MVP scope.
 responsibility: Help design or review software architecture decisions using canonical architecture principles.
 non_responsibility: Does not maintain Agent Foundry, import external skills, publish adapters, or perform broad product strategy work.
 inputs:
@@ -13,10 +13,14 @@ inputs:
   - existing code structure when available
   - technology constraints
   - MVP scope or delivery goals
+  - repository or system inventory when boundaries are mixed or unclear
 process:
   - identify stable domain objects
   - identify independent axes of change
   - evaluate boundaries before tools
+  - for mixed or maturing systems, inventory current layers before designing target movement
+  - classify existing paths, modules, records, generated outputs, runtime state, private state, and proposed design evidence by ownership and change behavior
+  - mark ambiguous areas as Mixed or Needs Architect Classification instead of forcing premature final taxonomy
   - check semantic preservation
   - check failure state modeling
   - check UI/domain separation
@@ -25,6 +29,8 @@ process:
 outputs:
   - architecture recommendations
   - risks and tradeoffs
+  - layer taxonomy and boundary inventory
+  - mixed-area follow-up questions
   - review findings
   - focused checklist
 canonical_practices:
@@ -46,6 +52,9 @@ published_to:
 usage_triggers:
   - architecture design
   - architecture review
+  - layer taxonomy
+  - boundary inventory
+  - repository layer inventory
   - 架构设计
   - 架构 review
 success_criteria:
@@ -54,6 +63,8 @@ success_criteria:
   - identifies over-normalized domain models
   - identifies missing failure states
   - identifies UI/business logic leakage
+  - identifies mixed ownership layers before recommending file movement or migration
+  - keeps preliminary inventory evidence separate from final architecture policy
   - identifies implicit UI interaction contracts that need a ViewModel or contract doc
   - identifies MVP scope risks
 review_cadence: monthly

--- a/assets/skills/ASSET-COLLAB-001-agent-collaboration.asset.yaml
+++ b/assets/skills/ASSET-COLLAB-001-agent-collaboration.asset.yaml
@@ -2,7 +2,7 @@ id: ASSET-COLLAB-001
 title: Agent Collaboration
 asset_type: skill
 status: active
-version: 9
+version: 10
 created: 2026-05-28
 updated: 2026-06-09
 purpose: Guide GitHub issue, pull request, Project/Epic scheduling, multi-agent synchronization, CLI comment, document conversion, and interruption-resume workflows.
@@ -18,8 +18,11 @@ inputs:
   - CLI comment body or generated document deliverable
 process:
   - identify whether the task touches issues, PRs, multi-agent sync, CLI comments, document conversion, or resumed work
+  - when turning a roadmap stage or milestone into GitHub work, create or update the lightweight scheduler surface before releasing tasks
+  - distinguish GitHub built-in Status from custom Roadmap Status; use labels, Project fields, issue state, and durable comments together
   - when bootstrapping multi-agent work, create or locate the repo-local workflow contract before handing issues to Implementers
   - apply an issue role-fit gate before moving work into an Implementer inbox
+  - decompose epics into dependency-gated issues with clear owner role, risk, acceptance criteria, and Ready conditions
   - split mixed issues or constrain Implementers to evidence, preliminary classification, implementation, or verification when final decisions remain Architect-owned
   - apply the matching collaboration, implementation, or testing practice
   - for Implementer pickup, read Project/label state plus issue execution contracts before creating branches or PRs
@@ -32,6 +35,7 @@ process:
   - do not treat an open child PR as an automatic Architect review request when batch checkpoint mode applies
   - when a session switches roles, label structured self-review and residual risks instead of implying independent review
   - keep Project status, Roadmap Status, issue state, labels, and durable comments semantically coherent
+  - when an Implementer evidence pass reveals mixed taxonomy, architecture, privacy, or policy questions, route the issue to Architect review before releasing downstream batches
   - when executing a task list from another agent or user, verify each item against the original list before declaring done
   - preserve durable traceability in issues, PRs, comments, or verification records
   - validate with artifact-specific checks
@@ -39,6 +43,7 @@ process:
 outputs:
   - issue or PR workflow recommendations
   - repo-local workflow contract recommendations
+  - roadmap-to-Project issue breakdown and scheduler field recommendations
   - Project/Epic/label queue guidance
   - issue role-fit recommendations
   - Execution Contract role-boundary, pickup confirmation, and completion handoff guidance
@@ -81,6 +86,9 @@ usage_triggers:
   - Epic workflow
   - Execution Contract
   - needs label inbox
+  - roadmap planning
+  - milestone to GitHub issues
+  - Roadmap Status
   - issue completion comment
   - PR review handoff
   - CLI Markdown comment
@@ -91,6 +99,8 @@ success_criteria:
   - authorized issue/branch/PR work is not left as uncommitted local state when verification has passed
   - multi-agent repositories have a discovered or bootstrapped repo-local workflow contract
   - Project status, labels, issue comments, and PRs have clear roles in the handoff
+  - roadmap stages or milestones are decomposed into issues with Stage, Epic, Owner Role, Risk, Depends On, Roadmap Status, labels, and durable issue bodies
+  - GitHub built-in Status and custom Roadmap Status are not treated as the same state machine
   - Ready queues are sorted by explicit dependency gates before Implementers start coding
   - related child issues are batched for handoff when dependency gates make the batch safe and detectable
   - issue execution contracts define branch strategy, base branch, PR target, dependencies, role fit, Architect-owned decisions, Implementer boundary, completion handoff, merge rule, and verification
@@ -100,6 +110,7 @@ success_criteria:
   - low-risk child issues in the same Epic integration branch default to batch execution/review when their completion handoff is `batch checkpoint`
   - open child PRs do not automatically become Architect inbox work unless completion handoff, high-risk trigger, failed verification, or batch checkpoint requires review
   - Implementer issues explicitly separate evidence, implementation, and verification from Architect-owned taxonomy, architecture, policy, harvest, privacy, or security decisions
+  - Implementer evidence batches do not become final architecture or taxonomy decisions until Architect review accepts or corrects them
   - evidence-only or preliminary-classification issues move to Review rather than Done when Architect-owned decisions remain
   - Project built-in status, Roadmap Status, issue state, labels, and durable comments do not contradict each other
   - multi-agent feature work prefers Epic integration branches unless a direct-to-main or stacked PR exception is justified

--- a/assets/skills/ASSET-META-001-practice-harvester.asset.yaml
+++ b/assets/skills/ASSET-META-001-practice-harvester.asset.yaml
@@ -2,29 +2,33 @@ id: ASSET-META-001
 title: Practice Harvester
 asset_type: skill
 status: active
-version: 2
+version: 3
 created: 2026-05-26
 updated: 2026-06-09
-purpose: Maintain reusable practices by harvesting lessons, importing external skills, publishing adapters, and reviewing skill rot.
+purpose: Maintain reusable practices and assets by harvesting lessons, discovering reusable skills/assets, importing external skills, publishing adapters, and reviewing skill rot.
 responsibility: Maintain the Agent Foundry lifecycle of practices, assets, indexes, adapters, usage evidence, and related review reports.
 non_responsibility: Does not perform domain-specific engineering work except to harvest or package reusable lessons from it.
 inputs:
   - current session context
+  - linked issue, PR, commit, or roadmap history when the user asks to review a whole session or phase
   - external skill source
   - existing practice and asset indexes
   - recent work history when discovering assets
 process:
   - locate and validate the current Agent Foundry Core and Vault
   - reconstruct the relevant session or correction
+  - when harvesting skills or assets from a long session, set an explicit evidence window that includes earlier phases, linked issues, PRs, and commits rather than only the latest discussion topic
   - route artifacts before drafting candidates
   - apply the generalization gate
   - classify candidate practices or assets
+  - for asset discovery, choose create, extend, skip, or defer using the smallest suitable asset rule
   - deduplicate against indexes
   - present a concise review list before canonical mutation
   - apply approved items
   - publish relevant adapters only after approved canonical changes are applied
 outputs:
   - harvest report or review list
+  - asset discovery review list
   - proposed or active practice entries
   - active asset records
   - updated indexes
@@ -60,14 +64,20 @@ published_to:
 usage_triggers:
   - harvest practices
   - 做一次 harvest practice
+  - harvest skills
+  - harvest assets
   - import skill
   - 导入这个 skill
+  - discover assets
+  - 发现可打包资产
   - publish practices
   - review practices
   - 检查 skill rot
 success_criteria:
   - artifact routing, generalization, rejected-as-practice, canonical impact, adapter impact, and runtime impact are visible before approval
   - candidates are deduplicated against existing practices and assets
+  - skill or asset harvests review the requested evidence window, not just the most recent subtopic
+  - existing assets are extended when coverage is partial, instead of creating near-duplicate skills
   - human approval is requested per meaningful new or changed item
   - broad approval language is not interpreted as permission to skip unshown workflow steps
   - self-referential workflow changes stop at a review list before canonical mutation

--- a/indexes/asset_index.yaml
+++ b/indexes/asset_index.yaml
@@ -1,5 +1,5 @@
 schema_version: 1
-updated: 2026-06-03
+updated: 2026-06-09
 
 asset_types:
   skill:
@@ -20,6 +20,10 @@ assets:
     usage_triggers:
       - harvest practices
       - 做一次 harvest practice
+      - harvest skills
+      - harvest assets
+      - discover assets
+      - 发现可打包资产
       - import skill
       - review practices
 
@@ -33,6 +37,9 @@ assets:
     usage_triggers:
       - architecture design
       - architecture review
+      - layer taxonomy
+      - boundary inventory
+      - repository layer inventory
       - 架构设计
       - 架构 review
 
@@ -49,7 +56,10 @@ assets:
       - multi-agent repository synchronization
       - GitHub Project workflow
       - Epic workflow
+      - roadmap planning
+      - milestone to GitHub issues
       - Execution Contract
+      - Roadmap Status
       - needs label inbox
       - issue completion comment
       - PR review handoff

--- a/usage/usage-aggregate.yaml
+++ b/usage/usage-aggregate.yaml
@@ -47,7 +47,7 @@ aggregates:
     period: 2026-06
     agent: "codex"
     machine_hash: "a6bcad5212d8"
-    useful_count: 11
+    useful_count: 12
     neutral_count: 0
     not_useful_count: 0
     unknown_count: 0


### PR DESCRIPTION
## Summary

- Extend ASSET-COLLAB-001 for roadmap-to-GitHub Project planning and Architect/Implementer batch planning.
- Extend ASSET-ARCH-001 for layer taxonomy and boundary inventory before migration or file movement.
- Extend ASSET-META-001 so `harvest skills` / `harvest assets` uses whole-session or phase-level evidence windows.
- Update asset index triggers and publish the corresponding Codex, Hermes, Claude Code, and ChatGPT adapters.
- Record concise ASSET-META-001 usage aggregate evidence.

Deferred by user request:

- Personal Tool Productization Planning remains deferred and is not added as an active asset capability in this PR.

## Verification

- `python3 scripts/check_consistency.py`
- `python3 scripts/check_adapter_quality.py`
- `python3 scripts/check_activation.py`
- `git diff --check`
- `python3 scripts/install_foundry.py`
- `python3 scripts/install_foundry.py --apply`
