### PR TITLE
[codex] Add capability pack manifest fixtures

### DIFF
--- a/fixtures/capability-packs/bootstrap-minimal/manifest.yaml
+++ b/fixtures/capability-packs/bootstrap-minimal/manifest.yaml
@@ -1,0 +1,55 @@
+manifest_schema_version: 1
+pack_id: pack.bootstrap.minimal
+title: Minimal Agent Foundry Bootstrap Pack
+description: Minimal public bootstrap snapshot for AF-5 fixture validation.
+lifecycle_status: reviewed
+version: 0.1.0
+exported_at: 2026-06-11
+distribution_type: mandatory_bootstrap
+source_provenance: "Agent Foundry public Core fixture for issue #75"
+maintainer_contact: "https://github.com/farmerhunter/agent-foundry"
+license: "repository license"
+sensitivity: public
+review_state: reviewed
+
+compatibility:
+  core_schema_version_min: 1
+  core_schema_version_max: 1
+  vault_layout_versions: [1]
+  requires_bootstrap_pack: false
+
+included_records:
+  - id: BOOT-001
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/BOOT-001-bootstrap-orientation.md
+    source_version: 1
+    content_sha256: "0783a718f8da5215e47932f9039d84bf1ef8c6b59eeecc351a126532e3221764"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: ASSET-BOOT-001
+    kind: asset
+    lifecycle_status: active
+    path: records/assets/ASSET-BOOT-001-bootstrap-status.asset.yaml
+    source_version: 1
+    content_sha256: "61cc197353a2564806b5a1f4827b8d732c5c68f0272ce1e04acf2e040d63ad4f"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+
+executable_payloads: []
+
+conflict_policy:
+  id_collision: fail_closed
+  same_version_hash_mismatch: fail_closed
+  newer_version_update: reviewed_diff_required
+  local_edit_behavior: preserve_vault_and_propose_merge
+  rollback_notes: "Disable pack membership metadata and regenerate outputs; do not delete canonical records by default."
+
+integrity:
+  digest_algorithm: sha256
+  manifest_paths_are_relative: true
+  private_vault_content: excluded

--- a/fixtures/capability-packs/bootstrap-minimal/records/assets/ASSET-BOOT-001-bootstrap-status.asset.yaml
+++ b/fixtures/capability-packs/bootstrap-minimal/records/assets/ASSET-BOOT-001-bootstrap-status.asset.yaml
@@ -1,0 +1,28 @@
+id: ASSET-BOOT-001
+title: Bootstrap Status Checklist
+asset_type: skill
+status: active
+version: 1
+created: 2026-06-11
+updated: 2026-06-11
+purpose: Report whether a blank Vault has received the reviewed bootstrap records.
+responsibility: Summarize Core root, Vault root, bootstrap pack membership, and refresh readiness.
+non_responsibility: Does not install runtimes, import optional packs, or mutate private evidence.
+inputs:
+  - Core root
+  - selected Vault root
+  - bootstrap pack membership metadata
+process:
+  - Validate roots.
+  - Check bootstrap membership records.
+  - Report refresh readiness.
+outputs:
+  - Bootstrap status summary
+canonical_practices:
+  - BOOT-001
+published_to:
+  - codex
+usage_triggers:
+  - bootstrap status
+success_criteria:
+  - Blank Vault and bootstrap-only states can be distinguished without reading a pack snapshot as runtime authority.

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/BOOT-001-bootstrap-orientation.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/BOOT-001-bootstrap-orientation.md
@@ -1,0 +1,26 @@
+---
+id: BOOT-001
+title: Bootstrap Orientation
+domain: meta
+type: checklist
+status: active
+version: 1
+created: 2026-06-11
+updated: 2026-06-11
+tags: [bootstrap, onboarding]
+aliases: [BOOT-001]
+---
+
+## Principle
+
+Start from a valid blank Vault, deploy reviewed bootstrap records, then refresh generated runtime outputs from canonical Vault data.
+
+## Rationale
+
+The bootstrap pack is an import path into normal Vault records. It is not a runtime dependency or a hidden source of truth.
+
+## Guidance
+
+- Validate Core and Vault roots before deployment.
+- Record pack membership and provenance on deployed records.
+- Run refresh only after the selected Vault owns the accepted records.

