### PR TITLE
Add blank Vault init and selected adapter publish

### DIFF
--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -174,7 +174,7 @@ AF-2 follow-up implications:
 
 ## Blank Vault Initialization
 
-Blank Vault initialization is the AF-2 design for creating a new User Vault without inheriting the maintainer's personal records. It is not implemented yet. Current single-repo operation remains the only implemented mode until AF-3 updates locators, scripts, checks, and runtime publishing for separate `core_root` and `vault_root` paths.
+Blank Vault initialization is the AF-2 design for creating a new User Vault without inheriting the maintainer's personal records. AF-3 now provides a local initializer and validation path through `scripts/init_vault.py`, `scripts/check_foundry_roots.py`, and `scripts/test_foundry_roots.py`. Current single-repo operation remains supported for compatibility while AF-3 continues updating publish, install, and migration flows for separate `core_root` and `vault_root` paths.
 
 Design goal:
 
@@ -224,7 +224,16 @@ Validation expectations for a blank Vault:
 7. Consistency checks distinguish "empty but valid Vault" from "missing or corrupt Vault."
 8. Pack deployment can add canonical data after initialization without changing the definition of blank Vault.
 
-Implementation implications for AF-3:
+Implemented AF-3 baseline:
+
+- `scripts/init_vault.py` creates empty `practices/`, `assets/`, `imports/inbox`, `usage/local`, empty practice and asset indexes, and an empty shared usage aggregate;
+- blank Vault initialization does not copy maintainer practices/assets;
+- blank Vault initialization does not trigger runtime install;
+- `scripts/publish_adapters.py` validates selected Core/Vault roots before publishing;
+- blank Vault adapter publishing reports `nothing to publish`;
+- maintainer-like Vault adapter publishing can produce deterministic adapter outputs in a selected output root.
+
+Implementation implications still remaining for AF-3:
 
 - scripts that currently assume repository-relative `practices/`, `assets/`, `indexes/`, and `usage/` must accept a separate `vault_root`;
 - checks should validate Core schemas/workflows against an arbitrary Vault;

