### PR TITLE
Generate runtime skills from active skill assets

### DIFF
--- a/scripts/check_adapter_quality.py
+++ b/scripts/check_adapter_quality.py
@@ -101,6 +101,72 @@ def parse_index_entries(path: Path) -> list[dict[str, str]]:
     return entries
 
 
+def yaml_scalar(text: str, key: str) -> str:
+    for line in text.splitlines():
+        if line.startswith(f"{key}:"):
+            return line.split(":", 1)[1].strip().strip('"').strip("'")
+    return ""
+
+
+def yaml_list(text: str, key: str) -> list[str]:
+    values: list[str] = []
+    in_list = False
+    for line in text.splitlines():
+        if line.startswith(f"{key}:"):
+            rest = line.split(":", 1)[1].strip()
+            if rest.startswith("[") and rest.endswith("]"):
+                return inline_list(rest)
+            in_list = True
+            continue
+        if in_list and line and not line.startswith(" "):
+            break
+        if in_list and line.strip().startswith("- "):
+            values.append(line.strip()[2:].strip().strip('"').strip("'"))
+    return values
+
+
+def slug_from_asset(entry: dict[str, str]) -> str:
+    stem = Path(entry.get("path", "")).name.removesuffix(".asset.yaml").removesuffix(".yaml")
+    prefix = f"{entry.get('id', '')}-"
+    if stem.startswith(prefix):
+        stem = stem[len(prefix) :]
+    slug = re.sub(r"[^a-z0-9]+", "-", stem.lower()).strip("-")
+    return slug or re.sub(r"[^a-z0-9]+", "-", entry.get("title", entry.get("id", "")).lower()).strip("-")
+
+
+def active_asset_entries(vault_root: Path) -> list[dict[str, str]]:
+    return [
+        entry
+        for entry in parse_index_entries(vault_root / "indexes" / "asset_index.yaml")
+        if entry.get("status") in ACTIVE_STATUSES
+    ]
+
+
+def active_skill_assets(vault_root: Path) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    for entry in active_asset_entries(vault_root):
+        path = vault_root / entry.get("path", "")
+        if not path.exists():
+            continue
+        text = read(path)
+        if yaml_scalar(text, "asset_type") != "skill":
+            continue
+        record = dict(entry)
+        record.update(
+            {
+                "slug": slug_from_asset(entry),
+                "title": yaml_scalar(text, "title") or entry.get("title", entry["id"]),
+                "purpose": yaml_scalar(text, "purpose"),
+                "responsibility": yaml_scalar(text, "responsibility"),
+                "usage_triggers": yaml_list(text, "usage_triggers"),
+                "process": yaml_list(text, "process"),
+                "published_to": yaml_list(text, "published_to") or inline_list(entry.get("published_to", "")),
+            }
+        )
+        records.append(record)
+    return records
+
+
 def core_adapter_files(core_root: Path, outputs: list[str]) -> list[Path]:
     files: list[Path] = []
     for output in outputs:
@@ -167,6 +233,43 @@ def active_ids(vault_root: Path, index_rel: str) -> list[str]:
             continue
         ids.append(entry["id"])
     return ids
+
+
+def expected_skill_path(generated_root: Path, adapter_id: str, slug: str) -> Path:
+    return generated_root / adapter_id / "skills" / slug / "SKILL.md"
+
+
+def check_generated_skill_artifacts(generated_root: Path, vault_root: Path) -> list[str]:
+    errors: list[str] = []
+    for record in active_skill_assets(vault_root):
+        published_to = record.get("published_to", [])
+        if not isinstance(published_to, list):
+            continue
+        for adapter_id in ("codex", "hermes"):
+            if adapter_id not in published_to:
+                continue
+            path = expected_skill_path(generated_root, adapter_id, str(record["slug"]))
+            if not path.exists():
+                errors.append(
+                    f"Selected output skill artifact: {adapter_id} missing generated SKILL.md "
+                    f"for active skill asset {record['id']}: {path}"
+                )
+                continue
+            text = read(path)
+            checks = {
+                "front matter": text.startswith("---\n") and "\n---\n" in text[4:],
+                "asset ID": str(record["id"]) in text,
+                "title": str(record.get("title", "")) in text,
+                "purpose": str(record.get("purpose", "")) in text,
+                "responsibility": "## Responsibility" in text and str(record.get("responsibility", "")) in text,
+                "trigger or process": "## Trigger Guidance" in text or "## Process" in text,
+            }
+            for label, ok in checks.items():
+                if not ok:
+                    errors.append(
+                        f"Selected output skill artifact: {adapter_id} {record['id']} SKILL.md missing {label}: {path}"
+                    )
+    return errors
 
 
 def manifest_ids(manifest: Path, key: str) -> list[str]:
@@ -278,6 +381,7 @@ def check_selected_output_surface(core_root: Path, vault_root: Path, generated_r
                 phrase = phrase.split("<", 1)[0].strip()
             if phrase and phrase not in text:
                 errors.append(f"Selected output coverage: {name} generated output missing command phrase: {phrase}")
+    errors.extend(check_generated_skill_artifacts(generated_root, vault_root))
     return errors
 
 

--- a/scripts/publish_adapters.py
+++ b/scripts/publish_adapters.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 from datetime import date
 from pathlib import Path
 
@@ -55,6 +56,77 @@ def inline_list(value: str) -> list[str]:
     if not (value.startswith("[") and value.endswith("]")):
         return []
     return [item.strip().strip('"').strip("'") for item in value[1:-1].split(",") if item.strip()]
+
+
+def yaml_scalar(text: str, key: str) -> str:
+    for line in text.splitlines():
+        if line.startswith(f"{key}:"):
+            return line.split(":", 1)[1].strip().strip('"').strip("'")
+    return ""
+
+
+def yaml_list(text: str, key: str) -> list[str]:
+    lines = text.splitlines()
+    values: list[str] = []
+    in_list = False
+    for line in lines:
+        if line.startswith(f"{key}:"):
+            rest = line.split(":", 1)[1].strip()
+            if rest.startswith("[") and rest.endswith("]"):
+                return inline_list(rest)
+            in_list = True
+            continue
+        if in_list and line and not line.startswith(" "):
+            break
+        if in_list and line.strip().startswith("- "):
+            values.append(line.strip()[2:].strip().strip('"').strip("'"))
+    return values
+
+
+def slug_from_asset(entry: dict[str, str]) -> str:
+    path = Path(entry.get("path", ""))
+    stem = path.name.removesuffix(".asset.yaml").removesuffix(".yaml")
+    asset_id = entry.get("id", "")
+    prefix = f"{asset_id}-"
+    if stem.startswith(prefix):
+        stem = stem[len(prefix) :]
+    slug = re.sub(r"[^a-z0-9]+", "-", stem.lower()).strip("-")
+    return slug or re.sub(r"[^a-z0-9]+", "-", entry.get("title", asset_id).lower()).strip("-")
+
+
+def skill_asset_records(vault_root: Path, active_assets: list[dict[str, str]]) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    for entry in active_assets:
+        rel = entry.get("path", "")
+        if not rel:
+            continue
+        path = vault_root / rel
+        if not path.exists():
+            continue
+        text = read(path)
+        if yaml_scalar(text, "asset_type") != "skill":
+            continue
+        record = dict(entry)
+        record.update(
+            {
+                "slug": slug_from_asset(entry),
+                "source_path": rel,
+                "asset_type": "skill",
+                "title": yaml_scalar(text, "title") or entry.get("title", entry["id"]),
+                "purpose": yaml_scalar(text, "purpose"),
+                "responsibility": yaml_scalar(text, "responsibility"),
+                "non_responsibility": yaml_scalar(text, "non_responsibility"),
+                "usage_triggers": yaml_list(text, "usage_triggers"),
+                "inputs": yaml_list(text, "inputs"),
+                "process": yaml_list(text, "process"),
+                "outputs": yaml_list(text, "outputs"),
+                "success_criteria": yaml_list(text, "success_criteria"),
+                "canonical_practices": yaml_list(text, "canonical_practices"),
+                "published_to": yaml_list(text, "published_to") or inline_list(entry.get("published_to", "")),
+            }
+        )
+        records.append(record)
+    return records
 
 
 def parse_profiles(core_root: Path) -> dict[str, dict[str, object]]:
@@ -204,6 +276,90 @@ def write_adapter_outputs(
     return written
 
 
+def bullet_lines(values: object) -> list[str]:
+    items = [str(value) for value in values] if isinstance(values, list) else []
+    return [f"- {item}" for item in items] or ["- Not specified in canonical asset record."]
+
+
+def generated_skill_body(record: dict[str, object]) -> str:
+    slug = str(record["slug"])
+    title = str(record.get("title") or record["id"])
+    purpose = str(record.get("purpose") or "Generated Agent Foundry runtime skill.")
+    triggers = record.get("usage_triggers", [])
+    trigger_summary = ", ".join(str(item) for item in triggers[:4]) if isinstance(triggers, list) else ""
+    description = purpose
+    if trigger_summary:
+        description = f"{purpose} Triggers: {trigger_summary}."
+    if len(description) > 260:
+        description = description[:257].rstrip() + "..."
+    quoted_description = '"' + description.replace("\\", "\\\\").replace('"', '\\"') + '"'
+    lines = [
+        "---",
+        f"name: {slug}",
+        f"description: {quoted_description}",
+        "---",
+        "",
+        f"# {title}",
+        "",
+        "Generated transitional runtime skill from the selected Agent Foundry Vault.",
+        f"Canonical source: `{record.get('source_path', '')}`.",
+        f"Asset ID: `{record['id']}`.",
+        "",
+        "## Trigger Guidance",
+        *bullet_lines(triggers),
+        "",
+        "## Responsibility",
+        str(record.get("responsibility") or "Not specified in canonical asset record."),
+        "",
+        "## Non-Responsibility",
+        str(record.get("non_responsibility") or "Not specified in canonical asset record."),
+        "",
+        "## Required Or Optional Inputs",
+        *bullet_lines(record.get("inputs", [])),
+        "",
+        "## Process",
+        *bullet_lines(record.get("process", [])),
+        "",
+        "## Outputs",
+        *bullet_lines(record.get("outputs", [])),
+        "",
+        "## Success Criteria",
+        *bullet_lines(record.get("success_criteria", [])),
+        "",
+        "## Canonical Practices",
+        *bullet_lines(record.get("canonical_practices", [])),
+        "",
+        "## Safety Boundaries",
+        "- Treat the Vault YAML asset record as the source of truth.",
+        "- Do not perform high-risk actions without explicit approval.",
+        "- Do not mutate runtime, config, private remote, or canonical practice state unless the user explicitly approves that action.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def write_generated_skill_outputs(
+    output_root: Path,
+    skill_assets: list[dict[str, object]],
+    apply: bool,
+) -> list[Path]:
+    written: list[Path] = []
+    for record in skill_assets:
+        published_to = record.get("published_to", [])
+        if not isinstance(published_to, list):
+            continue
+        for adapter_id in ("codex", "hermes"):
+            if adapter_id not in published_to:
+                continue
+            target = output_root / adapter_id / "skills" / str(record["slug"]) / "SKILL.md"
+            written.append(target)
+            print(f"{'write' if apply else 'would write'}: {target}")
+            if apply:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(generated_skill_body(record), encoding="utf-8")
+    return written
+
+
 def publish(core_root: Path, vault_root: Path, output_root: Path, apply: bool) -> int:
     errors = validate(core_root, vault_root)
     if errors:
@@ -228,6 +384,7 @@ def publish(core_root: Path, vault_root: Path, output_root: Path, apply: bool) -
         return 1
 
     written = write_adapter_outputs(core_root, output_root, active_practices, active_assets, apply)
+    written.extend(write_generated_skill_outputs(output_root, skill_asset_records(vault_root, active_assets), apply))
     write_manifest(output_root, manifest_text(active_practices, active_assets), apply)
     print(f"Adapter publish {'wrote' if apply else 'planned'} {len(written)} files.")
     print(f"Active practices selected: {len(active_practices)}")

--- a/scripts/test_adapter_quality_split.py
+++ b/scripts/test_adapter_quality_split.py
@@ -171,9 +171,42 @@ def main() -> int:
             ]
         )
         errors.extend(expect("selected-output-promoted-asset", selected_quality, True, "selected-output surface"))