--- a/fixtures/capability-packs/optional-multi-agent/manifest.yaml
+++ b/fixtures/capability-packs/optional-multi-agent/manifest.yaml
@@ -1,0 +1,66 @@
+manifest_schema_version: 1
+pack_id: pack.multi-agent.optional
+title: Optional Multi-Agent Collaboration Pack
+description: Minimal optional capability snapshot with inert helper payload metadata.
+lifecycle_status: candidate
+version: 0.1.0
+exported_at: 2026-06-11
+distribution_type: optional_capability
+source_provenance: "Agent Foundry public Core fixture for issue #75"
+maintainer_contact: "https://github.com/farmerhunter/agent-foundry"
+license: "repository license"
+sensitivity: public
+review_state: unreviewed
+
+compatibility:
+  core_schema_version_min: 1
+  core_schema_version_max: 1
+  vault_layout_versions: [1]
+  requires_bootstrap_pack: true
+
+included_records:
+  - id: COLLAB-PACK-001
+    kind: practice
+    lifecycle_status: candidate
+    path: records/practices/COLLAB-PACK-001-review-handoff.md
+    source_version: 1
+    content_sha256: "cff47b12ef1fdda1cc975433226cd4c8d10124b87d71c7feb2659f7d4aaceed9"
+    destination_layer: canonical_vault_record
+    membership_role: optional_member
+    activation_default: manual_review
+    import_action: stage_only
+  - id: ASSET-COLLAB-PACK-001
+    kind: asset
+    lifecycle_status: candidate
+    path: records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
+    source_version: 1
+    content_sha256: "aa875a255de4818d07e8f6af38490782a990a403150e83570d006f2e622d5e51"
+    destination_layer: canonical_vault_record
+    membership_role: optional_member
+    activation_default: manual_review
+    import_action: stage_only
+
+executable_payloads:
+  - id: helper.review-handoff-summary
+    title: Review Handoff Summary Helper
+    lifecycle_status: candidate
+    path: payloads/helpers/review_handoff_summary.py
+    source_sha256: "61ebb3b134a4ce82bba92103b8033a4474688057bfbf5be68e908d8322a1b334"
+    interpreter: python3
+    execute_from_pack: false
+    install_boundary: managed_runtime_copy_required
+    permissions: [filesystem-read]
+    dependencies: []
+    runtime_impact: "May read reviewed issue or PR handoff text only after managed install."
+
+conflict_policy:
+  id_collision: fail_closed
+  same_version_hash_mismatch: fail_closed
+  newer_version_update: reviewed_diff_required
+  local_edit_behavior: preserve_vault_and_propose_merge
+  rollback_notes: "Keep local Vault edits canonical; remove generated runtime copies through receipts when later install support exists."
+
+integrity:
+  digest_algorithm: sha256
+  manifest_paths_are_relative: true
+  private_vault_content: excluded

--- a/fixtures/capability-packs/optional-multi-agent/payloads/helpers/review_handoff_summary.py
+++ b/fixtures/capability-packs/optional-multi-agent/payloads/helpers/review_handoff_summary.py
@@ -1,0 +1,6 @@
+def summarize_handoff(scope, verification, residual_risks):
+    return {
+        "scope": list(scope),
+        "verification": list(verification),
+        "residual_risks": list(residual_risks),
+    }

--- a/fixtures/capability-packs/optional-multi-agent/records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
+++ b/fixtures/capability-packs/optional-multi-agent/records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
@@ -1,0 +1,27 @@
+id: ASSET-COLLAB-PACK-001
+title: Review Handoff Summary Helper
+asset_type: skill
+status: candidate
+version: 1
+created: 2026-06-11
+updated: 2026-06-11
+purpose: Draft a concise issue and PR completion handoff from reviewed local evidence.
+responsibility: Summarize scope, verification, residual risks, and reviewer target.
+non_responsibility: Does not post comments, mutate GitHub labels, install helpers, or execute from pack staging.
+inputs:
+  - issue number
+  - PR number
+  - verification results
+process:
+  - Read provided handoff evidence.
+  - Build a concise completion summary.
+  - Leave posting and label changes to Core or GitHub workflow tooling.
+outputs:
+  - Handoff summary draft
+canonical_practices:
+  - COLLAB-PACK-001
+published_to: []
+usage_triggers:
+  - review handoff summary
+success_criteria:
+  - The helper can be reviewed as source without being executed from the pack snapshot.

