### PR TITLE
Define split-aware locator contract

### DIFF
--- a/adapters/chatgpt/knowledge/harvest-practices.md
+++ b/adapters/chatgpt/knowledge/harvest-practices.md
@@ -4,7 +4,7 @@ Canonical source: `workflows/harvest-practices.md`
 
 Use when the user says `harvest practices` or `做一次 harvest practice`.
 
-When harvesting from another project, that project is evidence source only. Locate Agent Foundry before proposing canonical changes. Use `AGENT_FOUNDRY_HOME`, then `~/.agent-foundry/config.yaml`, then the current directory only if it contains canonical markers such as `indexes/practice_index.yaml`, `indexes/asset_index.yaml`, and `workflows/harvest-practices.md`.
+When harvesting from another project, that project is evidence source only. Locate Agent Foundry before proposing canonical changes. Prefer explicit roots when available, then `AGENT_FOUNDRY_CORE` plus `AGENT_FOUNDRY_VAULT` after commands support them, then `~/.agent-foundry/config.yaml`, then `AGENT_FOUNDRY_HOME` as same-root compatibility, then the current directory only if it validates as the required Core and Vault context. Core markers include `workflows/harvest-practices.md` and `schemas/practice-entry.schema.yaml`; Vault markers include `indexes/practice_index.yaml`, `indexes/asset_index.yaml`, and `usage/usage-aggregate.yaml`. Do not require Core-owned workflow files inside a split Vault.
 
 Route:
 

--- a/adapters/claude-code/CLAUDE.md
+++ b/adapters/claude-code/CLAUDE.md
@@ -44,7 +44,7 @@ When asked to refresh, read `workflows/refresh.md` and follow the steps: git pul
 
 When asked to harvest, persist, deduplicate, merge, or publish reusable lessons:
 
-1. Locate Agent Foundry Core and Vault. Use `AGENT_FOUNDRY_HOME`, then `~/.agent-foundry/config.yaml`, then the current directory only if canonical markers exist. The current project is evidence source, not canonical destination.
+1. Locate Agent Foundry Core and Vault. Prefer explicit roots when available, then `AGENT_FOUNDRY_CORE` plus `AGENT_FOUNDRY_VAULT` after commands support them, then `~/.agent-foundry/config.yaml`, then `AGENT_FOUNDRY_HOME` as same-root compatibility, then the current directory only if it validates as the required Core and Vault context. The current project is evidence source, not canonical destination.
 2. Read `workflows/harvest-practices.md`.
 3. Read `schemas/practice-entry.schema.yaml`.
 4. Run the current capability check; do not use future architecture concepts as current writable substrate.

--- a/adapters/codex/skills/practice-harvester/SKILL.md
+++ b/adapters/codex/skills/practice-harvester/SKILL.md
@@ -36,7 +36,7 @@ Before substantial changes, check:
 
 ## Workflow
 
-1. Locate Agent Foundry Core and Vault. Use `AGENT_FOUNDRY_HOME`, then `~/.agent-foundry/config.yaml`, then the current directory only if canonical markers exist. The current project is evidence source, not canonical destination.
+1. Locate Agent Foundry Core and Vault. Prefer explicit roots when available, then `AGENT_FOUNDRY_CORE` plus `AGENT_FOUNDRY_VAULT` after commands support them, then `~/.agent-foundry/config.yaml`, then `AGENT_FOUNDRY_HOME` as same-root compatibility, then the current directory only if it validates as the required Core and Vault context. The current project is evidence source, not canonical destination.
 2. Select the workflow from the short command or user intent.
 3. Read `references/harvest-workflow.md` for harvesting, `references/import-policy.md` for imports, `references/asset-policy.md` for assets, `workflows/refresh.md` from the repo for refresh, or the repository workflow file for publish/review.
 4. Read `references/schema.md`.
@@ -73,4 +73,4 @@ Before substantial changes, check:
 - Make adapter fidelity executable. Adapter quality checks must verify the exact contract surface they claim to protect, such as Compact Preflight sections, canonical IDs, published asset IDs, target conventions, and high-fidelity requirements, not just generated file existence or broad text matches.
 - Review assets with lifecycle evidence. Asset review should use lifecycle state, usage evidence, overlap, canonical coverage, stale triggers, and published targets before recommending keep, revise, deprecate, archive, split, or merge.
 - Sync aggregate usage statistics, not raw evidence. Keep raw usage logs local under `usage/local/`, sync sanitized aggregate rows in `usage/usage-aggregate.yaml`, and keep missed activation or other review-only signals out of shared usage counts unless explicitly summarized through an approved aggregate format.
-- When working from another project, locate and validate the Foundry Vault before writing canonical records. Required markers include `indexes/practice_index.yaml`, `indexes/asset_index.yaml`, and `workflows/harvest-practices.md`.
+- When working from another project, locate and validate Foundry Core and Vault before writing canonical records. Core markers include `workflows/harvest-practices.md` and `schemas/practice-entry.schema.yaml`; Vault markers include `indexes/practice_index.yaml`, `indexes/asset_index.yaml`, and `usage/usage-aggregate.yaml`. Do not require Core-owned workflow files inside a split Vault.

--- a/adapters/codex/skills/practice-harvester/references/harvest-workflow.md
+++ b/adapters/codex/skills/practice-harvester/references/harvest-workflow.md
@@ -2,7 +2,7 @@
 
 Canonical source: `workflows/harvest-practices.md`
 
-Locate Agent Foundry before writing canonical records. Use `AGENT_FOUNDRY_HOME`, then `~/.agent-foundry/config.yaml`, then the current directory only if it contains canonical markers. The current project is evidence source, not canonical destination.
+Locate Agent Foundry before writing canonical records. Prefer explicit roots when available, then `AGENT_FOUNDRY_CORE` plus `AGENT_FOUNDRY_VAULT` after commands support them, then `~/.agent-foundry/config.yaml`, then `AGENT_FOUNDRY_HOME` as same-root compatibility, then the current directory only if it validates as the required Core and Vault context. Core markers include `workflows/harvest-practices.md` and `schemas/practice-entry.schema.yaml`; Vault markers include `indexes/practice_index.yaml`, `indexes/asset_index.yaml`, and `usage/usage-aggregate.yaml`. Do not require Core-owned workflow files inside a split Vault. The current project is evidence source, not canonical destination.
 
 Follow this route:
 

--- a/adapters/hermes/skills/practice-harvester/SKILL.md
+++ b/adapters/hermes/skills/practice-harvester/SKILL.md
@@ -36,7 +36,7 @@ Before substantial changes, check:
 
 ## Workflow
 
