### PR TITLE
Track selected-output runtime install receipts

### DIFF
--- a/scripts/adapter_install_receipt.py
+++ b/scripts/adapter_install_receipt.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Write and verify machine-local selected-output adapter install receipts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RECEIPT_PATH = ROOT / "runtime" / "local" / "adapter-install-receipt.yaml"
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def git_commit(root: Path) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=root,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout.strip() if result.returncode == 0 else "unknown"
+
+
+def source_files_for_target(adapter_root: Path, target: str) -> list[tuple[Path, Path]]:
+    if target in {"codex", "hermes"}:
+        src = adapter_root / target / "skills"
+        return [(path, path.relative_to(adapter_root)) for path in sorted(src.rglob("*")) if path.is_file()] if src.exists() else []
+    if target == "claude-code":
+        src_root = adapter_root / "claude-code"
+        files: list[tuple[Path, Path]] = []
+        claude = src_root / "CLAUDE.md"
+        if claude.exists():
+            files.append((claude, claude.relative_to(adapter_root)))
+        commands = src_root / "commands"
+        if commands.exists():
+            files.extend((path, path.relative_to(adapter_root)) for path in sorted(commands.rglob("*")) if path.is_file())
+        return files
+    return []
+
+
+def destination_for_source(target: str, source_rel: Path, install_path: Path) -> Path | None:
+    if target in {"codex", "hermes"}:
+        prefix = Path(target) / "skills"
+        rel = source_rel.relative_to(prefix)
+        return install_path / rel
+    if target == "claude-code":
+        if source_rel == Path("claude-code") / "CLAUDE.md":
+            return install_path / "agent-foundry" / "CLAUDE.md"
+        prefix = Path("claude-code") / "commands"
+        rel = source_rel.relative_to(prefix)
+        return install_path / "commands" / "agent-foundry" / rel
+    return None
+
+
+def installed_file_entries(adapter_root: Path, target: str, install_path: Path) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    for source, source_rel in source_files_for_target(adapter_root, target):
+        dest = destination_for_source(target, source_rel, install_path)
+        if dest is None or not dest.exists():
+            continue
+        entries.append(
+            {
+                "target": target,
+                "source": str(source_rel),
+                "destination": str(dest.expanduser()),
+                "sha256": file_sha256(dest),
+            }
+        )
+    return entries
+
+
+def write_receipt(
+    *,
+    core_root: Path,
+    vault_root: Path,
+    adapter_root: Path,
+    installed_targets: dict[str, Path],
+    receipt_path: Path = RECEIPT_PATH,
+) -> None:
+    manifest = adapter_root / "adapter-publish-manifest.yaml"
+    files: list[dict[str, str]] = []
+    for target, install_path in installed_targets.items():
+        files.extend(installed_file_entries(adapter_root, target, install_path.expanduser()))
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "installed_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "core_root": str(core_root),
+        "core_commit": git_commit(core_root),
+        "vault_root": str(vault_root),
+        "vault_commit": git_commit(vault_root) if (vault_root / ".git").exists() else "unknown",
+        "adapter_root": str(adapter_root),
+        "adapter_manifest": str(manifest) if manifest.exists() else "",
+        "adapter_manifest_sha256": file_sha256(manifest) if manifest.exists() else "",
+        "installed_targets": sorted(installed_targets),
+        "installed_files": files,
+    }
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def read_receipt(receipt_path: Path = RECEIPT_PATH) -> dict[str, Any] | None:
+    if not receipt_path.exists():
+        return None
+    try:
+        data = json.loads(receipt_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {"error": f"invalid receipt JSON/YAML subset: {receipt_path}"}
+    return data if isinstance(data, dict) else {"error": f"invalid receipt payload: {receipt_path}"}
+
+
+def receipt_status(receipt: dict[str, Any]) -> tuple[str, list[str]]:
+    if "error" in receipt:
+        return "selected-output-unknown", [str(receipt["error"])]
+    files = receipt.get("installed_files")
+    if not isinstance(files, list) or not files:
+        return "selected-output-unknown", ["receipt has no installed files"]
+    problems: list[str] = []
+    for entry in files:
+        if not isinstance(entry, dict):
+            problems.append("receipt has invalid installed file entry")
+            continue
+        dest = Path(str(entry.get("destination", ""))).expanduser()
+        expected = str(entry.get("sha256", ""))
+        label = f"{entry.get('target', 'unknown')}:{dest}"
+        if not dest.exists():
+            problems.append(f"missing {label}")
+        elif expected and file_sha256(dest) != expected:
+            problems.append(f"changed {label}")
+    return ("selected-output-drift", problems) if problems else ("selected-output-in-sync", [])
+
+
+def receipt_target_statuses(receipt: dict[str, Any]) -> dict[str, tuple[str, list[str], int]]:
+    if "error" in receipt:
+        return {"unknown": ("selected-output-unknown", [str(receipt["error"])], 0)}
+    files = receipt.get("installed_files")
+    if not isinstance(files, list) or not files:
+        return {"unknown": ("selected-output-unknown", ["receipt has no installed files"], 0)}
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for entry in files:
+        if isinstance(entry, dict):
+            grouped.setdefault(str(entry.get("target", "unknown")), []).append(entry)
+    statuses: dict[str, tuple[str, list[str], int]] = {}
+    for target, entries in grouped.items():
+        problems: list[str] = []
+        for entry in entries:
+            dest = Path(str(entry.get("destination", ""))).expanduser()
+            expected = str(entry.get("sha256", ""))
+            if not dest.exists():
+                problems.append(f"missing {dest}")
+            elif expected and file_sha256(dest) != expected:
+                problems.append(f"changed {dest}")
+        statuses[target] = (
+            "selected-output-drift" if problems else "selected-output-in-sync",
+            problems,
+            len(entries),
+        )
+    return statuses

--- a/scripts/install_foundry.py
+++ b/scripts/install_foundry.py
@@ -7,6 +7,7 @@ import argparse
 import subprocess
 from pathlib import Path
 
+from adapter_install_receipt import write_receipt
 from foundry_config import CONFIG_PATH, parse_config, write_config
 from runtime_manifest import parse_targets, read_manifest
 
@@ -77,6 +78,7 @@ def main() -> int:
 
     targets = parse_targets(read_manifest())
     selected = [args.target] if args.target else list(targets)
+    installed_targets: dict[str, Path] = {}
     for target in selected:
         if target not in targets:
             raise SystemExit(f"Unknown target: {target}")
@@ -93,6 +95,11 @@ def main() -> int:
         code = run(sync_command(target, config.get("install_path", ""), adapter_root, args.apply), execute=True)
         if code != 0:
             return code
+        if args.apply:
+            installed_targets[target] = Path(config.get("install_path", "")).expanduser()
+    if args.apply and installed_targets:
+        write_receipt(core_root=core_root, vault_root=vault_root, adapter_root=adapter_root, installed_targets=installed_targets)
+        print(f"wrote adapter install receipt: {ROOT / 'runtime' / 'local' / 'adapter-install-receipt.yaml'}")
     return 0
 
 

--- a/scripts/sync_status.py
+++ b/scripts/sync_status.py
@@ -8,6 +8,7 @@ import hashlib
 import subprocess
 import tarfile
 from pathlib import Path
+from adapter_install_receipt import RECEIPT_PATH, read_receipt, receipt_status, receipt_target_statuses
 from foundry_config import CONFIG_PATH, parse_config, validate as validate_config
 
 
@@ -154,8 +155,32 @@ def runtime_drift_status() -> str:
     mode, note = locator_mode()
     lines: list[str] = [
         f"mode: {mode}",
-        f"comparison: {note}",
     ]
+    if mode == "split":
+        receipt = read_receipt(RECEIPT_PATH)
+        if receipt is None:
+            lines.append(f"comparison: {note}")
+            lines.append("selected-output: selected-output-unknown reason=install receipt missing")
+        else:
+            lines.append("comparison: selected-output install receipt is authoritative; Core adapters are secondary reference diagnostics")
+            state, problems = receipt_status(receipt)
+            installed_at = receipt.get("installed_at", "unknown") if isinstance(receipt, dict) else "unknown"
+            manifest_sha = receipt.get("adapter_manifest_sha256", "") if isinstance(receipt, dict) else ""
+            files = receipt.get("installed_files", []) if isinstance(receipt, dict) else []
+            count = len(files) if isinstance(files, list) else 0
+            suffix = f" installed_at={installed_at} files={count}"
+            if manifest_sha:
+                suffix += f" manifest_sha256={str(manifest_sha)[:12]}"
+            lines.append(f"selected-output: {state}{suffix}")
+            for target, (target_state, target_problems, checked) in sorted(receipt_target_statuses(receipt).items()):
+                lines.append(f"{target}: {target_state} checked={checked} missing_changed={len(target_problems)}")
+            for problem in problems[:10]:
+                lines.append(f"selected-output detail: {problem}")
+            if len(problems) > 10:
+                lines.append(f"selected-output detail: ... {len(problems) - 10} more")
+        lines.append("core-reference:")
+    else:
+        lines.append(f"comparison: {note}")
     for name, config in targets.items():
         if config.get("status") != "enabled":
             lines.append(f"{name}: skipped status={config.get('status')}")

--- a/scripts/test_adapter_install_receipt.py
+++ b/scripts/test_adapter_install_receipt.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Smoke tests for selected-output adapter install receipts."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from adapter_install_receipt import read_receipt, receipt_status, receipt_target_statuses, write_receipt
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="agent-foundry-receipt-test.") as raw:
+        root = Path(raw)
+        core = root / "core"
+        vault = root / "vault"
+        adapter = root / "generated"
+        codex_dest = root / "runtime" / "codex"
+        hermes_dest = root / "runtime" / "hermes"
+        receipt = root / "receipt.yaml"
+        for repo in (core, vault):
+            (repo / ".git").mkdir(parents=True)
+
+        write(adapter / "adapter-publish-manifest.yaml", "active_assets:\n  - ASSET-COLLAB-002\n")
+        write(adapter / "codex" / "skills" / "role-automation-planner" / "SKILL.md", "codex skill\n")
+        write(adapter / "hermes" / "skills" / "role-automation-planner" / "SKILL.md", "hermes skill\n")
+        write(codex_dest / "role-automation-planner" / "SKILL.md", "codex skill\n")
+        write(hermes_dest / "role-automation-planner" / "SKILL.md", "hermes skill\n")
+
+        write_receipt(
+            core_root=core,
+            vault_root=vault,
+            adapter_root=adapter,
+            installed_targets={"codex": codex_dest, "hermes": hermes_dest},
+            receipt_path=receipt,
+        )
+
+        loaded = read_receipt(receipt)
+        assert loaded is not None
+        state, problems = receipt_status(loaded)
+        assert state == "selected-output-in-sync", (state, problems)
+        targets = receipt_target_statuses(loaded)
+        assert targets["codex"][0] == "selected-output-in-sync"
+        assert targets["hermes"][0] == "selected-output-in-sync"
+
+        write(codex_dest / "role-automation-planner" / "SKILL.md", "changed\n")
+        state, problems = receipt_status(loaded)
+        assert state == "selected-output-drift"
+        assert any("changed" in problem for problem in problems)
+        targets = receipt_target_statuses(loaded)
+        assert targets["codex"][0] == "selected-output-drift"
+        assert targets["hermes"][0] == "selected-output-in-sync"
+
+    print("Adapter install receipt tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements #71 selected-output runtime install receipts and makes `sync_status.py` selected-output aware in split mode.

## Changes

- Adds `scripts/adapter_install_receipt.py` for machine-local receipt writing and verification.
- Updates `scripts/install_foundry.py` to write `runtime/local/adapter-install-receipt.yaml` after `--apply` installs from an adapter root.
- Updates `scripts/sync_status.py` so split mode uses the selected-output install receipt as authoritative runtime sync evidence and keeps Core adapter comparison as secondary reference diagnostics.
- Adds `scripts/test_adapter_install_receipt.py` for in-sync and changed-file drift receipt behavior.

## Verification

```bash
python3 -m py_compile scripts/adapter_install_receipt.py scripts/install_foundry.py scripts/sync_status.py scripts/test_adapter_install_receipt.py
python3 scripts/test_adapter_install_receipt.py
python3 scripts/check_foundry_roots.py --core-root . --vault-root ~/.agent-foundry/vault/agent-foundry-vault-farmerhunter
python3 scripts/check_consistency.py
python3 scripts/check_adapter_quality.py --surface core
python3 scripts/check_activation.py
git diff --check
```

Manual smoke:

```bash
tmp=$(mktemp -d /tmp/agent-foundry-refresh-71.XXXXXX)
python3 scripts/publish_adapters.py --core-root . --vault-root ~/.agent-foundry/vault/agent-foundry-vault-farmerhunter --output-root "$tmp" --apply
python3 scripts/check_adapter_quality.py --surface selected-output --vault-root ~/.agent-foundry/vault/agent-foundry-vault-farmerhunter --generated-root "$tmp"
python3 scripts/install_foundry.py --core-root . --vault-root ~/.agent-foundry/vault/agent-foundry-vault-farmerhunter --adapter-root "$tmp" --apply
python3 scripts/sync_status.py | sed -n '/runtime adapter drift:/,$p'
```

Observed `sync_status.py` now reports:

```text
selected-output: selected-output-in-sync ...
claude-code: selected-output-in-sync checked=2 missing_changed=0
codex: selected-output-in-sync checked=9 missing_changed=0
hermes: selected-output-in-sync checked=9 missing_changed=0
core-reference:
...
```

Missing receipt smoke:

```bash
mv runtime/local/adapter-install-receipt.yaml /tmp/agent-foundry-receipt-backup-71.yaml
python3 scripts/sync_status.py | sed -n '/runtime adapter drift:/,$p'
mv /tmp/agent-foundry-receipt-backup-71.yaml runtime/local/adapter-install-receipt.yaml
```

Observed selected-output unknown with Core reference diagnostics only as fallback.

## Safety

- Receipt is written under ignored `runtime/local/`.
- No Vault canonical records are changed.
- No Core `adapters/` generated output is written.
- ChatGPT remains manual import.