--- a/fixtures/capability-packs/optional-multi-agent/records/practices/COLLAB-PACK-001-review-handoff.md
+++ b/fixtures/capability-packs/optional-multi-agent/records/practices/COLLAB-PACK-001-review-handoff.md
@@ -1,0 +1,27 @@
+---
+id: COLLAB-PACK-001
+title: Review Handoff Discipline
+domain: agent-collaboration
+type: checklist
+status: candidate
+version: 1
+created: 2026-06-11
+updated: 2026-06-11
+tags: [multi-agent, review, handoff]
+aliases: [COLLAB-PACK-001]
+review_required: true
+---
+
+## Principle
+
+When an Implementer hands work to a Reviewer, durable issue and PR comments must identify scope, verification, residual risks, and the expected review target.
+
+## Rationale
+
+Multi-agent work loses continuity when completion evidence lives only in a chat thread.
+
+## Guidance
+
+- Put handoff evidence on both the issue and PR when a PR exists.
+- Include exact verification commands and outcomes.
+- Mark unresolved risks explicitly instead of implying independent review has already happened.

--- a/fixtures/vaults/blank/.agent-foundry-vault.yaml
+++ b/fixtures/vaults/blank/.agent-foundry-vault.yaml
@@ -1,0 +1,7 @@
+schema_version: 1
+layout_kind: vault
+layout_version: 1
+identity: fixture-blank-vault
+supported_modes: [combined, split]
+supported_core_layout_versions: [1]
+privacy_boundary: private_by_default

--- a/fixtures/vaults/blank/indexes/asset_index.yaml
+++ b/fixtures/vaults/blank/indexes/asset_index.yaml
@@ -1,0 +1,6 @@
+schema_version: 1
+updated: 2026-06-11
+
+asset_types: {}
+
+assets: []

--- a/fixtures/vaults/blank/indexes/practice_index.yaml
+++ b/fixtures/vaults/blank/indexes/practice_index.yaml
@@ -1,0 +1,6 @@
+schema_version: 1
+updated: 2026-06-11
+
+domains: {}
+
+practices: []

--- a/fixtures/vaults/blank/usage/usage-aggregate.yaml
+++ b/fixtures/vaults/blank/usage/usage-aggregate.yaml
@@ -1,0 +1,4 @@
+schema_version: 1
+updated: 2026-06-11
+
+aggregates: []

--- a/fixtures/vaults/bootstrap-only/.agent-foundry-vault.yaml
+++ b/fixtures/vaults/bootstrap-only/.agent-foundry-vault.yaml
@@ -1,0 +1,7 @@
+schema_version: 1
+layout_kind: vault
+layout_version: 1
+identity: fixture-bootstrap-only-vault
+supported_modes: [combined, split]
+supported_core_layout_versions: [1]
+privacy_boundary: private_by_default

--- a/fixtures/vaults/bootstrap-only/assets/skills/ASSET-BOOT-001-bootstrap-status.asset.yaml
+++ b/fixtures/vaults/bootstrap-only/assets/skills/ASSET-BOOT-001-bootstrap-status.asset.yaml
@@ -1,0 +1,28 @@
+id: ASSET-BOOT-001
+title: Bootstrap Status Checklist
+asset_type: skill
+status: active
+version: 1
+created: 2026-06-11
+updated: 2026-06-11
+purpose: Report whether a blank Vault has received the reviewed bootstrap records.
+responsibility: Summarize Core root, Vault root, bootstrap pack membership, and refresh readiness.
+non_responsibility: Does not install runtimes, import optional packs, or mutate private evidence.
+inputs:
+  - Core root
+  - selected Vault root
+  - bootstrap pack membership metadata
+process:
+  - Validate roots.
+  - Check bootstrap membership records.
+  - Report refresh readiness.
+outputs:
+  - Bootstrap status summary
+canonical_practices:
+  - BOOT-001
+published_to:
+  - codex
+usage_triggers:
+  - bootstrap status
+success_criteria:
+  - Blank Vault and bootstrap-only states can be distinguished without reading a pack snapshot as runtime authority.