-1. Locate Agent Foundry Core and Vault. Use `AGENT_FOUNDRY_HOME`, then `~/.agent-foundry/config.yaml`, then the current directory only if canonical markers exist. The current project is evidence source, not canonical destination.
+1. Locate Agent Foundry Core and Vault. Prefer explicit roots when available, then `AGENT_FOUNDRY_CORE` plus `AGENT_FOUNDRY_VAULT` after commands support them, then `~/.agent-foundry/config.yaml`, then `AGENT_FOUNDRY_HOME` as same-root compatibility, then the current directory only if it validates as the required Core and Vault context. The current project is evidence source, not canonical destination.
 2. Select the workflow from the short command or user intent.
 3. Read `references/harvest-workflow.md` for harvesting, `references/import-policy.md` for imports, `references/asset-policy.md` for assets, `workflows/refresh.md` from the repo for refresh, or the repository workflow file for publish/review.
 4. Read `references/schema.md`.
@@ -73,4 +73,4 @@ Before substantial changes, check:
 - Make adapter fidelity executable. Adapter quality checks must verify the exact contract surface they claim to protect, such as Compact Preflight sections, canonical IDs, published asset IDs, target conventions, and high-fidelity requirements, not just generated file existence or broad text matches.
 - Review assets with lifecycle evidence. Asset review should use lifecycle state, usage evidence, overlap, canonical coverage, stale triggers, and published targets before recommending keep, revise, deprecate, archive, split, or merge.
 - Sync aggregate usage statistics, not raw evidence. Keep raw usage logs local under `usage/local/`, sync sanitized aggregate rows in `usage/usage-aggregate.yaml`, and keep missed activation or other review-only signals out of shared usage counts unless explicitly summarized through an approved aggregate format.
-- When working from another project, locate and validate the Foundry Vault before writing canonical records. Required markers include `indexes/practice_index.yaml`, `indexes/asset_index.yaml`, and `workflows/harvest-practices.md`.
+- When working from another project, locate and validate Foundry Core and Vault before writing canonical records. Core markers include `workflows/harvest-practices.md` and `schemas/practice-entry.schema.yaml`; Vault markers include `indexes/practice_index.yaml`, `indexes/asset_index.yaml`, and `usage/usage-aggregate.yaml`. Do not require Core-owned workflow files inside a split Vault.

--- a/adapters/hermes/skills/practice-harvester/references/harvest-workflow.md
+++ b/adapters/hermes/skills/practice-harvester/references/harvest-workflow.md
@@ -5,7 +5,7 @@ Canonical sources:
 - `workflows/harvest-practices.md`
 - META-001, META-002, META-003
 
-Locate Agent Foundry before writing canonical records. Use `AGENT_FOUNDRY_HOME`, then `~/.agent-foundry/config.yaml`, then the current directory only if it contains canonical markers. The current project is evidence source, not canonical destination.
+Locate Agent Foundry before writing canonical records. Prefer explicit roots when available, then `AGENT_FOUNDRY_CORE` plus `AGENT_FOUNDRY_VAULT` after commands support them, then `~/.agent-foundry/config.yaml`, then `AGENT_FOUNDRY_HOME` as same-root compatibility, then the current directory only if it validates as the required Core and Vault context. Core markers include `workflows/harvest-practices.md` and `schemas/practice-entry.schema.yaml`; Vault markers include `indexes/practice_index.yaml`, `indexes/asset_index.yaml`, and `usage/usage-aggregate.yaml`. Do not require Core-owned workflow files inside a split Vault. The current project is evidence source, not canonical destination.
 
 Route:
 

--- a/docs/lifecycle-compatibility.md
+++ b/docs/lifecycle-compatibility.md
@@ -53,11 +53,11 @@ When the command is run from another project, that project is the evidence sourc
 
 1. `AGENT_FOUNDRY_HOME`;
 2. `~/.agent-foundry/config.yaml`;
-3. current directory, only if canonical markers exist;
+3. current directory, only if it validates as the required Core and Vault context;
 4. known fallback paths;
 5. ask the user.
 
-After locating the Vault, validate markers such as `indexes/practice_index.yaml`, `indexes/asset_index.yaml`, and `workflows/harvest-practices.md` before writing.
+After locating Agent Foundry, validate Core markers such as `workflows/harvest-practices.md` and `schemas/practice-entry.schema.yaml`, and Vault markers such as `indexes/practice_index.yaml`, `indexes/asset_index.yaml`, and `usage/usage-aggregate.yaml` before writing. Do not require Core-owned workflow files inside a split Vault.
 
 | Agent | Adaptation |
 |---|---|

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -73,7 +73,7 @@ Agent Foundry should use maturity stages for planning and release versions for d
 | AF-1 | Governed Foundry | Practices, assets, workflows, review gates, adapter publishing, and current/proposed boundaries are governed explicitly. | Harvest/review/publish lifecycle is coherent; roadmap and hygiene work are tracked. |
 | AF-2 | Productizable Foundry | Repository layers and user/product boundaries are clear enough to support a reusable system. | Core, User Vault, Generated, Runtime, Local Private, and Proposed Design Evidence are separated by policy and implementation plan. |
 | AF-3 | Split Vault Migration | Core and the maintainer's User Vault are physically separated without breaking existing local runtimes. | Public Core no longer requires maintainer vault content; maintainer Vault is private by default; existing Codex, Claude Code, Hermes, and ChatGPT setups are migrated or given a tested migration path; clean new-user setup is tested. |
-| AF-4 | Onboarding Ready | New users can start from an empty Vault, curated capability packs, or imported runtime assets without confusing starter content with canonical truth. | Onboarding flows are tested; starter packs and imports enter as reviewed candidates; external-user setup is understandable without maintainer context. |
+| AF-4 | Onboarding Ready | New users can install Core, create a blank Vault, deploy the mandatory bootstrap capability pack, optionally deploy additional capability packs, and refresh adapters without confusing pack content with private maintainer history. | Blank Vault creation, bootstrap pack deployment, optional pack selection, runtime-asset import, and first-run refresh are tested. |
 | AF-5 | Memory-System Ready | Future memory-system records, evidence policy, routing, privacy, and MCP boundaries are designed but not necessarily implemented. | Memory-system implementation home can be chosen with clear tradeoffs. |
 | AF-6 | Memory-System Implementation | A reviewed memory/knowledge system is implemented according to the chosen architecture. | MVP validates the main memory lifecycle without bypassing Agent Foundry governance. |
 
@@ -95,7 +95,7 @@ Suggested mapping:
 | AF-4 | `v0.4.0`: external-user onboarding baseline. |
 | AF-5 | `v0.5.0`: memory-system-ready design baseline. |
 | AF-6 MVP | `v0.6.0` or later: memory-system MVP, not automatically `v1.0`. |
