### PR TITLE
Split adapter quality validation surfaces

### DIFF
--- a/scripts/check_adapter_quality.py
+++ b/scripts/check_adapter_quality.py
@@ -1,22 +1,20 @@
 #!/usr/bin/env python3
 """Adapter quality checks for Agent Foundry.
 
-This script is intentionally dependency-free. It checks adapter profiles against
-generated adapter outputs and verifies that key triggers, canonical IDs, and
-asset IDs are visible for audit.
+This script is intentionally dependency-free. It separates Core high-fidelity
+adapter validation from selected-Vault generated output validation.
 """
 
 from __future__ import annotations
 
+import argparse
 import re
-import sys
 from pathlib import Path
 
 from foundry_config import CONFIG_PATH, parse_config
 
 
-ROOT = Path(__file__).resolve().parents[1]
-PROFILE = ROOT / "adapters" / "adapter_profiles.yaml"
+DEFAULT_ROOT = Path(__file__).resolve().parents[1]
 ACTIVE_STATUSES = {"active", "revised"}
 
 
@@ -25,10 +23,7 @@ def configured_vault_root() -> Path:
     vault_root = data.get("vault_root", "")
     if isinstance(vault_root, str) and vault_root:
         return Path(vault_root).expanduser().resolve()
-    return ROOT
-
-
-VAULT_ROOT = configured_vault_root()
+    return DEFAULT_ROOT
 
 
 def read(path: Path) -> str:
@@ -42,14 +37,15 @@ def inline_list(value: str) -> list[str]:
     return [item.strip().strip('"').strip("'") for item in value[1:-1].split(",") if item.strip()]
 
 
-def parse_profiles() -> dict[str, dict[str, object]]:
+def parse_profiles(core_root: Path) -> dict[str, dict[str, object]]:
     profiles: dict[str, dict[str, object]] = {}
     current: str | None = None
     section: str | None = None
     current_vocab: str | None = None
     in_adapters = False
 
-    for raw in read(PROFILE).splitlines():
+    profile = core_root / "adapters" / "adapter_profiles.yaml"
+    for raw in read(profile).splitlines():
         line = raw.rstrip()
         if line == "adapters:":
             in_adapters = True
@@ -105,10 +101,10 @@ def parse_index_entries(path: Path) -> list[dict[str, str]]:
     return entries
 
 
-def adapter_files(outputs: list[str]) -> list[Path]:
+def core_adapter_files(core_root: Path, outputs: list[str]) -> list[Path]:
     files: list[Path] = []
     for output in outputs:
-        path = ROOT / output
+        path = core_root / output
         if path.is_file():
             files.append(path)
         elif path.is_dir():
@@ -116,9 +112,22 @@ def adapter_files(outputs: list[str]) -> list[Path]:
     return files
 
 
-def output_text(outputs: list[str]) -> str:
+def output_file(output_root: Path, output: str) -> Path:
+    rel = Path(output)
+    if rel.parts and rel.parts[0] == "adapters":
+        rel = Path(*rel.parts[1:])
+    if output.endswith("/") or rel.suffix == "":
+        return output_root / rel / "README.md"
+    return output_root / rel
+
+
+def selected_output_files(output_root: Path, outputs: list[str]) -> list[Path]:
+    return [path for path in (output_file(output_root, output) for output in outputs) if path.is_file()]
+
+
+def output_text(files: list[Path]) -> str:
     chunks: list[str] = []
-    for path in adapter_files(outputs):
+    for path in files:
         if path.name == ".agent-foundry-managed":
             continue
         chunks.append(read(path))
@@ -142,70 +151,164 @@ def id_visible(identifier: str, text: str) -> bool:
     return False
 
 
-def active_practices_by_domain() -> dict[str, list[str]]:
+def active_practices_by_domain(vault_root: Path) -> dict[str, list[str]]:
     by_domain: dict[str, list[str]] = {}
-    for entry in parse_index_entries(VAULT_ROOT / "indexes" / "practice_index.yaml"):
+    for entry in parse_index_entries(vault_root / "indexes" / "practice_index.yaml"):
         if entry.get("status") not in ACTIVE_STATUSES:
             continue
         by_domain.setdefault(entry.get("domain", ""), []).append(entry["id"])
     return by_domain
 
 