--- a/fixtures/vaults/bootstrap-only/indexes/asset_index.yaml
+++ b/fixtures/vaults/bootstrap-only/indexes/asset_index.yaml
@@ -1,0 +1,12 @@
+schema_version: 1
+updated: 2026-06-11
+
+asset_types:
+  skill: [ASSET-BOOT-001]
+
+assets:
+  - id: ASSET-BOOT-001
+    title: Bootstrap Status Checklist
+    asset_type: skill
+    status: active
+    path: assets/skills/ASSET-BOOT-001-bootstrap-status.asset.yaml

--- a/fixtures/vaults/bootstrap-only/indexes/practice_index.yaml
+++ b/fixtures/vaults/bootstrap-only/indexes/practice_index.yaml
@@ -1,0 +1,12 @@
+schema_version: 1
+updated: 2026-06-11
+
+domains:
+  meta: [BOOT-001]
+
+practices:
+  - id: BOOT-001
+    title: Bootstrap Orientation
+    domain: meta
+    status: active
+    path: practices/meta/BOOT-001-bootstrap-orientation.md

--- a/fixtures/vaults/bootstrap-only/practices/meta/BOOT-001-bootstrap-orientation.md
+++ b/fixtures/vaults/bootstrap-only/practices/meta/BOOT-001-bootstrap-orientation.md
@@ -1,0 +1,26 @@
+---
+id: BOOT-001
+title: Bootstrap Orientation
+domain: meta
+type: checklist
+status: active
+version: 1
+created: 2026-06-11
+updated: 2026-06-11
+tags: [bootstrap, onboarding]
+aliases: [BOOT-001]
+---
+
+## Principle
+
+Start from a valid blank Vault, deploy reviewed bootstrap records, then refresh generated runtime outputs from canonical Vault data.
+
+## Rationale
+
+The bootstrap pack is an import path into normal Vault records. It is not a runtime dependency or a hidden source of truth.
+
+## Guidance
+
+- Validate Core and Vault roots before deployment.
+- Record pack membership and provenance on deployed records.
+- Run refresh only after the selected Vault owns the accepted records.

--- a/fixtures/vaults/bootstrap-only/usage/usage-aggregate.yaml
+++ b/fixtures/vaults/bootstrap-only/usage/usage-aggregate.yaml
@@ -1,0 +1,4 @@
+schema_version: 1
+updated: 2026-06-11
+
+aggregates: []