-| Post-AF-6 | Future: capability pack discovery/export after the core lifecycle and memory decisions are stable. |
+| Post-AF-6 | Future: advanced automatic capability pack discovery and lifecycle optimization after the core onboarding path is stable. |
 
 `v1.0` should wait until the reusable core, user vault story, generated artifact policy, and runtime adapter behavior are stable enough that external users can rely on them without understanding this repository's personal history.
 
@@ -258,7 +258,8 @@ Blank Vault baseline:
 - It should include empty indexes and empty aggregate evidence, not the maintainer's current active practice/asset records.
 - Core owns schemas, templates, workflows, and initialization logic. The Vault owns user records and non-sensitive vault policy.
 - Runtime install is not implied by blank Vault creation. Runtime deployment remains a separate local operation using Core tooling plus the selected Vault.
-- Starter capability packs and runtime-asset imports are optional AF-4 onboarding inputs, not AF-2 blank defaults.
+- Capability pack deployment happens after blank Vault creation. The mandatory bootstrap pack and optional packs enter the Vault as canonical data before `refresh`.
+- Runtime-asset imports are optional AF-4 onboarding inputs, not AF-2 blank defaults.
 - Empty indexes and aggregates should pass validation once AF-3 updates checks for separate Core and Vault roots.
 
 ### M3: Physical Core/Vault Split And Migration
@@ -327,7 +328,7 @@ AF-3 epics and task breakdown:
 
 - **Public Core cleanup**
   - Keep reusable `workflows/`, `schemas/`, `scripts/`, `templates/`, runtime templates, adapter profiles, adapter quality rules, and product docs in Core.
-  - Replace personal defaults with templates, examples, empty indexes, or documented starter packs.
+  - Replace personal defaults with templates, examples, empty indexes, or documented capability pack deployment constraints.
   - Ensure Core does not publish the maintainer's active practices/assets as default product state.
   - Preserve blank-vault templates or generation logic in Core, while keeping blank-vault records empty and non-personal.
   - Separate Core-owned adapter profiles and quality checks from generated adapter outputs.
@@ -368,6 +369,7 @@ AF-3 epics and task breakdown:
   - Add fixtures or temporary test directories for combined repo, blank Vault, and maintainer-like Vault validation.
   - Keep tests local and deterministic; do not require private remote access for public Core validation.
   - Verify generated adapter outputs do not leak inactive candidate/proposed records or private paths.
+  - Preserve the substrate needed for later pack deployment: blank Vault first, pack canonical data second, refresh third.
   - Exit when consistency, adapter quality, activation, runtime dry-run, and split-root validation checks pass.
 
 - **External-user readiness gate**
@@ -376,7 +378,7 @@ AF-3 epics and task breakdown:
   - Confirm a user can choose a suitable Vault location: private Git repo, local-only repo, or other explicitly supported storage.
   - Document where the Vault should live and how agents remember or rediscover it.
   - Test nested usage: running harvest/refresh from inside a product project must locate the correct Core and Vault without confusing the product project with either.
-  - Confirm setup docs clearly state what AF-3 does not include: starter packs, runtime-asset import, and memory-system implementation.
+  - Confirm setup docs clearly state what AF-3 does not include: implementing bootstrap pack deployment, optional pack UX, runtime-asset import, or memory-system implementation.
   - Exit when the project can truthfully say "public Core plus separate Vault works" without claiming AF-4 onboarding polish.
 
 Planned GitHub issue sequence:
@@ -387,7 +389,7 @@ Planned GitHub issue sequence:
 | 2 | #28 Split-aware locator and context model | Epic | Architect | High | #27 defines root names, markers, and precedence | Batch checkpoint |
 | 3 | #35 Split-root validation fixtures and checks | Task batch | Implementer with Architect-owned acceptance | Medium | #28 defines marker contract | Batch checkpoint with #28 |
 | 4 | #29 Adapter generation from selected Vault | Task batch | Implementer | Medium | #28 marker contract and #35 validation helpers exist | Batch checkpoint |
-| 5 | #30 Blank Vault initializer and validation | Task batch | Implementer | Medium | #35 validates empty Vault shape | Batch checkpoint |
+| 5 | #30 Blank Vault initializer and validation | Task batch | Implementer | Medium | #35 validates empty Vault shape and preserves pack-deployment substrate | Batch checkpoint |
 | 6 | #31 Maintainer Vault extraction plan and backup | Decision / Task | Architect | High | #28, #35, #29, and #30 pass in combined compatibility mode | Explicit user approval before moving private records |
 | 7 | #32 Public Core cleanup and docs rewrite | Task batch | Implementer with Architect review | Medium | #31 defines extraction target and Core contents | Batch checkpoint |
 | 8 | #33 Runtime deployment migration | Epic / Task batch | Architect + Implementer | High | #28, #35, #29, and #30 pass; generated adapters are split-aware | User or structured Architect review before apply |
@@ -426,6 +428,7 @@ Minimum verification matrix:
 | Current combined compatibility | Existing consistency, adapter quality, activation, runtime dry-run, and locator status pass. |
 | Split maintainer operation | Core root and maintainer Vault root validate separately; adapter generation and runtime dry-run use the selected Vault. |
 | Blank Vault operation | Empty indexes and aggregate validate; adapter publishing reports empty/minimal output without copying maintainer content. |
+| Pack deployment substrate | The design preserves the sequence blank Vault -> pack canonical data deployment -> refresh, without treating packs as runtime-only helpers or a second source of truth. |
 | Product project harvest context | Agent locates Core and Vault from outside both roots; product project is evidence source only. |
 | Runtime migration | Codex, Claude Code, Hermes managed outputs are inventoried and dry-run before apply; ChatGPT manual import state is reported. |
 | Privacy check | Public Core contains no required maintainer Vault records, raw evidence, machine-local paths, secrets, or private adoption decisions. |
@@ -437,25 +440,54 @@ Acceptance criteria:
 - Existing local Codex, Claude Code, Hermes, and ChatGPT workflows have a tested migration path.
 - `core_root` and `vault_root` can be different paths and are both validated before canonical writes.
 - Product project, Foundry Vault operation, and Foundry Core maintenance contexts are distinguishable before writes or runtime installs.
-- A blank Vault can be initialized and checked without personal practices/assets.
+- A blank Vault can be initialized and checked without personal practices/assets, and later pack deployment can add canonical data without redefining blank Vault.
 - Adapter generation and runtime install work from both the maintainer Vault and a blank/new user Vault.
 - Rollback instructions exist for the split migration.
 - No future memory-system storage is introduced as part of the split.
 
 ### M4: Onboarding Experience
 
-Goal: make new-user startup useful without forcing everyone to begin from a completely empty Vault.
+Goal: make new-user startup useful by separating blank Vault creation from capability pack deployment and adapter refresh.
 