-def active_assets_by_adapter() -> dict[str, list[str]]:
-    by_adapter: dict[str, list[str]] = {}
-    for entry in parse_index_entries(VAULT_ROOT / "indexes" / "asset_index.yaml"):
+def active_ids(vault_root: Path, index_rel: str) -> list[str]:
+    ids: list[str] = []
+    for entry in parse_index_entries(vault_root / index_rel):
         if entry.get("status") not in ACTIVE_STATUSES:
             continue
-        published = inline_list(entry.get("published_to", ""))
-        for adapter in published:
-            by_adapter.setdefault(adapter, []).append(entry["id"])
-    return by_adapter
+        ids.append(entry["id"])
+    return ids
 
 
-def main() -> int:
+def manifest_ids(manifest: Path, key: str) -> list[str]:
+    ids: list[str] = []
+    in_list = False
+    for raw in read(manifest).splitlines():
+        line = raw.rstrip()
+        if line.startswith(f"{key}:"):
+            in_list = True
+            if line.split(":", 1)[1].strip() == "[]":
+                return []
+            continue
+        if in_list and line and not line.startswith(" "):
+            break
+        if in_list and line.strip().startswith("- "):
+            ids.append(line.strip()[2:].strip().strip('"').strip("'"))
+    return ids
+
+
+def check_core_surface(core_root: Path, vault_root: Path) -> list[str]:
     errors: list[str] = []
-    profiles = parse_profiles()
-    practices_by_domain = active_practices_by_domain()
-    assets_by_adapter = active_assets_by_adapter()
+    profiles = parse_profiles(core_root)
+    split_mode = core_root.resolve() != vault_root.resolve()
+    practices_by_domain = {} if split_mode else active_practices_by_domain(vault_root)
 
     for name, profile in profiles.items():
         if name == "deepseek":
             continue
         outputs = list(profile["outputs"])
         for output in outputs:
-            if not (ROOT / output).exists():
-                errors.append(f"{name}: profile output missing: {output}")
+            if not (core_root / output).exists():
+                errors.append(f"Core template quality: {name} profile output missing: {output}")
 
-        text = output_text(outputs)
+        text = output_text(core_adapter_files(core_root, outputs))
         if profile.get("direct_programming_agent") and not text.strip():
-            errors.append(f"{name}: direct programming adapter has no output text")
+            errors.append(f"Core template quality: {name} direct programming adapter has no output text")
 
         for phrase in profile.get("command_phrases", []):
             if "<" in phrase:
                 phrase = phrase.split("<", 1)[0].strip()
             if phrase and phrase not in text:
-                errors.append(f"{name}: command phrase missing from outputs: {phrase}")
+                errors.append(f"Core template quality: {name} command phrase missing from outputs: {phrase}")
 
         for domain in profile.get("included_domains", []):
             for pid in practices_by_domain.get(domain, []):
                 if not id_visible(pid, text):
-                    errors.append(f"{name}: included active practice not visible in adapter outputs: {pid}")
-
-        for aid in assets_by_adapter.get(name, []):
-            if aid not in text:
-                errors.append(f"{name}: published active asset ID not visible in adapter outputs: {aid}")
+                    errors.append(f"Core template quality: {name} included active practice not visible: {pid}")
 
         if name == "chatgpt" and "knowledge/" not in "\n".join(outputs):
-            errors.append("chatgpt: full fidelity adapter should include knowledge files")
+            errors.append("Core template quality: chatgpt full fidelity adapter should include knowledge files")
         if name == "hermes" and "Do not disable Hermes native memory" not in text:
-            errors.append("hermes: native memory/self-growth guardrail missing")
+            errors.append("Core template quality: hermes native memory/self-growth guardrail missing")
+    return errors
+
+
+def check_selected_output_surface(core_root: Path, vault_root: Path, generated_root: Path | None) -> list[str]:
+    errors: list[str] = []
+    if generated_root is None:
+        return [
+            "Missing publish step: selected generated output validation requires --generated-root from "
+            "publish_adapters.py --output-root <dir> --apply"
+        ]
+    if generated_root.resolve() == (core_root / "adapters").resolve():
+        return [
+            "Unsafe Core overwrite attempt: selected generated output root is Core adapters/. "
+            "Publish to a separate --output-root instead."
+        ]
+
+    manifest = generated_root / "adapter-publish-manifest.yaml"
+    if not manifest.exists():
+        return [
+            f"Missing publish step: selected generated output manifest not found: {manifest}. "
+            "Run publish_adapters.py --output-root <dir> --apply before selected-output validation."
+        ]
+
+    expected_practices = active_ids(vault_root, "indexes/practice_index.yaml")
+    expected_assets = active_ids(vault_root, "indexes/asset_index.yaml")
+    manifest_practices = manifest_ids(manifest, "active_practices")
+    manifest_assets = manifest_ids(manifest, "active_assets")
+    for pid in expected_practices:
+        if pid not in manifest_practices:
+            errors.append(f"Selected output coverage: active practice missing from publish manifest: {pid}")
+    for aid in expected_assets:
+        if aid not in manifest_assets:
+            errors.append(f"Selected output coverage: active asset missing from publish manifest: {aid}")
+    for pid in manifest_practices:
+        if pid not in expected_practices:
+            errors.append(f"Selected output coverage: manifest contains non-active or unknown practice: {pid}")
+    for aid in manifest_assets:
+        if aid not in expected_assets:
+            errors.append(f"Selected output coverage: manifest contains non-active or unknown asset: {aid}")
+
+    profiles = parse_profiles(core_root)
+    expected_ids = expected_practices + expected_assets
+    for name, profile in profiles.items():
+        if name == "deepseek" or not profile.get("direct_programming_agent"):
+            continue
+        outputs = list(profile["outputs"])
+        files = selected_output_files(generated_root, outputs)
+        if not files:
+            errors.append(f"Selected output coverage: {name} generated output missing under {generated_root}")
+            continue
+        text = output_text(files)
+        for identifier in expected_ids:
+            if identifier not in text:
+                errors.append(f"Selected output coverage: {name} generated output missing active ID: {identifier}")
+        for phrase in profile.get("command_phrases", []):
+            if "<" in phrase:
+                phrase = phrase.split("<", 1)[0].strip()
+            if phrase and phrase not in text:
+                errors.append(f"Selected output coverage: {name} generated output missing command phrase: {phrase}")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check Agent Foundry adapter quality surfaces.")
+    parser.add_argument("--core-root", default=str(DEFAULT_ROOT), help="Agent Foundry Core root.")
+    parser.add_argument("--vault-root", default="", help="Selected Vault root. Defaults to configured vault_root.")
+    parser.add_argument(
+        "--surface",
+        choices=["core", "selected-output"],
+        default="core",
+        help="Validation surface: Core high-fidelity templates or selected generated output.",
+    )
+    parser.add_argument("--generated-root", default="", help="Generated adapter output root for selected-output surface.")
+    args = parser.parse_args()
+
+    core_root = Path(args.core_root).expanduser().resolve()
+    vault_root = Path(args.vault_root).expanduser().resolve() if args.vault_root else configured_vault_root()
+    generated_root = Path(args.generated_root).expanduser().resolve() if args.generated_root else None
+
+    if args.surface == "core":
+        errors = check_core_surface(core_root, vault_root)
+    else:
+        errors = check_selected_output_surface(core_root, vault_root, generated_root)
 
     if errors:
-        print("Adapter quality check failed:")
+        print(f"Adapter quality check failed for {args.surface} surface:")
         for error in errors:
             print(f"- {error}")
         return 1
-    print("Adapter quality check passed.")
+    print(f"Adapter quality check passed for {args.surface} surface.")
     return 0
 
 