--- a/schemas/capability-pack-manifest.schema.yaml
+++ b/schemas/capability-pack-manifest.schema.yaml
@@ -1,0 +1,64 @@
+# Capability pack manifest schema.
+# This is a human-readable AF-5 MVP schema, not a strict machine validator yet.
+
+required_fields:
+  manifest_schema_version: "Integer schema version for this manifest format."
+  pack_id: "Stable pack id such as pack.bootstrap.minimal or pack.multi-agent.optional."
+  title: "Short human-readable pack title."
+  description: "One sentence describing the pack's reusable capability."
+  lifecycle_status: "candidate | reviewed | active | deprecated | retired | archived"
+  version: "Snapshot version string. Use semantic versioning when practical."
+  exported_at: "UTC timestamp or YYYY-MM-DD for the exported snapshot."
+  distribution_type: "mandatory_bootstrap | optional_capability | product_project_candidate"
+  source_provenance: "Public source, issue, repository, release, or export note for the snapshot."
+  maintainer_contact: "Maintainer or source contact when available."
+  license: "License or review-required when unknown."
+  sensitivity: "public | internal | private | sensitive"
+  review_state: "unreviewed | reviewed | accepted | rejected"
+  compatibility: "Core and Vault schema/layout compatibility requirements."
+  included_records: "Practices, assets, docs, templates, examples, or config defaults included in the snapshot."
+  executable_payloads: "Executable helper source declarations. Payloads are inert in pack staging."
+  conflict_policy: "Required fail-closed, update, local-edit, and rollback behavior."
+  integrity: "Digest algorithm and checksum policy for snapshot contents."
+
+compatibility_fields:
+  core_schema_version_min: "Minimum Core schema version supported by the pack."
+  core_schema_version_max: "Maximum Core schema version supported by the pack."
+  vault_layout_versions: "List of supported Vault layout versions."
+  requires_bootstrap_pack: "Boolean. Optional packs should declare whether bootstrap must already be deployed."
+
+included_record_fields:
+  id: "Stable record id."
+  kind: "practice | asset | doc | template | example | config_default"
+  lifecycle_status: "Record lifecycle state intended after reviewed deployment."
+  path: "Path inside the pack snapshot, relative to the manifest directory."
+  source_version: "Version of this item within the pack."
+  content_sha256: "SHA-256 digest of the referenced snapshot file."
+  destination_layer: "canonical_vault_record | vault_metadata | import_staging_reference"
+  membership_role: "bootstrap_required | optional_member | dependency | example"
+  activation_default: "active | proposed | candidate | manual_review"
+  import_action: "create_or_review_update | stage_only | skip_if_present"
+
+executable_payload_fields:
+  id: "Stable payload id."
+  title: "Short helper title."
+  lifecycle_status: "candidate | reviewed | active | deprecated | retired | archived"
+  path: "Path inside the pack snapshot, relative to the manifest directory."
+  source_sha256: "SHA-256 digest of the referenced helper source."
+  interpreter: "Runtime or interpreter such as python3, node, bash, or none."
+  execute_from_pack: "Must be false for AF-5 staging fixtures."
+  install_boundary: "managed_runtime_copy_required | manual_import_only | no_install"
+  permissions: "Declared filesystem, network, process, or mutation permissions."
+  dependencies: "Declared runtime dependencies."
+  runtime_impact: "Human-readable statement of affected runtime targets after managed install."
+
+rules:
+  - "A pack snapshot is a transfer and review artifact, not a live source of truth after deployment."
+  - "After deployment, selected User Vault records own canonical practice, asset, membership, and provenance state."
+  - "Do not package raw maintainer Vault evidence, local runtime manifests, secrets, or private User Vault content."
+  - "All included files and executable payload sources must have checksums."
+  - "Executable payloads must be declared but must not be executed from pack staging."
+  - "Same id, same version, different hash must fail closed and require review."
+  - "Same id from unrelated provenance or incompatible kind must fail closed."
+  - "Local Vault edits must be treated as canonical user state and handled through a reviewed merge proposal."
+  - "Runtime installation is out of scope for the manifest fixture; generated or managed runtime outputs come later."

--- a/scripts/check_capability_pack_fixtures.py
+++ b/scripts/check_capability_pack_fixtures.py
@@ -273,8 +273,13 @@ def main() -> int:
     manifest_paths = sorted(PACK_ROOT.glob("*/manifest.yaml"))
     if not manifest_paths:
         errors.append("No capability pack manifest fixtures found")
+    distribution_types: set[str] = set()
     for manifest_path in manifest_paths:
+        distribution_types.add(top_level_scalars(read(manifest_path)).get("distribution_type", ""))
         errors.extend(check_manifest(manifest_path))
+    for required_type in ["mandatory_bootstrap", "optional_capability"]:
+        if required_type not in distribution_types:
+            errors.append(f"Missing capability pack fixture with distribution_type {required_type}")
     errors.extend(check_vault_fixtures())
 
     if errors:

--- a/scripts/check_capability_pack_fixtures.py
+++ b/scripts/check_capability_pack_fixtures.py
@@ -152,6 +152,7 @@ def check_manifest(path: Path) -> list[str]:
     errors: list[str] = []
     text = read(path)
     rel_manifest = path.relative_to(ROOT)
+    errors.extend(check_no_forbidden_fixture_text(rel_manifest, path))
     manifest = top_level_scalars(text)
     missing = sorted(REQUIRED_MANIFEST_FIELDS - manifest.keys())
     for field in missing:

--- a/scripts/check_capability_pack_fixtures.py
+++ b/scripts/check_capability_pack_fixtures.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Validate AF-5 capability pack manifest fixtures.
+
+Dependency-free by design. This checks only the small YAML subset used by the
+Core fixtures and never imports or executes declared payload sources.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+from check_foundry_roots import validate as validate_roots
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACK_ROOT = ROOT / "fixtures" / "capability-packs"
+VAULT_FIXTURE_ROOT = ROOT / "fixtures" / "vaults"
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+REQUIRED_MANIFEST_FIELDS = {
+    "manifest_schema_version",
+    "pack_id",
+    "title",
+    "description",
+    "lifecycle_status",
+    "version",
+    "exported_at",
+    "distribution_type",
+    "source_provenance",
+    "maintainer_contact",
+    "license",
+    "sensitivity",
+    "review_state",
+}
+
+REQUIRED_RECORD_FIELDS = {
+    "id",
+    "kind",
+    "lifecycle_status",
+    "path",
+    "source_version",
+    "content_sha256",
+    "destination_layer",
+    "membership_role",
+    "activation_default",
+    "import_action",
+}
+
+REQUIRED_PAYLOAD_FIELDS = {
+    "id",
+    "title",
+    "lifecycle_status",
+    "path",
+    "source_sha256",
+    "interpreter",
+    "execute_from_pack",
+    "install_boundary",
+    "permissions",
+    "dependencies",
+    "runtime_impact",
+}
+
+FORBIDDEN_PACK_TEXT = {
+    "/Users/",
+    "runtime/local",
+    "usage/local",
+    "sync/local",
+    "gho_",
+}
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def unquote(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def top_level_scalars(text: str) -> dict[str, str]:
+    data: dict[str, str] = {}
+    for raw in text.splitlines():
+        if raw.startswith(" ") or ":" not in raw:
+            continue
+        key, value = raw.split(":", 1)
+        value = value.strip()
+        if value:
+            data[key.strip()] = unquote(value)
+    return data
+
+
+def section_scalars(text: str, section: str) -> dict[str, str]:
+    data: dict[str, str] = {}
+    in_section = False
+    for raw in text.splitlines():
+        if raw == f"{section}:":
+            in_section = True
+            continue
+        if in_section and raw and not raw.startswith(" "):
+            break
+        if in_section and raw.startswith("  ") and ":" in raw:
+            key, value = raw.strip().split(":", 1)
+            data[key] = unquote(value)
+    return data
+
+
+def list_entries(text: str, section: str) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    in_section = False
+    saw_inline_empty = False
+
+    for raw in text.splitlines():
+        if raw.startswith(f"{section}:"):
+            in_section = True
+            saw_inline_empty = raw.split(":", 1)[1].strip() == "[]"
+            continue
+        if in_section and raw and not raw.startswith(" "):
+            break
+        if not in_section or saw_inline_empty:
+            continue
+        stripped = raw.strip()
+        if raw.startswith("  - "):
+            if current:
+                entries.append(current)
+            current = {}
+            item = stripped[2:].strip()
+            if ":" in item:
+                key, value = item.split(":", 1)
+                current[key.strip()] = unquote(value)
+            continue
+        if current is not None and raw.startswith("    ") and not raw.startswith("      ") and ":" in stripped:
+            key, value = stripped.split(":", 1)
+            current[key.strip()] = unquote(value)
+
+    if current:
+        entries.append(current)
+    return entries
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def check_manifest(path: Path) -> list[str]:
+    errors: list[str] = []
+    text = read(path)
+    rel_manifest = path.relative_to(ROOT)
+    manifest = top_level_scalars(text)
+    missing = sorted(REQUIRED_MANIFEST_FIELDS - manifest.keys())
+    for field in missing:
+        errors.append(f"{rel_manifest}: missing manifest field {field}")
+
+    if manifest.get("distribution_type") not in {
+        "mandatory_bootstrap",
+        "optional_capability",
+        "product_project_candidate",
+    }:
+        errors.append(f"{rel_manifest}: invalid distribution_type {manifest.get('distribution_type')}")
+    if manifest.get("sensitivity") != "public":
+        errors.append(f"{rel_manifest}: fixture pack sensitivity must be public")
+
+    compatibility = section_scalars(text, "compatibility")
+    for field in ["core_schema_version_min", "core_schema_version_max", "vault_layout_versions", "requires_bootstrap_pack"]:
+        if field not in compatibility:
+            errors.append(f"{rel_manifest}: compatibility missing {field}")
+    if compatibility.get("vault_layout_versions") != "[1]":
+        errors.append(f"{rel_manifest}: fixture must support Vault layout version [1]")
+
+    conflict_policy = section_scalars(text, "conflict_policy")
+    for field in [
+        "id_collision",
+        "same_version_hash_mismatch",
+        "newer_version_update",
+        "local_edit_behavior",
+        "rollback_notes",
+    ]:
+        if field not in conflict_policy:
+            errors.append(f"{rel_manifest}: conflict_policy missing {field}")
+    if conflict_policy.get("id_collision") != "fail_closed":
+        errors.append(f"{rel_manifest}: id_collision must fail closed")
+    if conflict_policy.get("same_version_hash_mismatch") != "fail_closed":
+        errors.append(f"{rel_manifest}: same-version hash mismatch must fail closed")
+
+    integrity = section_scalars(text, "integrity")
+    if integrity.get("digest_algorithm") != "sha256":
+        errors.append(f"{rel_manifest}: integrity.digest_algorithm must be sha256")
+    if integrity.get("private_vault_content") != "excluded":
+        errors.append(f"{rel_manifest}: private_vault_content must be excluded")
+
+    records = list_entries(text, "included_records")
+    if not records:
+        errors.append(f"{rel_manifest}: included_records must not be empty")
+    seen_ids: set[str] = set()
+    for entry in records:
+        item_id = entry.get("id", "<unknown>")
+        missing_record = sorted(REQUIRED_RECORD_FIELDS - entry.keys())
+        for field in missing_record:
+            errors.append(f"{rel_manifest}: included_record {item_id} missing {field}")
+        if item_id in seen_ids:
+            errors.append(f"{rel_manifest}: duplicate included_record id {item_id}")
+        seen_ids.add(item_id)
+        if entry.get("destination_layer") != "canonical_vault_record":
+            errors.append(f"{rel_manifest}: {item_id} must target canonical_vault_record in MVP fixtures")
+        digest = entry.get("content_sha256", "")
+        if not SHA256_RE.match(digest):
+            errors.append(f"{rel_manifest}: {item_id} has invalid content_sha256")
+            continue
+        item_path = path.parent / entry.get("path", "")
+        if not item_path.exists():
+            errors.append(f"{rel_manifest}: {item_id} path missing: {entry.get('path')}")
+        else:
+            if sha256(item_path) != digest:
+                errors.append(f"{rel_manifest}: {item_id} content_sha256 mismatch")
+            errors.extend(check_no_forbidden_fixture_text(rel_manifest, item_path))
+
+    for payload in list_entries(text, "executable_payloads"):
+        payload_id = payload.get("id", "<unknown>")
+        missing_payload = sorted(REQUIRED_PAYLOAD_FIELDS - payload.keys())
+        for field in missing_payload:
+            errors.append(f"{rel_manifest}: executable_payload {payload_id} missing {field}")
+        if payload.get("execute_from_pack") != "false":
+            errors.append(f"{rel_manifest}: executable_payload {payload_id} must not execute from pack")
+        if payload.get("install_boundary") not in {
+            "managed_runtime_copy_required",
+            "manual_import_only",
+            "no_install",
+        }:
+            errors.append(f"{rel_manifest}: executable_payload {payload_id} has invalid install_boundary")
+        digest = payload.get("source_sha256", "")
+        if not SHA256_RE.match(digest):
+            errors.append(f"{rel_manifest}: executable_payload {payload_id} has invalid source_sha256")
+            continue
+        payload_path = path.parent / payload.get("path", "")
+        if not payload_path.exists():
+            errors.append(f"{rel_manifest}: executable_payload {payload_id} path missing: {payload.get('path')}")
+        else:
+            if sha256(payload_path) != digest:
+                errors.append(f"{rel_manifest}: executable_payload {payload_id} source_sha256 mismatch")
+            errors.extend(check_no_forbidden_fixture_text(rel_manifest, payload_path))
+
+    return errors
+
+
+def check_no_forbidden_fixture_text(manifest_rel: Path, path: Path) -> list[str]:
+    errors: list[str] = []
+    text = read(path)
+    rel_path = path.relative_to(ROOT)
+    for marker in sorted(FORBIDDEN_PACK_TEXT):
+        if marker in text:
+            errors.append(f"{manifest_rel}: {rel_path} contains forbidden fixture text {marker}")
+    return errors
+
+
+def check_vault_fixtures() -> list[str]:
+    errors: list[str] = []
+    for name in ["blank", "bootstrap-only"]:
+        vault_root = VAULT_FIXTURE_ROOT / name
+        fixture_errors = validate_roots(ROOT, vault_root)
+        errors.extend(f"fixtures/vaults/{name}: {error}" for error in fixture_errors)
+    return errors
+
+
+def main() -> int:
+    errors: list[str] = []
+    manifest_paths = sorted(PACK_ROOT.glob("*/manifest.yaml"))
+    if not manifest_paths:
+        errors.append("No capability pack manifest fixtures found")
+    for manifest_path in manifest_paths:
+        errors.extend(check_manifest(manifest_path))
+    errors.extend(check_vault_fixtures())
+
+    if errors:
+        print("Capability pack fixture check failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("Capability pack fixture check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -553,6 +553,26 @@ def check_activation_script() -> list[str]:
     return output.splitlines()
 
 
+def check_capability_pack_fixtures_script() -> list[str]:
+    script = ROOT / "scripts" / "check_capability_pack_fixtures.py"
+    if not script.exists():
+        return ["Missing scripts/check_capability_pack_fixtures.py"]
+    result = subprocess.run(
+        ["python3", str(script)],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode == 0:
+        return []
+    output = (result.stdout + result.stderr).strip()
+    if not output:
+        return ["Capability pack fixture check failed without output"]
+    return output.splitlines()
+
+
 def main() -> int:
     errors: list[str] = []
     errors += check_index_paths(VAULT_ROOT / "indexes" / "practice_index.yaml", VAULT_ROOT, "Practice")
@@ -571,6 +591,7 @@ def main() -> int:
     errors += check_obsidian_compatibility()
     errors += check_adapter_quality_script()
     errors += check_activation_script()
+    errors += check_capability_pack_fixtures_script()
 
     if errors:
         print("Consistency check failed:")


### PR DESCRIPTION
## Summary

Implements #75 with the minimal AF-5 capability pack manifest/check surface:

- adds a human-readable capability pack manifest schema under Core schema conventions
- adds bootstrap and optional capability pack fixtures with public synthetic records only
- adds blank and bootstrap-only Vault fixtures for root validation coverage
- adds `scripts/check_capability_pack_fixtures.py` and wires it into `check_consistency.py`
- declares optional executable payload metadata and validates that payloads are inert in pack staging

## Verification

- `python3 scripts/check_capability_pack_fixtures.py` -> `Capability pack fixture check passed.`
- `python3 scripts/check_consistency.py` -> `Consistency check passed.`
- `python3 scripts/check_adapter_quality.py` -> `Adapter quality check passed for core surface.`
- `python3 scripts/check_activation.py` -> `Activation check passed.`
- `python3 -m py_compile scripts/check_capability_pack_fixtures.py scripts/check_consistency.py` -> no output, exit 0
- `git diff --cached --check` before commit -> no output, exit 0

## Handoff

Completion handoff: to:architect

Residual risks:
- This is intentionally a fixture-driven MVP schema/check, not a full marketplace or install schema.
- YAML parsing in the fixture check is intentionally limited to the Core fixture subset.
- Runtime installation and executable helper execution remain out of scope; payloads are declared and checksum-validated only.

No selected User Vault, runtime installs, local config, private remotes, or generated runtime files were mutated.