-Onboarding should support multiple explicit modes:
+Onboarding sequence:
 
-- **Empty Vault**
-  - Best for users who want full control and no inherited capability records.
-  - Starts with schemas, templates, empty indexes, and empty aggregate evidence.
+```text
+install Core
+  -> create blank Vault
+  -> deploy mandatory bootstrap capability pack as canonical Vault data
+  -> optionally deploy selected capability packs as canonical Vault data
+  -> optionally import existing runtime assets as reviewed candidates
+  -> refresh
+  -> generate and install adapters from the Vault
+```
 
-- **Starter capability packs**
-  - Best for users who want a useful baseline such as multi-agent collaboration, technical documentation writing, or provider integration.
-  - Packs should be curated, public, reviewed, and installable without private evidence.
-  - Pack contents enter the user's Vault as proposed or active records only according to the user's selected onboarding policy.
+The blank Vault remains genuinely blank. It contains structure, metadata, empty indexes, and empty aggregate evidence, but no practices or assets. The mandatory bootstrap pack is deployed immediately after blank Vault creation so the installed system is usable. Optional packs use the same deployment mechanism.
+
+Capability packs are canonical data bundles, not runtime-only helpers and not a second CRUD system. Deploying a pack writes normal practices, assets, index entries, and pack metadata into the user's Vault. After deployment, those records are governed by the same create, read, update, deprecate, retire, review, and adapter-publish workflows as manually created records.
+
+Predefined packs and discovered packs are compatible with freeform Vault maintenance:
+
+- Predefined packs are curated Core-distributed canonical data.
+- Discovered packs are reviewed bundle proposals inferred from existing Vault records, workflows, and usage evidence.
+- Deployment creates or updates ordinary Vault records with provenance and pack membership metadata.
+- Pack membership is metadata, not ownership; a record may belong to no pack, one pack, or multiple packs.
+- Pack updates must propose normal record changes and must not silently overwrite user-edited records.
+- Users and agents can still create, edit, archive, or retire arbitrary practices and assets outside any pack.
+- `refresh` reads current Vault records, not pack definitions, when generating adapters.
+
+Mandatory pack:
+
+- **Bootstrap capability pack**
+  - Required for normal onboarding.
+  - Contains the minimal canonical data needed for Agent Foundry to run harvest, asset discovery, refresh, review, and adapter publishing.
+  - Must be public, reviewed, private-evidence-free, and small enough not to import the maintainer's whole Vault history.
+
+Optional early pack:
+
+- **Multi-agent collaboration pack**
+  - Strong first optional pack candidate because the current collaboration practices/assets are mature, repeatedly used, and bounded.
+  - Should not block bootstrap pack completion.
+  - Should be packaged only after the bootstrap deployment path works.
 
 - **Import existing runtime assets**
   - Best for users who already have Codex skills, Claude Code instructions, Hermes skills, or ChatGPT project materials.
@@ -464,15 +496,25 @@ Onboarding should support multiple explicit modes:
 
 Epics:
 
-- **Onboarding mode selector**
-  - Define the user choice among empty Vault, starter pack, runtime import, or mixed setup.
-  - Make the consequences visible before writing files.
-  - Start from the AF-2 blank Vault baseline, then layer optional starter/import choices explicitly.
+- **Blank Vault creation**
+  - Implement the AF-2 blank Vault baseline as an empty but valid Vault.
+  - Keep runtime install and pack deployment separate from Vault creation.
 
-- **Starter capability pack design**
-  - Define how starter packs relate to assets, practices, templates, examples, and generated adapters.
+- **Capability pack deployment**
+  - Define pack manifest, provenance, record copy/merge behavior, pack membership metadata, version compatibility, and conflict handling.
+  - Define mandatory bootstrap pack deployment and optional pack selection using the same mechanism.
+  - Ensure pack deployment writes canonical data into the Vault before refresh.
+
+- **Bootstrap capability pack**
+  - Identify the minimal harvest/discover/refresh/review/publish records needed for normal onboarding.
+  - Build the pack from public, reviewed canonical data, not from private maintainer evidence.
+  - Verify that a user can refresh adapters after deploying only the bootstrap pack.
+
+- **Optional capability pack design**
+  - Define how optional packs relate to assets, practices, templates, examples, generated adapters, and pack membership metadata.
   - Ensure packs do not include maintainer-private Vault content.
-  - Keep pack activation reviewable and reversible.
+  - Keep pack deployment reviewable, reversible, and compatible with user edits.
+  - Package multi-agent collaboration as the first optional pack after bootstrap works.
 
 - **Runtime asset import path**
   - Define how to scan existing Codex, Claude Code, Hermes, and ChatGPT assets.
@@ -481,14 +523,19 @@ Epics:
 
 - **First-run verification**
   - Confirm Core and Vault are located.
+  - Confirm blank Vault validates before pack deployment.
+  - Confirm bootstrap pack deploys canonical data into the Vault.
+  - Confirm optional packs, when selected, use the same deployment path.
   - Confirm runtime targets are detected or intentionally skipped.
-  - Confirm the user knows which records are empty, proposed, active, imported, or starter-pack sourced.
+  - Confirm `refresh` generates adapters from Vault canonical records, not Core hidden state.
+  - Confirm the user knows which records are pack-sourced, imported, user-created, proposed, active, deprecated, or retired.
 
 Acceptance criteria:
 
-- A new user can choose empty, starter-pack, or import-based onboarding.
-- Starter content is never confused with the maintainer's private Vault.
-- Imported runtime assets are reviewed before becoming canonical.
+- A new user can install Core, create a blank Vault, deploy the mandatory bootstrap pack, optionally deploy selected packs, and run refresh.
+- Bootstrap pack content is never confused with the maintainer's private Vault.
+- Optional packs and imported runtime assets are reviewed or selected before becoming canonical.
+- Pack deployment and freeform practice/asset CRUD share the same Vault records and do not create parallel truth sources.
 - The onboarding flow preserves Core/Vault/context separation.
 
 ### M5: Existing Foundry Lifecycle Completion
@@ -598,11 +645,11 @@ Acceptance criteria:
 - Decision record names the chosen option and rejected alternatives.
 - Future implementation plan has file boundaries, data flow, validation, privacy policy, and rollback path.
 
-### M8: Capability Pack Discovery and Lifecycle
+### M8: Advanced Capability Pack Discovery and Lifecycle
 
-Goal: define whether Agent Foundry can recognize, maintain, and export higher-level capability packs that emerge from repeated work.
+Goal: improve whether Agent Foundry can recognize, maintain, and export higher-level capability packs that emerge from repeated work after the basic AF-4 pack deployment path exists.
 