--- a/scripts/test_adapter_quality_split.py
+++ b/scripts/test_adapter_quality_split.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Regression fixture for split Core/Vault adapter quality checks."""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from foundry_config import CONFIG_PATH, parse_config
+
+
+ROOT = Path(__file__).resolve().parents[1]
+QUALITY = ROOT / "scripts" / "check_adapter_quality.py"
+PUBLISH = ROOT / "scripts" / "publish_adapters.py"
+
+
+def configured_vault_root() -> Path:
+    data = parse_config(CONFIG_PATH)
+    vault_root = data.get("vault_root", "")
+    if isinstance(vault_root, str) and vault_root:
+        return Path(vault_root).expanduser().resolve()
+    raise RuntimeError("configured vault_root missing")
+
+
+def digest_tree(path: Path) -> dict[str, str]:
+    digests: dict[str, str] = {}
+    for file_path in sorted(p for p in path.rglob("*") if p.is_file()):
+        rel = str(file_path.relative_to(path))
+        digests[rel] = hashlib.sha256(file_path.read_bytes()).hexdigest()
+    return digests
+
+
+def run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, *args],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def expect(name: str, result: subprocess.CompletedProcess[str], should_pass: bool, expected_text: str = "") -> list[str]:
+    output = result.stdout + result.stderr
+    if (result.returncode == 0) == should_pass and (not expected_text or expected_text in output):
+        print(f"{name}: ok")
+        return []
+    return [
+        f"{name}: expected {'pass' if should_pass else 'failure'}"
+        + (f" containing {expected_text!r}" if expected_text else "")
+        + f", got exit {result.returncode}\n{output.strip()}"
+    ]
+
+
+def promote_asset_collab_002(vault_root: Path) -> None:
+    index = vault_root / "indexes" / "asset_index.yaml"
+    index_text = index.read_text(encoding="utf-8")
+    index_text = index_text.replace(
+        "  - id: ASSET-COLLAB-002\n"
+        "    title: Role Dispatch and Automation Planner\n"
+        "    path: assets/skills/ASSET-COLLAB-002-role-automation-planner.asset.yaml\n"
+        "    asset_type: skill\n"
+        "    status: proposed\n",
+        "  - id: ASSET-COLLAB-002\n"
+        "    title: Role Dispatch and Automation Planner\n"
+        "    path: assets/skills/ASSET-COLLAB-002-role-automation-planner.asset.yaml\n"
+        "    asset_type: skill\n"
+        "    status: active\n",
+    )
+    index_text = index_text.replace(
+        "    canonical_practices: [META-004, META-005, COLLAB-001, COLLAB-002, COLLAB-003, COLLAB-004, COLLAB-008, COLLAB-009, COLLAB-010, COLLAB-011, COLLAB-012, COLLAB-014, GOV-002, GOV-004, GOV-005, GOV-006, RUNTIME-001, RUNTIME-003]\n"
+        "    published_to: []\n",
+        "    canonical_practices: [META-004, META-005, COLLAB-001, COLLAB-002, COLLAB-003, COLLAB-004, COLLAB-008, COLLAB-009, COLLAB-010, COLLAB-011, COLLAB-012, COLLAB-014, GOV-002, GOV-004, GOV-005, GOV-006, RUNTIME-001, RUNTIME-003]\n"
+        "    published_to: [codex, claude-code, hermes, chatgpt]\n",
+    )
+    index.write_text(index_text, encoding="utf-8")
+
+    asset = vault_root / "assets" / "skills" / "ASSET-COLLAB-002-role-automation-planner.asset.yaml"
+    asset_text = asset.read_text(encoding="utf-8")
+    asset_text = asset_text.replace("status: proposed\n", "status: active\n", 1)
+    asset_text = asset_text.replace("published_to: []\n", "published_to: [codex, claude-code, hermes, chatgpt]\n", 1)
+    asset.write_text(asset_text, encoding="utf-8")
+
+
+def main() -> int:
+    errors: list[str] = []
+    real_vault = configured_vault_root()
+    adapters_before = digest_tree(ROOT / "adapters")
+
+    with tempfile.TemporaryDirectory(prefix="agent-foundry-adapter-quality-") as tmp:
+        base = Path(tmp)
+        temp_vault = base / "vault"
+        generated = base / "generated-adapters"
+        missing_generated = base / "missing-generated"
+        shutil.copytree(real_vault, temp_vault)
+        promote_asset_collab_002(temp_vault)
+
+        core_quality = run(
+            [
+                str(QUALITY),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(temp_vault),
+                "--surface",
+                "core",
+            ]
+        )
+        errors.extend(expect("core-surface-promoted-asset", core_quality, True, "core surface"))
+
+        missing_publish = run(
+            [
+                str(QUALITY),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(temp_vault),
+                "--surface",
+                "selected-output",
+                "--generated-root",
+                str(missing_generated),
+            ]
+        )
+        errors.extend(expect("selected-output-missing-publish", missing_publish, False, "Missing publish step"))
+
+        unsafe_quality = run(
+            [
+                str(QUALITY),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(temp_vault),
+                "--surface",
+                "selected-output",
+                "--generated-root",
+                str(ROOT / "adapters"),
+            ]
+        )
+        errors.extend(expect("selected-output-unsafe-core-root", unsafe_quality, False, "Unsafe Core overwrite attempt"))
+
+        publish = run(
+            [
+                str(PUBLISH),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(temp_vault),
+                "--output-root",
+                str(generated),
+                "--apply",
+            ]
+        )
+        errors.extend(expect("publish-promoted-asset", publish, True, "Adapter publish wrote"))
+
+        selected_quality = run(
+            [
+                str(QUALITY),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(temp_vault),
+                "--surface",
+                "selected-output",
+                "--generated-root",
+                str(generated),
+            ]
+        )
+        errors.extend(expect("selected-output-promoted-asset", selected_quality, True, "selected-output surface"))
+        generated_text = "\n".join(path.read_text(encoding="utf-8") for path in generated.rglob("*") if path.is_file())
+        if "ASSET-COLLAB-002" not in generated_text:
+            errors.append("selected-output-promoted-asset: generated output missing ASSET-COLLAB-002")
+
+        unsafe_publish = run(
+            [
+                str(PUBLISH),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(temp_vault),
+                "--output-root",
+                str(ROOT / "adapters"),
+                "--apply",
+            ]
+        )
+        errors.extend(expect("publish-refuses-core-overwrite", unsafe_publish, False, "Refusing to overwrite Core adapter templates"))
+
+    if digest_tree(ROOT / "adapters") != adapters_before:
+        errors.append("core-adapters-mutated: regression fixture changed tracked Core adapters")
+
+    if errors:
+        print("Adapter quality split fixture failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("Adapter quality split fixture passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements #67 Option A by separating adapter quality validation surfaces:

- Core `adapters/` remain high-fidelity tracked templates/content.
- Selected-Vault generated adapter output is validated separately through an explicit `--surface selected-output --generated-root <dir>` check.
- Split Core/Vault mode no longer requires selected-Vault active IDs to appear in Core high-fidelity adapter files.
- Selected generated output validation checks active selected-Vault practice/asset IDs against the publish manifest and generated adapter files.
- Missing publish output and unsafe Core overwrite attempts now produce surface-specific failure messages.

## Safety Boundaries

- Did not promote `ASSET-COLLAB-002` in the real User Vault.
- Did not copy or rsync generated output into Core `adapters/`.
- Did not runtime apply adapters.
- Did not weaken `check_activation.py` or Compact Preflight checks.
- Kept `publish_adapters.py` refusing direct Core adapter overwrite.

## Verification

```bash
python3 -m py_compile scripts/check_adapter_quality.py scripts/test_adapter_quality_split.py scripts/publish_adapters.py scripts/check_consistency.py scripts/check_activation.py
python3 scripts/test_adapter_quality_split.py
python3 scripts/test_foundry_roots.py
tmp=$(mktemp -d /tmp/agent-foundry-67-selected-output.XXXXXX) && python3 scripts/publish_adapters.py --core-root . --vault-root ~/.agent-foundry/vault/agent-foundry-vault-farmerhunter --output-root "$tmp" --apply && python3 scripts/check_adapter_quality.py --surface selected-output --vault-root ~/.agent-foundry/vault/agent-foundry-vault-farmerhunter --generated-root "$tmp"
python3 scripts/check_foundry_roots.py --core-root . --vault-root ~/.agent-foundry/vault/agent-foundry-vault-farmerhunter
python3 scripts/check_consistency.py
python3 scripts/check_adapter_quality.py --surface core
python3 scripts/check_activation.py
git diff --check
if python3 scripts/publish_adapters.py --core-root . --vault-root ~/.agent-foundry/vault/agent-foundry-vault-farmerhunter --output-root adapters --apply; then exit 1; fi
```

Results:

- Adapter quality split fixture passed, including temp-Vault ASSET-COLLAB-002 promotion and selected-output validation.
- Split-root fixture tests passed.
- Selected real-Vault generated output validation passed from a temp output root.
- Root validation, consistency, Core adapter quality, activation, and whitespace checks passed.
- Direct Core adapter overwrite was refused as expected.
- Real User Vault still has `ASSET-COLLAB-002` as `proposed` with `published_to: []`.

Closes no issue automatically; #67 should move to separate Reviewer session per contract.