--- a/scripts/init_vault.py
+++ b/scripts/init_vault.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Initialize a blank Agent Foundry Vault."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+from pathlib import Path
+
+from check_foundry_roots import validate
+from foundry_config import ROOT
+
+
+def write(path: Path, text: str, apply: bool) -> None:
+    print(f"{'write' if apply else 'would write'}: {path}")
+    if apply:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+
+def ensure_dir(path: Path, apply: bool) -> None:
+    print(f"{'mkdir' if apply else 'would mkdir'}: {path}")
+    if apply:
+        path.mkdir(parents=True, exist_ok=True)
+
+
+def fail_if_existing_vault(vault_root: Path, force: bool) -> None:
+    markers = [
+        vault_root / "indexes" / "practice_index.yaml",
+        vault_root / "indexes" / "asset_index.yaml",
+        vault_root / "usage" / "usage-aggregate.yaml",
+    ]
+    existing = [path for path in markers if path.exists()]
+    if existing and not force:
+        rels = "\n".join(f"- {path}" for path in existing)
+        raise SystemExit(
+            "Refusing to overwrite existing Vault marker files. "
+            "Use --force only after backing up the target.\n"
+            f"{rels}"
+        )
+
+
+def practice_index_text(today: str) -> str:
+    return "\n".join(
+        [
+            "schema_version: 1",
+            f"updated: {today}",
+            "",
+            "domains: {}",
+            "",
+            "practices: []",
+            "",
+        ]
+    )
+
+
+def asset_index_text(today: str) -> str:
+    return "\n".join(
+        [
+            "schema_version: 1",
+            f"updated: {today}",
+            "",
+            "asset_types: {}",
+            "",
+            "assets: []",
+            "",
+        ]
+    )
+
+
+def usage_aggregate_text(today: str) -> str:
+    return "\n".join(
+        [
+            "schema_version: 1",
+            f"updated: {today}",
+            "",
+            "aggregates: []",
+            "",
+        ]
+    )
+
+
+def initialize(vault_root: Path, apply: bool, force: bool) -> None:
+    vault_root = vault_root.expanduser().resolve()
+    fail_if_existing_vault(vault_root, force)
+    today = date.today().isoformat()
+    for rel in [
+        "practices",
+        "assets",
+        "imports/inbox",
+        "usage/local",
+    ]:
+        ensure_dir(vault_root / rel, apply)
+    write(vault_root / "indexes" / "practice_index.yaml", practice_index_text(today), apply)
+    write(vault_root / "indexes" / "asset_index.yaml", asset_index_text(today), apply)
+    write(vault_root / "usage" / "usage-aggregate.yaml", usage_aggregate_text(today), apply)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Initialize a blank Agent Foundry Vault.")
+    parser.add_argument("vault_root", help="Directory to initialize as a blank Vault.")
+    parser.add_argument("--core-root", default=str(ROOT), help="Core root used for post-init validation.")
+    parser.add_argument("--apply", action="store_true", help="Write files. Default is dry-run.")
+    parser.add_argument("--force", action="store_true", help="Overwrite existing Vault marker files.")
+    args = parser.parse_args()
+
+    vault_root = Path(args.vault_root).expanduser().resolve()
+    core_root = Path(args.core_root).expanduser().resolve()
+    initialize(vault_root, args.apply, args.force)
+
+    if args.apply:
+        errors = validate(core_root, vault_root)
+        if errors:
+            print("Blank Vault initialized but validation failed:")
+            for error in errors:
+                print(f"- {error}")
+            return 1
+        print("Blank Vault initialized and validated.")
+    else:
+        print("Dry-run only. Re-run with --apply to create the blank Vault.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/publish_adapters.py
+++ b/scripts/publish_adapters.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Publish adapter outputs from a selected Agent Foundry Vault."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from datetime import date
+from pathlib import Path
+
+from check_foundry_roots import validate
+from foundry_config import ROOT
+
+
+ACTIVE_STATUSES = {"active", "revised"}
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def simple_yaml_entries(index_text: str, list_key: str) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    in_list = False
+    for line in index_text.splitlines():
+        if line.startswith(f"{list_key}:"):
+            rest = line.split(":", 1)[1].strip()
+            if rest == "[]":
+                return []
+            in_list = True
+            continue
+        if in_list and line and not line.startswith(" "):
+            in_list = False
+        if not in_list:
+            continue
+        if line.startswith("  - id: "):
+            if current:
+                entries.append(current)
+            current = {"id": line.split(":", 1)[1].strip().strip('"')}
+        elif current is not None and line.startswith("    ") and ":" in line:
+            key, value = line.strip().split(":", 1)
+            current[key] = value.strip().strip('"')
+    if current:
+        entries.append(current)
+    return entries
+
+
+def active_entries(vault_root: Path, index_rel: str, list_key: str) -> list[dict[str, str]]:
+    entries = simple_yaml_entries(read(vault_root / index_rel), list_key)
+    return [entry for entry in entries if entry.get("status") in ACTIVE_STATUSES]
+
+
+def copytree_contents(src: Path, dest: Path, apply: bool) -> list[Path]:
+    copied: list[Path] = []
+    for path in sorted(src.rglob("*")):
+        if path.is_dir():
+            continue
+        rel = path.relative_to(src)
+        if rel.as_posix() == "adapter-publish-manifest.yaml":
+            continue
+        target = dest / rel
+        copied.append(target)
+        print(f"{'copy' if apply else 'would copy'}: {src.name}/{rel} -> {target}")
+        if apply:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(path, target)
+    return copied
+
+
+def manifest_text(active_practices: list[dict[str, str]], active_assets: list[dict[str, str]]) -> str:
+    lines = [
+        "schema_version: 1",
+        f"updated: {date.today().isoformat()}",
+        "source: selected_vault",
+        "private_paths_recorded: false",
+        "",
+    ]
+    if active_practices:
+        lines.append("active_practices:")
+        for entry in active_practices:
+            lines.append(f"  - {entry['id']}")
+    else:
+        lines.append("active_practices: []")
+    lines.append("")
+    if active_assets:
+        lines.append("active_assets:")
+        for entry in active_assets:
+            lines.append(f"  - {entry['id']}")
+    else:
+        lines.append("active_assets: []")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_manifest(output_root: Path, text: str, apply: bool) -> None:
+    path = output_root / "adapter-publish-manifest.yaml"
+    print(f"{'write' if apply else 'would write'}: {path}")
+    if apply:
+        output_root.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+
+def publish(core_root: Path, vault_root: Path, output_root: Path, apply: bool) -> int:
+    errors = validate(core_root, vault_root)
+    if errors:
+        print("Adapter publish failed root validation:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    active_practices = active_entries(vault_root, "indexes/practice_index.yaml", "practices")
+    active_assets = active_entries(vault_root, "indexes/asset_index.yaml", "assets")
+    if not active_practices and not active_assets:
+        print("Selected Vault has no active or revised practices/assets. Nothing to publish.")
+        write_manifest(output_root, manifest_text(active_practices, active_assets), apply)
+        return 0
+
+    source_adapters = core_root / "adapters"
+    if not source_adapters.exists():
+        print(f"Core adapter template root missing: {source_adapters}")
+        return 1
+
+    if source_adapters.resolve() == output_root.resolve():
+        print("Output root is the Core adapter template root; retaining existing adapter files.")
+        copied: list[Path] = []
+    else:
+        copied = copytree_contents(source_adapters, output_root, apply)
+    write_manifest(output_root, manifest_text(active_practices, active_assets), apply)
+    print(f"Adapter publish {'wrote' if apply else 'planned'} {len(copied)} files.")
+    print(f"Active practices selected: {len(active_practices)}")
+    print(f"Active assets selected: {len(active_assets)}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Publish adapters from a selected Agent Foundry Vault.")
+    parser.add_argument("--core-root", default=str(ROOT), help="Agent Foundry Core root.")
+    parser.add_argument("--vault-root", default=str(ROOT), help="Selected Agent Foundry Vault root.")
+    parser.add_argument("--output-root", default="", help="Adapter output directory. Defaults to <core-root>/adapters.")
+    parser.add_argument("--apply", action="store_true", help="Write files. Default is dry-run.")
+    args = parser.parse_args()
+
+    core_root = Path(args.core_root).expanduser().resolve()
+    vault_root = Path(args.vault_root).expanduser().resolve()
+    output_root = Path(args.output_root).expanduser().resolve() if args.output_root else core_root / "adapters"
+    return publish(core_root, vault_root, output_root, args.apply)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/publish_adapters.py
+++ b/scripts/publish_adapters.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import shutil
 from datetime import date
 from pathlib import Path
 
@@ -51,21 +50,58 @@ def active_entries(vault_root: Path, index_rel: str, list_key: str) -> list[dict
     return [entry for entry in entries if entry.get("status") in ACTIVE_STATUSES]
 
 
-def copytree_contents(src: Path, dest: Path, apply: bool) -> list[Path]:
-    copied: list[Path] = []
-    for path in sorted(src.rglob("*")):
-        if path.is_dir():
+def inline_list(value: str) -> list[str]:
+    value = value.strip()
+    if not (value.startswith("[") and value.endswith("]")):
+        return []
+    return [item.strip().strip('"').strip("'") for item in value[1:-1].split(",") if item.strip()]
+
+
+def parse_profiles(core_root: Path) -> dict[str, dict[str, object]]:
+    profiles: dict[str, dict[str, object]] = {}
+    current: str | None = None
+    section: str | None = None
+    in_adapters = False
+    profile_text = read(core_root / "adapters" / "adapter_profiles.yaml")
+
+    for raw in profile_text.splitlines():
+        line = raw.rstrip()
+        if line == "adapters:":
+            in_adapters = True
             continue
-        rel = path.relative_to(src)
-        if rel.as_posix() == "adapter-publish-manifest.yaml":
+        if not in_adapters:
             continue
-        target = dest / rel
-        copied.append(target)
-        print(f"{'copy' if apply else 'would copy'}: {src.name}/{rel} -> {target}")
-        if apply:
-            target.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(path, target)
-    return copied
+        if line.startswith("  ") and not line.startswith("    ") and line.endswith(":"):
+            current = line.strip().removesuffix(":")
+            profiles[current] = {
+                "target": current,
+                "direct_programming_agent": False,
+                "outputs": [],
+                "included_domains": [],
+                "command_phrases": [],
+            }
+            section = None
+            continue
+        if current is None:
+            continue
+        stripped = line.strip()
+        if stripped.startswith("target:"):
+            profiles[current]["target"] = stripped.split(":", 1)[1].strip().strip('"')
+        elif stripped.startswith("direct_programming_agent:"):
+            profiles[current]["direct_programming_agent"] = stripped.endswith("true")
+        elif stripped.startswith("included_domains:"):
+            profiles[current]["included_domains"] = inline_list(stripped.split(":", 1)[1])
+        elif stripped == "outputs:":
+            section = "outputs"
+        elif stripped == "command_vocabulary:":
+            section = "command_vocabulary"
+        elif stripped.startswith("transform_policy:") or stripped.startswith("supports:"):
+            section = None
+        elif section == "outputs" and stripped.startswith("- "):
+            profiles[current]["outputs"].append(stripped[2:].strip().strip('"'))
+        elif section == "command_vocabulary" and ":" in stripped:
+            profiles[current]["command_phrases"].extend(inline_list(stripped.split(":", 1)[1]))
+    return profiles
 
 
 def manifest_text(active_practices: list[dict[str, str]], active_assets: list[dict[str, str]]) -> str:
@@ -101,6 +137,73 @@ def write_manifest(output_root: Path, text: str, apply: bool) -> None:
         path.write_text(text, encoding="utf-8")
 
 
+def adapter_body(
+    adapter_id: str,
+    profile: dict[str, object],
+    active_practices: list[dict[str, str]],
+    active_assets: list[dict[str, str]],
+) -> str:
+    practice_ids = [entry["id"] for entry in active_practices]
+    asset_ids = [entry["id"] for entry in active_assets]
+    phrases = [phrase.split("<", 1)[0].strip() for phrase in profile.get("command_phrases", []) if phrase]
+    lines = [
+        f"# Agent Foundry Adapter: {adapter_id}",
+        "",
+        f"Target: {profile.get('target', adapter_id)}",
+        "Generated from the selected Agent Foundry Vault.",
+        "",
+        "This AF-3 transitional output intentionally includes only selected active/revised canonical IDs,",
+        "adapter command vocabulary, and audit metadata. It does not copy maintainer adapter content,",
+        "private paths, raw usage evidence, or future memory-system paths.",
+        "",
+        "## Active Practices",
+    ]
+    lines.extend(f"- {pid}" for pid in practice_ids)
+    lines.extend(["", "## Active Assets"])
+    lines.extend(f"- {aid}" for aid in asset_ids)
+    lines.extend(["", "## Command Vocabulary"])
+    lines.extend(f"- {phrase}" for phrase in phrases if phrase)
+    lines.extend(["", "## Boundary"])
+    lines.append("Full semantic regeneration from canonical sections is future generator work.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def output_file(output_root: Path, output: str) -> Path:
+    rel = Path(output)
+    if rel.parts and rel.parts[0] == "adapters":
+        rel = Path(*rel.parts[1:])
+    if output.endswith("/") or rel.suffix == "":
+        return output_root / rel / "README.md"
+    return output_root / rel
+
+
+def write_adapter_outputs(
+    core_root: Path,
+    output_root: Path,
+    active_practices: list[dict[str, str]],
+    active_assets: list[dict[str, str]],
+    apply: bool,
+) -> list[Path]:
+    profiles = parse_profiles(core_root)
+    written: list[Path] = []
+    for adapter_id, profile in profiles.items():
+        if not profile.get("direct_programming_agent"):
+            continue
+        outputs = list(profile.get("outputs", []))
+        if not outputs:
+            continue
+        text = adapter_body(adapter_id, profile, active_practices, active_assets)
+        for output in outputs:
+            target = output_file(output_root, str(output))
+            written.append(target)
+            print(f"{'write' if apply else 'would write'}: {target}")
+            if apply:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(text, encoding="utf-8")
+    return written
+
+
 def publish(core_root: Path, vault_root: Path, output_root: Path, apply: bool) -> int:
     errors = validate(core_root, vault_root)
     if errors:
@@ -116,18 +219,17 @@ def publish(core_root: Path, vault_root: Path, output_root: Path, apply: bool) -
         write_manifest(output_root, manifest_text(active_practices, active_assets), apply)
         return 0
 
-    source_adapters = core_root / "adapters"
-    if not source_adapters.exists():
-        print(f"Core adapter template root missing: {source_adapters}")
+    if not (core_root / "adapters" / "adapter_profiles.yaml").exists():
+        print(f"Core adapter profile missing: {core_root / 'adapters' / 'adapter_profiles.yaml'}")
         return 1
 
-    if source_adapters.resolve() == output_root.resolve():
-        print("Output root is the Core adapter template root; retaining existing adapter files.")
-        copied: list[Path] = []
-    else:
-        copied = copytree_contents(source_adapters, output_root, apply)
+    if (core_root / "adapters").resolve() == output_root.resolve() and apply:
+        print("Refusing to overwrite Core adapter templates in place. Pass --output-root for generated outputs.")
+        return 1
+
+    written = write_adapter_outputs(core_root, output_root, active_practices, active_assets, apply)
     write_manifest(output_root, manifest_text(active_practices, active_assets), apply)
-    print(f"Adapter publish {'wrote' if apply else 'planned'} {len(copied)} files.")
+    print(f"Adapter publish {'wrote' if apply else 'planned'} {len(written)} files.")
     print(f"Active practices selected: {len(active_practices)}")
     print(f"Active assets selected: {len(active_assets)}")
     return 0

--- a/scripts/test_foundry_roots.py
+++ b/scripts/test_foundry_roots.py
@@ -81,6 +81,56 @@ def make_maintainer_like_vault(path: Path) -> None:
             shutil.copytree(source, target)
 
 
+def make_custom_vault(path: Path) -> None:
+    make_blank_vault(path)
+    write(
+        path / "practices" / "custom" / "CUST-001-custom-practice.md",
+        "\n".join(
+            [
+                "---",
+                "id: CUST-001",
+                "title: Custom practice",
+                "domain: meta",
+                "type: principle",
+                "status: active",
+                "version: 1",
+                "created: 2026-06-09",
+                "updated: 2026-06-09",
+                "tags: [custom]",
+                "aliases: [CUST-001]",
+                "---",
+                "",
+                "## Principle",
+                "",
+                "Use only the selected Vault records.",
+                "",
+            ]
+        ),
+    )
+    write(
+        path / "indexes" / "practice_index.yaml",
+        "\n".join(
+            [
+                "schema_version: 1",
+                "updated: 2026-06-09",
+                "",
+                "domains:",
+                "  meta:",
+                "    description: Custom test domain.",
+                "",
+                "practices:",
+                "  - id: CUST-001",
+                "    title: Custom practice",
+                "    path: practices/custom/CUST-001-custom-practice.md",
+                "    domain: meta",
+                "    type: principle",
+                "    status: active",
+                "",
+            ]
+        ),
+    )
+
+
 def expect(name: str, result: subprocess.CompletedProcess[str], should_pass: bool, expected_text: str = "") -> list[str]:
     passed = result.returncode == 0
     if passed == should_pass and (not expected_text or expected_text in (result.stdout + result.stderr)):
@@ -126,6 +176,17 @@ def main() -> int:
         errors.extend(expect("maintainer-like-publish", maintainer_publish, True, "Adapter publish wrote"))
         if not (base / "maintainer-adapters" / "adapter-publish-manifest.yaml").exists():
             errors.append("maintainer-like-publish: manifest was not written")
+
+        custom = base / "custom-vault"
+        custom_output = base / "custom-adapters"
+        make_custom_vault(custom)
+        custom_publish = run_publish(ROOT, custom, custom_output)
+        errors.extend(expect("custom-vault-publish", custom_publish, True, "Adapter publish wrote"))
+        output_text = "\n".join(path.read_text(encoding="utf-8") for path in custom_output.rglob("*") if path.is_file())
+        if "CUST-001" not in output_text:
+            errors.append("custom-vault-publish: selected custom practice ID missing from output")
+        if "META-001" in output_text:
+            errors.append("custom-vault-publish: maintainer practice ID leaked into output")
 
     if errors:
         print("Split-root fixture tests failed:")

--- a/scripts/test_foundry_roots.py
+++ b/scripts/test_foundry_roots.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 CHECK = ROOT / "scripts" / "check_foundry_roots.py"
+INIT = ROOT / "scripts" / "init_vault.py"
+PUBLISH = ROOT / "scripts" / "publish_adapters.py"
 
 
 def write(path: Path, text: str) -> None:
@@ -37,18 +39,38 @@ def run_check(core_root: Path, vault_root: Path) -> subprocess.CompletedProcess[
     )
 
 
+def run_publish(core_root: Path, vault_root: Path, output_root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(PUBLISH),
+            "--core-root",
+            str(core_root),
+            "--vault-root",
+            str(vault_root),
+            "--output-root",
+            str(output_root),
+            "--apply",
+        ],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
 def make_blank_vault(path: Path) -> None:
-    write(
-        path / "indexes" / "practice_index.yaml",
-        "schema_version: 1\nupdated: 2026-06-09\n\ndomains: {}\n\npractices: []\n",
+    result = subprocess.run(
+        [sys.executable, str(INIT), str(path), "--core-root", str(ROOT), "--apply"],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
-    write(
-        path / "indexes" / "asset_index.yaml",
-        "schema_version: 1\nupdated: 2026-06-09\n\nasset_types: {}\n\nassets: []\n",
-    )
-    write(path / "usage" / "usage-aggregate.yaml", "schema_version: 1\nupdated: 2026-06-09\n\naggregates: []\n")
-    (path / "practices").mkdir(parents=True, exist_ok=True)
-    (path / "assets").mkdir(parents=True, exist_ok=True)
+    if result.returncode != 0:
+        raise RuntimeError(result.stdout + result.stderr)
 
 
 def make_maintainer_like_vault(path: Path) -> None:
@@ -96,6 +118,14 @@ def main() -> int:
         make_blank_vault(corrupt)
         write(corrupt / "indexes" / "practice_index.yaml", "schema_version: 1\nupdated: 2026-06-09\n")
         errors.extend(expect("corrupt-vault", run_check(ROOT, corrupt), False, "index missing required list: practices"))
+
+        blank_publish = run_publish(ROOT, blank, base / "blank-adapters")
+        errors.extend(expect("blank-publish", blank_publish, True, "Nothing to publish"))
+
+        maintainer_publish = run_publish(ROOT, maintainer_like, base / "maintainer-adapters")
+        errors.extend(expect("maintainer-like-publish", maintainer_publish, True, "Adapter publish wrote"))
+        if not (base / "maintainer-adapters" / "adapter-publish-manifest.yaml").exists():
+            errors.append("maintainer-like-publish: manifest was not written")
 
     if errors:
         print("Split-root fixture tests failed:")

--- a/workflows/check-consistency.md
+++ b/workflows/check-consistency.md
@@ -36,6 +36,8 @@ This checks:
 - indexed practice and asset paths resolve relative to the selected Vault;
 - blank Vault indexes and empty usage aggregate are valid;
 - missing or corrupt Vault indexes fail with actionable messages.
+- blank Vault publishing reports nothing to publish;
+- maintainer-like Vault publishing can produce adapter outputs in a temporary output root.
 
 To exercise deterministic same-root, blank Vault, maintainer-like Vault, and failure fixtures, run:
 

--- a/workflows/publish-adapters.md
+++ b/workflows/publish-adapters.md
@@ -8,6 +8,20 @@ Adapters are downstream outputs. Direct programming agents should receive full f
 
 Before publishing, read `workflows/transform-canonical-to-adapters.md` and `adapters/adapter_profiles.yaml`.
 
+Current AF-3 capability:
+
+- use `scripts/publish_adapters.py` for selected Core/Vault root validation and deterministic publishing;
+- pass `--core-root` and `--vault-root` when Core and Vault are split;
+- blank Vault publishing is valid and reports `nothing to publish`;
+- nonblank Vault publishing currently uses Core adapter templates plus selected active/revised Vault records as a transitional generator;
+- full semantic regeneration of every adapter file from canonical sections remains future generator work.
+
+Example:
+
+```bash
+python3 scripts/publish_adapters.py --core-root . --vault-root . --output-root /tmp/agent-foundry-adapters --apply
+```
+
 ## 1. Select Practices
 
 Publish only practices with:
@@ -71,6 +85,7 @@ Then run:
 
 ```bash
 python3 scripts/check_consistency.py
+python3 scripts/test_foundry_roots.py
 ```
 
 If unavailable, follow `workflows/check-consistency.md` manually.

--- a/workflows/publish-adapters.md
+++ b/workflows/publish-adapters.md
@@ -13,7 +13,7 @@ Current AF-3 capability:
 - use `scripts/publish_adapters.py` for selected Core/Vault root validation and deterministic publishing;
 - pass `--core-root` and `--vault-root` when Core and Vault are split;
 - blank Vault publishing is valid and reports `nothing to publish`;
-- nonblank Vault publishing currently uses Core adapter templates plus selected active/revised Vault records as a transitional generator;
+- nonblank Vault publishing currently generates minimal transitional adapter files from Core adapter profiles plus selected active/revised Vault records;
 - full semantic regeneration of every adapter file from canonical sections remains future generator work.
 
 Example:


### PR DESCRIPTION
## Summary
- add `scripts/init_vault.py` to create and validate a blank Vault without copying maintainer practices/assets or installing runtimes
- add `scripts/publish_adapters.py` to validate selected Core/Vault roots and deterministically publish adapter outputs from a selected Vault
- extend split-root fixture tests to cover blank Vault publishing and maintainer-like Vault adapter output generation
- document the AF-3 current capability and remaining generator boundary in system design and publish/check workflows

Closes #29.
Closes #30.

## Verification
- `python3 scripts/check_consistency.py`
- `python3 scripts/check_adapter_quality.py`
- `python3 scripts/check_activation.py`
- `python3 scripts/test_foundry_roots.py`
- `git diff --check`
- temp apply: `scripts/init_vault.py` created a blank Vault and `check_foundry_roots.py` validated it
- temp apply: `scripts/publish_adapters.py` wrote adapter outputs and a manifest without private local paths

## Batch Handoff
This is a batch checkpoint for #29 and #30. It intentionally avoids a per-issue stop between blank Vault initialization and selected-Vault adapter publishing.

## Residual Risk
- Adapter publishing is a transitional generator: nonblank Vault publishing uses Core adapter templates plus selected active/revised Vault records. Full semantic regeneration of every adapter file from canonical sections remains future generator work.