-This is intentionally later than repository hygiene, productization, physical split migration, onboarding, lifecycle completion, memory readiness, and the fork-vs-extension decision. Do not use this milestone to delay AF-1 through AF-7.
+This is intentionally later than repository hygiene, productization, physical split migration, onboarding, lifecycle completion, memory readiness, and the fork-vs-extension decision. Do not use this milestone to delay AF-1 through AF-7. AF-4 owns the mandatory bootstrap pack, optional pack deployment mechanism, and first optional multi-agent collaboration pack. M8 is for automatic discovery, advanced lifecycle optimization, export polish, and maintenance of emergent packs.
 
 Capability packs are not the same as individual assets. A future capability pack may bundle practices, assets, workflows, templates, adapter snippets, examples, configuration profiles, dependency metadata, and export/install behavior around a recurring user goal such as multi-agent collaboration or technical documentation writing.
 
@@ -613,9 +660,9 @@ Epics:
   - Let agents propose capability candidates during harvest, asset discovery, or lifecycle review.
   - Avoid requiring humans to predefine all future capability categories.
 
-- **Capability pack schema**
-  - Define relationships among practices, assets, workflows, templates, adapters, examples, dependencies, versions, and target runtimes.
-  - Keep the schema separate from current asset records unless review proves they should converge.
+- **Capability pack schema evolution**
+  - Extend the AF-4 manifest only when usage proves more fields are needed.
+  - Keep schema changes compatible with deployed Vault records and pack membership metadata.
 
 - **Review and activation lifecycle**
   - Define states such as detected, candidate, proposed, active, deprecated, split, and merged.
@@ -640,7 +687,7 @@ Acceptance criteria:
 - Do not add semantic/vector/graph indexes.
 - Do not add MCP write tools.
 - Do not import raw ChatGPT exports.