+        codex_skill = generated / "codex" / "skills" / "role-automation-planner" / "SKILL.md"
+        hermes_skill = generated / "hermes" / "skills" / "role-automation-planner" / "SKILL.md"
+        for name, path in [("codex", codex_skill), ("hermes", hermes_skill)]:
+            if not path.exists():
+                errors.append(f"selected-output-promoted-asset: {name} generated SKILL.md missing: {path}")
+                continue
+            text = path.read_text(encoding="utf-8")
+            for expected in ["ASSET-COLLAB-002", "Role Dispatch and Automation Planner", "## Responsibility", "## Process"]:
+                if expected not in text:
+                    errors.append(f"selected-output-promoted-asset: {name} generated SKILL.md missing {expected}")
         generated_text = "\n".join(path.read_text(encoding="utf-8") for path in generated.rglob("*") if path.is_file())
         if "ASSET-COLLAB-002" not in generated_text:
             errors.append("selected-output-promoted-asset: generated output missing ASSET-COLLAB-002")
+
+        codex_skill.unlink()
+        missing_skill_quality = run(
+            [
+                str(QUALITY),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(temp_vault),
+                "--surface",
+                "selected-output",
+                "--generated-root",
+                str(generated),
+            ]
+        )
+        errors.extend(
+            expect(
+                "selected-output-missing-generated-skill",
+                missing_skill_quality,
+                False,
+                "missing generated SKILL.md for active skill asset ASSET-COLLAB-002",
+            )
+        )
 
         unsafe_publish = run(
             [


### PR DESCRIPTION
## Summary

Implements #69 Architect decision for the smallest AF-4 generated-runtime-skill bridge.

- Extends `publish_adapters.py` to read active canonical `asset_type: skill` Vault records and generate first-class Codex/Hermes runtime skill artifacts under selected generated output.
- Generates downstream `SKILL.md` files such as:
  - `codex/skills/role-automation-planner/SKILL.md`
  - `hermes/skills/role-automation-planner/SKILL.md`
- Keeps Vault YAML as canonical source and generated files as downstream output only.
- Extends `check_adapter_quality.py --surface selected-output` to fail when active published Codex/Hermes skill assets lack expected generated `SKILL.md` files or required content.
- Extends ASSET-COLLAB-002 regression coverage in `scripts/test_adapter_quality_split.py`.

## Safety Boundaries

- Did not mutate real Vault asset status.
- Did not write generated files into Core `adapters/`.
- Did not runtime apply adapters in tests or verification.
- Did not modify or weaken `check_activation.py` or Core adapter quality semantics.
- Did not build high-fidelity generation for all adapter targets; Claude Code and ChatGPT remain existing adapter surfaces for now.

## Verification

```bash
python3 -m py_compile scripts/publish_adapters.py scripts/check_adapter_quality.py scripts/test_adapter_quality_split.py
python3 scripts/test_adapter_quality_split.py
tmp=$(mktemp -d /tmp/agent-foundry-69-selected-output.XXXXXX) && python3 scripts/publish_adapters.py --core-root . --vault-root ~/.agent-foundry/vault/agent-foundry-vault-farmerhunter --output-root "$tmp" --apply && ls "$tmp/codex/skills/role-automation-planner" "$tmp/hermes/skills/role-automation-planner" && python3 scripts/check_adapter_quality.py --surface selected-output --vault-root ~/.agent-foundry/vault/agent-foundry-vault-farmerhunter --generated-root "$tmp"
python3 scripts/check_adapter_quality.py --surface core
python3 scripts/check_activation.py
tmp=$(mktemp -d /tmp/agent-foundry-69-install-dry-run.XXXXXX) && python3 scripts/publish_adapters.py --core-root . --vault-root ~/.agent-foundry/vault/agent-foundry-vault-farmerhunter --output-root "$tmp" --apply >/tmp/agent-foundry-69-publish-final.txt && python3 scripts/install_foundry.py --adapter-root "$tmp" --target codex --skip-check && python3 scripts/install_foundry.py --adapter-root "$tmp" --target hermes --skip-check
python3 scripts/check_foundry_roots.py --core-root . --vault-root ~/.agent-foundry/vault/agent-foundry-vault-farmerhunter
python3 scripts/check_consistency.py
python3 scripts/check_adapter_quality.py --surface core
python3 scripts/check_activation.py
git diff --check
python3 scripts/test_foundry_roots.py
```

Results:

- `py_compile` passed.
- Focused ASSET-COLLAB-002 regression passed, including missing generated `SKILL.md` failure coverage.
- Selected-output publish generated `role-automation-planner/SKILL.md` for both Codex and Hermes.
- Selected-output quality check passed against generated output root.
- Core adapter quality and activation checks passed.
- Codex and Hermes install dry-runs showed generated skill files would copy to managed runtime skill directories; no runtime apply was performed.
- Root validation, consistency, whitespace, and split-root fixture tests passed.