-- Do not implement capability pack discovery, packaging, export, or install before the earlier repository, lifecycle, and memory-readiness decisions are stable.
+- Do not implement advanced automatic capability pack discovery, export marketplace behavior, or broad pack lifecycle automation before the basic AF-4 pack deployment path is stable.
 - Do not refactor adapters or runtime install behavior until repository hygiene policy exists.
 
 ## Immediate Next Planning Tasks

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -182,7 +182,7 @@ Design goal:
 public Core + empty User Vault -> valid starting point for reviewed practices, assets, usage evidence, and adapter generation
 ```
 
-`init-vault` should mean "create a valid, empty canonical destination" rather than "copy the maintainer's current vault." It should initialize structure and metadata only. It should not activate starter practices, install runtime adapters, import external skills, or write memory-system records.
+`init-vault` should mean "create a valid, empty canonical destination" rather than "copy the maintainer's current vault." It should initialize structure and metadata only. It should not activate practices, install runtime adapters, import external skills, deploy capability packs, or write memory-system records.
 
 Blank Vault contents:
 
@@ -199,7 +199,19 @@ Blank Vault contents:
 
 Template rule: practice and asset templates belong to Core. A blank Vault may receive copied template files only if the implementation needs standalone editing affordances, and those copies must be clearly marked as templates, not canonical records. Template copies must not appear in indexes as active records.
 
-Starter content rule: starter capability packs, imported Codex/Claude Code/Hermes/ChatGPT assets, and examples are onboarding inputs, not blank Vault defaults. They belong to AF-4 unless a later implementation explicitly lets the user choose them. If chosen, they enter as candidate/proposed records or as active records only under an explicit, reviewed onboarding policy.
+Capability pack rule: capability packs are deployed after blank Vault creation, not during blank Vault initialization. A deployed pack writes canonical practice and asset records, index entries, and any pack metadata into the user's Vault. After deployment, those records are normal Vault records governed by the same create, read, update, deprecate, retire, review, and adapter-publish workflows as manually created records. Pack deployment is an import/bootstrap path, not a second source of truth.
+
+Normal onboarding should deploy a mandatory bootstrap pack after the blank Vault exists. Optional packs, such as multi-agent collaboration or future technical documentation writing, use the same deployment mechanism but remain user-selected. Runtime adapters are generated only after pack deployment through `refresh`, from Vault canonical data.
+
+Predefined packs and discovered packs do not conflict with freeform Vault CRUD because they operate at different moments:
+
+- A predefined pack is curated Core-distributed canonical data that can be deployed into a Vault.
+- A discovered pack is a reviewed bundle proposal inferred from existing practices, assets, workflows, and usage evidence.
+- Once deployed, both become ordinary Vault records with provenance and pack membership metadata.
+- Later pack updates must propose normal record changes; they must not overwrite user-edited Vault records silently.
+- Users and agents may still create, edit, archive, or retire individual practices and assets outside any pack.
+- A record may belong to no pack, one pack, or multiple packs; pack membership is metadata, not ownership.
+- `refresh` ignores pack source and reads only the current active/revised Vault records.
 
 Validation expectations for a blank Vault:
 
@@ -210,6 +222,7 @@ Validation expectations for a blank Vault:
 5. Adapter publishing can report "nothing to publish" or produce an empty/minimal adapter output without treating that as a failure.
 6. Runtime install must not copy the maintainer's generated adapters into a new user's runtime.
 7. Consistency checks distinguish "empty but valid Vault" from "missing or corrupt Vault."
+8. Pack deployment can add canonical data after initialization without changing the definition of blank Vault.
 
 Implementation implications for AF-3:
 
@@ -217,13 +230,14 @@ Implementation implications for AF-3:
 - checks should validate Core schemas/workflows against an arbitrary Vault;
 - generated adapter outputs should be derived from the selected Vault, not from this repository's maintainer Vault by default;
 - blank-vault fixtures or templates should be reproducible from Core and should not require copying personal records;
+- later pack deployment should be able to populate a blank Vault with the mandatory bootstrap pack before `refresh`;
 - migration must test both the maintainer Vault and a blank/new-user Vault.
 
 Rejected as #7 scope:
 
 - creating `memory/`, `knowledge/`, `research_memos/`, or `project_memory`;
 - importing runtime skills or ChatGPT exports;
-- defining capability pack lifecycle beyond the constraint that packs are not blank defaults;
+- implementing capability pack deployment before the blank Vault and selected-root substrate are reviewed;
 - moving the maintainer's Vault into a private repo;
 - implementing `init-vault` scripts before the design is reviewed.
 
@@ -245,11 +259,13 @@ Target setup narrative after AF-3/AF-4:
 
 1. The user obtains the public Core.
 2. The user creates or selects a User Vault location.
-3. The user initializes an empty Vault or chooses an approved onboarding mode.
-4. The local locator records separate `core_root` and `vault_root`.
-5. Core tooling validates both roots before any canonical write.
-6. The user reviews runtime targets and applies adapter install only to selected local runtimes.
-7. ChatGPT remains manual unless a future supported import path exists.
+3. The user initializes an empty Vault.
+4. Core deploys the mandatory bootstrap pack into that Vault as canonical data.
+5. The user optionally deploys selected capability packs into the Vault.
+6. The local locator records separate `core_root` and `vault_root`.
+7. Core tooling validates both roots before any canonical write.
+8. The user runs `refresh`, which generates adapters from Vault canonical data and installs only to selected local runtimes.
+9. ChatGPT remains manual unless a future supported import path exists.
 
 Pre-split boundary for #9:
 
@@ -261,7 +277,8 @@ Pre-split boundary for #9:
 | How Core/Vault are located | `~/.agent-foundry/config.yaml` exists, but current scripts assume one root. | AF-3 separate root support. |
 | How adapters are generated | Current adapters are generated from the maintainer Vault. | AF-3 arbitrary-vault adapter generation. |
 | How runtimes are installed | Current machine-local manifest installs into selected local runtimes. | AF-3 migration checks for split Core/Vault; AF-4 first-run UX. |
-| How starter content appears | Starter packs and runtime imports are not blank defaults. | AF-4 onboarding mode selector. |
+| How bootstrap capability appears | Blank Vault is created first, then mandatory bootstrap pack is deployed as canonical Vault data. | AF-4 pack deployment and first-run verification. |
+| How optional capability content appears | Optional capability packs and runtime imports are not blank defaults; they are deployed or imported after the Vault exists. | AF-4 pack selection and import workflow. |
 | How existing runtime assets are imported | Existing runtime assets are evidence/candidates first. | AF-4 import workflow. |
 | What remains private | Raw evidence, local manifests, adoption state, secrets, maintainer Vault, personal records. | Current policy plus AF-3 migration. |
 
@@ -271,7 +288,7 @@ Docs implications:
 - `docs/usage.md` currently documents day-to-day use after Agent Foundry is already installed.
 - Neither file should be read as a tested external-user quickstart until AF-3 and AF-4 are complete.
 - AF-3 should rewrite deployment docs around public Core plus selected Vault.
-- AF-4 should add first-run onboarding choices: empty Vault, starter capability packs, runtime-asset import, or mixed setup.
+- AF-4 should add first-run onboarding sequence: blank Vault creation, mandatory bootstrap pack deployment, optional capability pack selection, runtime-asset import when selected, and unified refresh.
 
 Do not promise future memory-system behavior in external-user setup. Memory-system records, `knowledge/`, `research_memos/`, project memory, and MCP memory access remain proposed/future until reviewed architecture implements them.
 
@@ -310,7 +327,7 @@ Failure modes this prevents:
 - harvesting a project-local decision as a general Foundry practice;
 - modifying Core scripts when the user intended only to refresh a Vault;
 - installing stale adapters from the wrong Vault;
-- treating the maintainer's Vault as a default public starter pack;
+- treating the maintainer's Vault as a default public capability pack;
 - using future memory-system paths as current writable destinations.
 
 ## Configuration Boundary
@@ -322,7 +339,7 @@ Use these configuration classes:
 | Class | Examples | Ownership | Git behavior |
 | --- | --- | --- | --- |
 | Core config intent | adapter profiles, schemas, workflow defaults, runtime manifest template | Public Core | Tracked |
-| Vault config intent | vault metadata, selected starter packs, privacy defaults, optional import-pack choices | User Vault | Tracked in the user's Vault when non-sensitive |
+| Vault config intent | vault metadata, selected capability packs, privacy defaults, optional import-pack choices | User Vault | Tracked in the user's Vault when non-sensitive |
 | Machine-local locator | `~/.agent-foundry/config.yaml` with `core_root`, `vault_root`, markers, and compatibility fields | User machine | Not tracked |
 | Machine-local runtime deployment | `runtime/local/runtime_manifest.yaml`, enabled runtimes, install paths, adoption decisions | User machine | Gitignored |
 | Runtime copies | installed files under Codex, Claude Code, Hermes, and manual ChatGPT imports | User runtime | Outside Core/Vault canonical records |
@@ -372,13 +389,7 @@ Failure states should be explicit:
 - Manual target such as ChatGPT: produce import instructions, do not pretend install is automatic.
 - Core and Vault version mismatch: stop or warn before publishing adapters.
 
-Onboarding implication: a blank Vault should not be the only user path. Future onboarding should support at least three explicit modes:
-
-1. empty Vault for users who want to build capability records from scratch;
-2. starter capability packs curated from public Core examples or reviewed bundles;
-3. import from existing Codex, Claude Code, Hermes, or ChatGPT assets as candidate inputs, not active canonical truth.
-
-These onboarding modes must still preserve the Core/Vault boundary: starter packs and imported runtime assets are proposed inputs until the user accepts them into their Vault.
+Onboarding implication: a blank Vault is the first state, not the complete usable setup. Future onboarding should always create a blank Vault, deploy the mandatory bootstrap pack as canonical Vault data, optionally deploy selected capability packs, and then run `refresh`. Existing Codex, Claude Code, Hermes, or ChatGPT assets remain import candidates, not canonical truth, unless the user accepts them into the Vault.
 
 Machine-local locator:
 
@@ -490,7 +501,7 @@ Example conventions:
 2. Example records should avoid real personal project history, private paths, raw session evidence, and maintainer-specific runtime assumptions.
 3. A blank vault should start from schemas, templates, empty indexes, and empty or zeroed aggregates, not from the maintainer's active practices/assets by default.
 4. The maintainer's active practices and assets may be used as design references or optional import packs only after the Core/Vault split defines that packaging model.
-5. Adapter outputs for an external user should be generated from that user's approved vault records, not copied from this repository's personal vault unless explicitly chosen as a starter pack.
+5. Adapter outputs for an external user should be generated from that user's approved vault records, not copied from this repository's personal vault unless explicitly deployed through a reviewed capability pack.
 6. Proposed memory-system material must stay in docs/imports/evidence form until reviewed architecture creates implemented memory directories, schemas, and workflows.
 
 AF-2 should use this policy to design a blank vault initialization path, a Core/Vault split, and external-user setup boundaries. AF-1 does not move files yet; it marks the boundary so future movement is deliberate.

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -333,18 +333,22 @@ Locator semantics:
 - `core_root`: path to the reusable Agent Foundry Core that provides workflows, schemas, scripts, templates, adapter profiles, and docs.
 - `vault_root`: path to the active User Vault that provides practices, assets, indexes, shared aggregates, and vault-local docs.
 - `repo_root`: compatibility field for current single-repo operation. After physical split, it should be derived or deprecated rather than treated as proof that Core and Vault share a root.
-- `canonical_markers`: markers that validate a Vault before canonical writes.
-- `core_markers`: future markers that validate Core before running Core tooling.
+- `core_markers`: markers that validate Core before running Core tooling. Required examples include `workflows/harvest-practices.md`, `schemas/practice-entry.schema.yaml`, and `scripts/foundry_config.py`.
+- `vault_markers`: markers that validate a Vault before canonical writes. Required examples include `indexes/practice_index.yaml`, `indexes/asset_index.yaml`, and `usage/usage-aggregate.yaml`.
+- `canonical_markers`: deprecated compatibility field from the single-root staging state. It may be read for old local configs, but new configs should use `core_markers` and `vault_markers`.
 
-Current capability: `scripts/foundry_config.py` writes `core_root`, `vault_root`, and `repo_root` to the same path. This is valid only for the current single-repo staging state. AF-3 migration work must update the locator and scripts so `core_root` and `vault_root` may differ.
+Current capability: `scripts/foundry_config.py` writes `core_root`, `vault_root`, and `repo_root` to the same path for compatibility, but emits separate Core and Vault marker lists. This is still a single-repo staging mode until later AF-3 work teaches all commands to operate on distinct roots.
 
-Locator precedence should be explicit:
+Locator precedence:
 
 1. Explicit user-provided `--core-root` and `--vault-root` flags, when a command supports them.
-2. Explicit environment variables for Core and Vault roots, after they are designed.
+2. Paired `AGENT_FOUNDRY_CORE` and `AGENT_FOUNDRY_VAULT` environment variables, after commands implement them.
 3. `~/.agent-foundry/config.yaml`.
-4. Current directory only if it validates as the required context for the requested operation.
-5. Ask the user.
+4. `AGENT_FOUNDRY_HOME` as a same-root compatibility locator.
+5. Current directory only if it validates as the required context for the requested operation.
+6. Ask the user.
+
+Do not treat a single root found through `AGENT_FOUNDRY_HOME` or current directory as proof that split mode is unsupported. It is only a compatibility path. Commands should prefer explicit Core/Vault roots once they are available.
 
 Do not use a product project checkout as a Vault merely because the user is working there. Do not use a Vault as Core merely because it contains practices. Do not use Core as a Vault merely because it has templates or examples.
 
@@ -382,7 +386,7 @@ Machine-local locator:
 ~/.agent-foundry/config.yaml
 ```
 
-This file records `repo_root`, `core_root`, `vault_root`, and canonical markers. It is written during install and is not canonical knowledge. Agents working in another repository should locate Agent Foundry through this config or `AGENT_FOUNDRY_HOME`, then validate the markers before writing canonical records. After the physical split, `core_root` and `vault_root` may intentionally point to different repositories or directories; agents must validate both instead of assuming one repo root.
+This file records `repo_root`, `core_root`, `vault_root`, Core markers, and Vault markers. It is written during install and is not canonical knowledge. Agents working in another repository should locate Agent Foundry through this config or `AGENT_FOUNDRY_HOME`, then validate Core and Vault separately before writing canonical records. After the physical split, `core_root` and `vault_root` may intentionally point to different repositories or directories; agents must validate both instead of assuming one repo root.
 
 ## Generated Artifact Policy
 

--- a/scripts/foundry_config.py
+++ b/scripts/foundry_config.py
@@ -9,10 +9,15 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 CONFIG_PATH = Path.home() / ".agent-foundry" / "config.yaml"
+CORE_MARKERS = [
+    "workflows/harvest-practices.md",
+    "schemas/practice-entry.schema.yaml",
+    "scripts/foundry_config.py",
+]
 VAULT_MARKERS = [
     "indexes/practice_index.yaml",
     "indexes/asset_index.yaml",
-    "workflows/harvest-practices.md",
+    "usage/usage-aggregate.yaml",
 ]
 
 
@@ -22,15 +27,19 @@ def quote(value: Path | str) -> str:
     return f'"{escaped}"'
 
 
-def config_text(repo_root: Path = ROOT) -> str:
+def config_text(repo_root: Path = ROOT, core_root: Path | None = None, vault_root: Path | None = None) -> str:
     repo_root = repo_root.resolve()
+    core_root = (core_root or repo_root).resolve()
+    vault_root = (vault_root or repo_root).resolve()
     lines = [
         "schema_version: 1",
         f"repo_root: {quote(repo_root)}",
-        f"core_root: {quote(repo_root)}",
-        f"vault_root: {quote(repo_root)}",
-        "canonical_markers:",
+        f"core_root: {quote(core_root)}",
+        f"vault_root: {quote(vault_root)}",
+        "core_markers:",
     ]
+    lines.extend(f"  - {marker}" for marker in CORE_MARKERS)
+    lines.append("vault_markers:")
     lines.extend(f"  - {marker}" for marker in VAULT_MARKERS)
     lines.extend(
         [
@@ -43,7 +52,11 @@ def config_text(repo_root: Path = ROOT) -> str:
 
 
 def parse_config(path: Path = CONFIG_PATH) -> dict[str, str | list[str]]:
-    data: dict[str, str | list[str]] = {"canonical_markers": []}
+    data: dict[str, str | list[str]] = {
+        "core_markers": [],
+        "vault_markers": [],
+        "canonical_markers": [],
+    }
     if not path.exists():
         return data
     current_list = ""
@@ -70,35 +83,57 @@ def parse_config(path: Path = CONFIG_PATH) -> dict[str, str | list[str]]:
 def validate(path: Path = CONFIG_PATH) -> list[str]:
     errors: list[str] = []
     data = parse_config(path)
-    repo_root = Path(str(data.get("repo_root", ""))).expanduser()
-    vault_root = Path(str(data.get("vault_root", ""))).expanduser()
-    core_root = Path(str(data.get("core_root", ""))).expanduser()
-    markers = data.get("canonical_markers", [])
-    if not repo_root:
-        errors.append("missing repo_root")
-    elif not repo_root.exists():
+    repo_root_text = str(data.get("repo_root", ""))
+    core_root_text = str(data.get("core_root", ""))
+    vault_root_text = str(data.get("vault_root", ""))
+    repo_root = Path(repo_root_text).expanduser()
+    core_root = Path(core_root_text).expanduser()
+    vault_root = Path(vault_root_text).expanduser()
+    core_markers = data.get("core_markers", [])
+    vault_markers = data.get("vault_markers", [])
+    compatibility_markers = data.get("canonical_markers", [])
+    if repo_root_text and not repo_root.exists():
         errors.append(f"repo_root does not exist: {repo_root}")
-    if not core_root:
+    if not core_root_text:
         errors.append("missing core_root")
     elif not core_root.exists():
         errors.append(f"core_root does not exist: {core_root}")
-    if not vault_root:
+    if not vault_root_text:
         errors.append("missing vault_root")
     elif not vault_root.exists():
         errors.append(f"vault_root does not exist: {vault_root}")
-    if not isinstance(markers, list) or not markers:
-        errors.append("missing canonical_markers")
-    else:
-        for marker in markers:
+    if not isinstance(core_markers, list) or not core_markers:
+        if isinstance(compatibility_markers, list) and compatibility_markers:
+            core_markers = compatibility_markers
+        else:
+            errors.append("missing core_markers")
+    if not isinstance(vault_markers, list) or not vault_markers:
+        if isinstance(compatibility_markers, list) and compatibility_markers:
+            vault_markers = compatibility_markers
+        else:
+            errors.append("missing vault_markers")
+
+    if isinstance(core_markers, list):
+        for marker in core_markers:
+            marker_path = core_root / marker
+            if not marker_path.exists():
+                errors.append(f"core marker missing: {marker_path}")
+    if isinstance(vault_markers, list):
+        for marker in vault_markers:
             marker_path = vault_root / marker
             if not marker_path.exists():
-                errors.append(f"canonical marker missing: {marker_path}")
+                errors.append(f"vault marker missing: {marker_path}")
     return errors
 
 
-def write_config(path: Path = CONFIG_PATH, repo_root: Path = ROOT) -> None:
+def write_config(
+    path: Path = CONFIG_PATH,
+    repo_root: Path = ROOT,
+    core_root: Path | None = None,
+    vault_root: Path | None = None,
+) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(config_text(repo_root), encoding="utf-8")
+    path.write_text(config_text(repo_root, core_root, vault_root), encoding="utf-8")
     print(f"wrote foundry locator: {path}")
 
 
@@ -110,9 +145,11 @@ def status(path: Path = CONFIG_PATH) -> int:
     print(f"foundry locator: {path}")
     for key in ["repo_root", "core_root", "vault_root"]:
         print(f"{key}: {data.get(key, '')}")
-    markers = data.get("canonical_markers", [])
-    if isinstance(markers, list):
-        print("canonical_markers:")
+    for label in ["core_markers", "vault_markers", "canonical_markers"]:
+        markers = data.get(label, [])
+        if not isinstance(markers, list) or not markers:
+            continue
+        print(f"{label}:")
         for marker in markers:
             print(f"  - {marker}")
     errors = validate(path)
@@ -130,13 +167,18 @@ def main() -> int:
     sub = parser.add_subparsers(dest="command", required=True)
     write = sub.add_parser("write")
     write.add_argument("--path", default=str(CONFIG_PATH), help="Config path to write.")
-    write.add_argument("--repo-root", default=str(ROOT), help="Agent Foundry repo root.")
+    write.add_argument("--repo-root", default="", help="Compatibility repo root. Defaults to core root.")
+    write.add_argument("--core-root", default="", help="Agent Foundry Core root.")
+    write.add_argument("--vault-root", default="", help="Agent Foundry Vault root.")
     stat = sub.add_parser("status")
     stat.add_argument("--path", default=str(CONFIG_PATH), help="Config path to inspect.")
     args = parser.parse_args()
 
     if args.command == "write":
-        write_config(Path(args.path).expanduser(), Path(args.repo_root).expanduser())
+        core_root = Path(args.core_root).expanduser() if args.core_root else ROOT
+        vault_root = Path(args.vault_root).expanduser() if args.vault_root else core_root
+        repo_root = Path(args.repo_root).expanduser() if args.repo_root else core_root
+        write_config(Path(args.path).expanduser(), repo_root, core_root, vault_root)
     elif args.command == "status":
         return status(Path(args.path).expanduser())
     return 0

--- a/workflows/harvest-practices.md
+++ b/workflows/harvest-practices.md
@@ -12,17 +12,26 @@ The current project is usually the evidence source, not the canonical destinatio
 
 Use this order:
 
-1. `AGENT_FOUNDRY_HOME`, if set.
-2. `~/.agent-foundry/config.yaml`, using `vault_root` and `core_root`.
-3. The current directory, only if it contains canonical markers.
-4. Known fallback paths.
-5. Ask the user for the Agent Foundry path.
+1. Explicit `--core-root` and `--vault-root` flags, when the command supports them.
+2. Paired `AGENT_FOUNDRY_CORE` and `AGENT_FOUNDRY_VAULT` environment variables, after commands implement them.
+3. `~/.agent-foundry/config.yaml`, using `core_root`, `vault_root`, `core_markers`, and `vault_markers`.
+4. `AGENT_FOUNDRY_HOME`, if set, as a same-root compatibility locator.
+5. The current directory, only if it validates as the required Core and Vault context for the requested operation.
+6. Known fallback paths.
+7. Ask the user for the Agent Foundry path.
 
-Validate the location before proceeding. Required markers:
+Validate the location before proceeding. Required Core markers:
+
+- `workflows/harvest-practices.md`
+- `schemas/practice-entry.schema.yaml`
+
+Required Vault markers:
 
 - `indexes/practice_index.yaml`
 - `indexes/asset_index.yaml`
-- `workflows/harvest-practices.md`
+- `usage/usage-aggregate.yaml`
+
+During AF-3 compatibility mode, Core and Vault may share one root. After the physical split, do not validate a Vault by requiring Core-owned workflow files under `workflows/`.
 
 If the Vault is locked, dirty in a conflicting way, or unavailable, produce candidate recommendations only and do not write files.
 


### PR DESCRIPTION
## Summary

- Split the locator contract into `core_markers` and `vault_markers` while keeping same-root compatibility.
- Add `--core-root` and `--vault-root` support to `scripts/foundry_config.py write`.
- Keep deprecated `canonical_markers` readable for old local configs.
- Update harvest workflow, system design, lifecycle docs, and published adapters so Vault validation no longer requires Core-owned `workflows/` files.
- Document locator precedence, including explicit roots, future paired env vars, config, `AGENT_FOUNDRY_HOME` compatibility, current-directory validation, and ask-the-user fallback.

## Verification

- `python3 scripts/foundry_config.py write --path /tmp/af-same-root.yaml`
- `python3 scripts/foundry_config.py status --path /tmp/af-same-root.yaml`
- `python3 scripts/foundry_config.py write --path /tmp/af-split-root.yaml --core-root "$PWD" --vault-root /tmp/af-vault-test`
- `python3 scripts/foundry_config.py status --path /tmp/af-split-root.yaml`
- missing `vault_root` status test reports `missing vault_root`
- `python3 scripts/check_consistency.py`
- `python3 scripts/check_adapter_quality.py`
- `python3 scripts/check_activation.py`
- `git diff --check`
- `python3 scripts/install_foundry.py`

Closes #28.
