### PR TITLE
Define bootstrap capability pack content

### DIFF
--- a/fixtures/capability-packs/bootstrap-minimal/manifest.yaml
+++ b/fixtures/capability-packs/bootstrap-minimal/manifest.yaml
@@ -1,12 +1,12 @@
 manifest_schema_version: 1
 pack_id: pack.bootstrap.minimal
 title: Minimal Agent Foundry Bootstrap Pack
-description: Minimal public bootstrap snapshot for AF-5 fixture validation.
+description: Minimal public bootstrap snapshot for first-run harvest, review, refresh, publish, root, and runtime-boundary workflows.
 lifecycle_status: reviewed
-version: 0.1.0
-exported_at: 2026-06-11
+version: 0.2.0
+exported_at: 2026-06-12
 distribution_type: mandatory_bootstrap
-source_provenance: "Agent Foundry public Core fixture for issue #75"
+source_provenance: "Agent Foundry public Core fixture for issue #77"
 maintainer_contact: "https://github.com/farmerhunter/agent-foundry"
 license: "repository license"
 sensitivity: public
@@ -17,6 +17,23 @@ compatibility:
   core_schema_version_max: 1
   vault_layout_versions: [1]
   requires_bootstrap_pack: false
+
+selection_review:
+  rationale: "Provide the smallest usable blank-Vault baseline: bootstrap orientation plus the public Practice Harvester asset and its canonical meta, governance, and runtime practices."
+  included_groups:
+    - bootstrap orientation and status records
+    - Practice Harvester skill asset
+    - meta practices required for harvest, asset discovery, import review, dedupe, and adapter publishing
+    - governance practices required for source-of-truth and maintainability decisions
+    - runtime practices required for root, adapter, sync, and privacy boundaries
+  excluded_groups:
+    - optional multi-agent collaboration records
+    - architecture and provider-integration records
+    - product-project-specific records
+    - raw maintainer usage evidence
+    - private paths, runtime manifests, and local deployment receipts
+  adapter_impact: "After deployment and refresh, generated runtime outputs expose ASSET-META-001, ASSET-BOOT-001, and the included active practices only."
+  runtime_impact: "No runtime files are changed by deploying the pack; runtime installation remains a separate refresh/install step."
 
 included_records:
   - id: BOOT-001
@@ -29,12 +46,232 @@ included_records:
     membership_role: bootstrap_required
     activation_default: active
     import_action: create_or_review_update
+  - id: GOV-001
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/GOV-001-protect-canonical-source-of-truth.md
+    source_version: 1
+    content_sha256: "183be3ddd0347051fb9c07cd89d9741f6cd9a6c09eecbbbc039f2554e3f15e40"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: GOV-002
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/GOV-002-prefer-smallest-maintainable-mechanism.md
+    source_version: 2
+    content_sha256: "78dd9283183f02611808087c15ccc0e1f5d70e6c90da82b5bf9b18cee73305e4"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: GOV-003
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/GOV-003-treat-transient-context-as-evidence.md
+    source_version: 1
+    content_sha256: "d3d50f436c3a0bb5e255302d1900d46607bca3a64fbafc8f644253b8796f72e0"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: GOV-004
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/GOV-004-preserve-runtime-capability.md
+    source_version: 1
+    content_sha256: "4e092ed3616f522d24021dd3e88f51167f4f794bc592417fddb34f44ed9ea0de"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-001
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-001-canonical-practices-source-of-truth.md
+    source_version: 1
+    content_sha256: "bc411c01cbda78f8002bfa3cb51aa8a523f2b7635ae0c1db428befc033a46ae6"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-002
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-002-harvest-before-publishing.md
+    source_version: 1
+    content_sha256: "2b84e5ae40c3430894004ef90315d13a470aa805691ac773b132925aad77014e"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-003
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-003-borrow-external-skills-through-review.md
+    source_version: 1
+    content_sha256: "ee3c7c051f185bc3b7d3747a5dac140effb8284933f30ecb151dd25f1db2f7b7"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-004
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-004-choose-smallest-suitable-asset.md
+    source_version: 1
+    content_sha256: "47fef94b99fb9952239ab681c78c097e7d68d82555139641611cc16ac6e272e2"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-005
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-005-define-asset-boundaries-before-creation.md
+    source_version: 1
+    content_sha256: "187746bd40906ce15a46dc2a8c88db982730935fd5f00e9c9ade5b70c25bf82a"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-006
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-006-memory-is-evidence-not-source-of-truth.md
+    source_version: 1
+    content_sha256: "e7429a6b0904c9268f3f867e83bbf5151d4916075ee9e0bbd88ba48fbf4322fa"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-007
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-007-native-agent-learning-is-candidate-input.md
+    source_version: 1
+    content_sha256: "bd6952ad01cf6b926bb12e71c73b3eeea09359a62e4f7b502b0cc5c2f84d247e"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-008
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-008-route-through-assets-constrain-with-practices.md
+    source_version: 1
+    content_sha256: "b81bca421697152e9ce088bdf082b6e74d3b00d728586c8a760b99e9ded5c992"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-009
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-009-make-adapter-fidelity-executable.md
+    source_version: 2
+    content_sha256: "6f66caf3d0574c9c241b0088009c62c7bd40ff5946d2a2aaffa84fdb9397e4e4"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-010
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-010-review-assets-with-lifecycle-evidence.md
+    source_version: 1
+    content_sha256: "d31a102a8c6b658330f3e7099987126dc232503c2d65b0e64d3022b5df227dc4"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-011
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-011-route-artifacts-before-abstracting-practices.md
+    source_version: 1
+    content_sha256: "a144755298e994ac9be820cd59e588cb73271666416d3bfc514f96f591593344"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-012
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-012-treat-user-corrections-as-process-evidence-before-content-evidence.md
+    source_version: 3
+    content_sha256: "2ec58adada8a3c72dd00629905e2dea3fb4f44c3e11266588b2852b194b467e5"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-013
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-013-apply-generalization-gate-before-promoting-insights-into-practices.md
+    source_version: 1
+    content_sha256: "6c4341cb08f1fac6302223ccabac565f1ec181759d1a9b8ab15a306d772ee81f"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: RUNTIME-001
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/RUNTIME-001-treat-agent-runtimes-as-shared-environments.md
+    source_version: 2
+    content_sha256: "381ea45b1bd33f9d175d4ca948fa1df951ee6334451efdbe132402fbd1be2a67"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: RUNTIME-002
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/RUNTIME-002-separate-portable-adapter-intent-from-machine-local-state.md
+    source_version: 2
+    content_sha256: "1698103aafbcf8a7f71d37981bd24833bda3e50bee666a35b10c3b27493e7727"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: RUNTIME-003
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/RUNTIME-003-sync-operations-must-expose-unambiguous-state.md
+    source_version: 1
+    content_sha256: "e554ca573c6f95dc84b69a1111c90db07ffce9847eec273c8c958fe4ed6fea4b"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: RUNTIME-004
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/RUNTIME-004-sync-aggregates-not-raw-evidence.md
+    source_version: 2
+    content_sha256: "0be462345da8b6820243c360e0d3cda96a038991be5ebf4c2f1c6f44a76d73b9"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
   - id: ASSET-BOOT-001
     kind: asset
     lifecycle_status: active
     path: records/assets/ASSET-BOOT-001-bootstrap-status.asset.yaml
     source_version: 1
     content_sha256: "61cc197353a2564806b5a1f4827b8d732c5c68f0272ce1e04acf2e040d63ad4f"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: ASSET-META-001
+    kind: asset
+    lifecycle_status: active
+    path: records/assets/ASSET-META-001-practice-harvester.asset.yaml
+    source_version: 3
+    content_sha256: "c69cc0ec3a45a81dfd7d4dd30d0c55448345b736d7c72f978a0b216fd4509427"
     destination_layer: canonical_vault_record
     membership_role: bootstrap_required
     activation_default: active

--- a/fixtures/capability-packs/bootstrap-minimal/records/assets/ASSET-META-001-practice-harvester.asset.yaml
+++ b/fixtures/capability-packs/bootstrap-minimal/records/assets/ASSET-META-001-practice-harvester.asset.yaml
@@ -1,0 +1,88 @@
+id: ASSET-META-001
+title: Practice Harvester
+asset_type: skill
+status: active
+version: 3
+created: 2026-05-26
+updated: 2026-06-09
+purpose: Maintain reusable practices and assets by harvesting lessons, discovering reusable skills/assets, importing external skills, publishing adapters, and reviewing skill rot.
+responsibility: Maintain the Agent Foundry lifecycle of practices, assets, indexes, adapters, usage evidence, and related review reports.
+non_responsibility: Does not perform domain-specific engineering work except to harvest or package reusable lessons from it.
+inputs:
+  - current session context
+  - linked issue, PR, commit, or roadmap history when the user asks to review a whole session or phase
+  - external skill source
+  - existing practice and asset indexes
+  - recent work history when discovering assets
+process:
+  - locate and validate the current Agent Foundry Core and Vault
+  - reconstruct the relevant session or correction
+  - when harvesting skills or assets from a long session, set an explicit evidence window that includes earlier phases, linked issues, PRs, and commits rather than only the latest discussion topic
+  - route artifacts before drafting candidates
+  - apply the generalization gate
+  - classify candidate practices or assets
+  - for asset discovery, choose create, extend, skip, or defer using the smallest suitable asset rule
+  - deduplicate against indexes
+  - present a concise review list before canonical mutation
+  - apply approved items
+  - publish relevant adapters only after approved canonical changes are applied
+outputs:
+  - harvest report or review list
+  - asset discovery review list
+  - proposed or active practice entries
+  - active asset records
+  - updated indexes
+  - updated adapters
+  - review report
+canonical_practices:
+  - META-001
+  - META-002
+  - META-003
+  - META-004
+  - META-005
+  - META-006
+  - META-007
+  - META-008
+  - META-009
+  - META-010
+  - META-011
+  - META-012
+  - META-013
+  - GOV-001
+  - GOV-002
+  - GOV-003
+  - GOV-004
+  - RUNTIME-001
+  - RUNTIME-002
+  - RUNTIME-003
+  - RUNTIME-004
+published_to:
+  - codex
+  - claude-code
+  - hermes
+  - chatgpt
+usage_triggers:
+  - harvest practices
+  - 做一次 harvest practice
+  - harvest skills
+  - harvest assets
+  - import skill
+  - 导入这个 skill
+  - discover assets
+  - 发现可打包资产
+  - publish practices
+  - review practices
+  - 检查 skill rot
+success_criteria:
+  - artifact routing, generalization, rejected-as-practice, canonical impact, adapter impact, and runtime impact are visible before approval
+  - candidates are deduplicated against existing practices and assets
+  - skill or asset harvests review the requested evidence window, not just the most recent subtopic
+  - existing assets are extended when coverage is partial, instead of creating near-duplicate skills
+  - human approval is requested per meaningful new or changed item
+  - broad approval language is not interpreted as permission to skip unshown workflow steps
+  - self-referential workflow changes stop at a review list before canonical mutation
+  - approved items are activated and published to relevant adapters
+  - changed files and deferred items are reported clearly
+review_cadence: monthly
+review_after_days: 90
+evidence_summary: Created as the first core asset for this repository.

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/GOV-001-protect-canonical-source-of-truth.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/GOV-001-protect-canonical-source-of-truth.md
@@ -1,0 +1,62 @@
+---
+id: GOV-001
+title: Protect canonical source of truth
+domain: governance
+type: principle
+status: active
+version: 1
+created: 2026-05-28
+updated: 2026-05-28
+tags: [governance, source-of-truth, derived-data, maintainability]
+aliases:
+  - GOV-001
+  - do not create a second source of truth
+  - derived views must stay derived
+related: [META-001, META-006, ARCH-007]
+applies_when:
+  - creating indexes, summaries, generated files, views, caches, docs, or exports from existing data
+  - adding a second representation of data that already has a canonical owner
+  - deciding whether a document, schema, config, or generated artifact should be edited by hand
+  - improving tool compatibility without changing the underlying product or system behavior
+review_required: false
+provenance: "Extracted from the Obsidian rollback lesson on 2026-05-28."
+---
+
+## Principle
+
+Protect the canonical source of truth. In any project, derived views, generated artifacts, agent notes, summaries, caches, and compatibility files must not become a second hand-maintained truth source.
+
+## Rationale
+
+Duplicate truth sources create silent drift. They look helpful at first because they make a tool or workflow easier to use, but every future change must update multiple locations. Once agents or humans forget one of them, the project loses trust in its own records.
+
+## Guidance
+
+Before adding a new file, view, index, export, or generated artifact, identify:
+
+- the canonical owner;
+- whether the new artifact is canonical or derived;
+- how derived artifacts are regenerated;
+- whether consistency is checked automatically;
+- who is allowed to edit the artifact by hand.
+
+If the artifact is derived, make it generated, checked, or clearly non-authoritative. Prefer improving schema, validation, or generation paths over adding another manually maintained representation.
+
+## Watch Out For
+
+Do not justify duplicate truth sources by saying they improve readability in one tool. Tool-specific views are allowed only when they are generated from the canonical source or have a clear non-authoritative role.
+
+Do not let agent session conclusions replace project-owned durable records such as schemas, ADRs, migrations, API contracts, design docs, or canonical indexes.
+
+## Activation
+
+- Tier: always_preflight
+- Phases: planning, before_edit, before_new_file, review
+- Signals: creating derived views; adding a second representation; generating indexes, summaries, caches, exports, or compatibility files; deciding whether a file is canonical or derived
+- Evidence: final report identifies the canonical owner and whether any new artifact is canonical, derived, generated, or non-authoritative
+
+## Related Practices
+
+- [[META-001]]
+- [[META-006]]
+- [[ARCH-007]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/GOV-002-prefer-smallest-maintainable-mechanism.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/GOV-002-prefer-smallest-maintainable-mechanism.md
@@ -1,0 +1,73 @@
+---
+id: GOV-002
+title: Prefer the smallest maintainable mechanism
+domain: governance
+type: principle
+status: active
+version: 2
+created: 2026-05-28
+updated: 2026-06-02
+tags: [governance, maintainability, complexity, scope]
+aliases:
+  - GOV-002
+  - smallest maintainable mechanism
+  - do not add machinery before boundaries are clear
+related: [META-004, META-005, ARCH-001, ARCH-009]
+applies_when:
+  - choosing how much implementation, automation, abstraction, documentation, or tooling to add
+  - responding to an open-ended request such as "make the necessary changes"
+  - adding a new layer, workflow, script, framework, generated artifact, or integration
+  - deciding whether to create, extend, skip, or defer reusable capability
+review_required: false
+provenance: "Extracted from the Obsidian rollback lesson and capability-governance review on 2026-05-28."
+---
+
+## Principle
+
+Prefer the smallest maintainable mechanism that solves the real problem. More complete-looking solutions are worse when they add synchronization burden, unclear ownership, or long-term maintenance cost.
+
+## Rationale
+
+Agents tend to overbuild when the user gives an open-ended implementation request. Extra scripts, files, generated views, abstractions, or workflows can make the first result look polished while making the project harder to operate later.
+
+## Guidance
+
+Before adding machinery, ask:
+
+- What is the smallest change that preserves the intended capability?
+- What new state must be maintained?
+- What future workflow must remember this change?
+- Can the same value be achieved by tightening schema, checks, docs, or an existing workflow?
+- What fails if no one remembers this change later?
+
+Prefer bounded changes that integrate into existing workflows and checks. If a mechanism needs ongoing maintenance, define its owner, trigger, validation path, and failure mode.
+
+For frontend and interaction complexity, escalate by the shape of the problem:
+
+- one or two local toggles: use local state;
+- mutually exclusive views: use a discriminated union;
+- action availability depends on several domain or workflow states: introduce a small interaction ViewModel;
+- shared state has complex write paths: consider a reducer or lightweight store;
+- async flows require cancellation, retry, rollback, or concurrent transition control: consider a state machine;
+- URL, deep-link, history, or multi-page navigation are real requirements: consider a router;
+- visual consistency, accessibility, and component reuse dominate the problem: consider a component framework.
+
+Do not treat a busy JSX file as automatic evidence for a larger framework. First identify whether the missing mechanism is a state boundary, interaction contract, shared write model, transition model, navigation model, or visual system.
+
+## Watch Out For
+
+Do not treat "more complete" as "more correct." A hub note, generated index, helper script, adapter, automation, or abstraction is only justified if it improves long-term operation without creating hidden sync work.
+
+## Activation
+
+- Tier: always_preflight
+- Phases: planning, before_edit, before_new_layer, review
+- Signals: open-ended implementation request; adding scripts, workflows, adapters, generated files, abstractions, automations, or integrations; solution seems complete but adds maintenance state
+- Evidence: final report explains the smaller mechanism chosen or the maintenance path for added machinery
+
+## Related Practices
+
+- [[META-004]]
+- [[META-005]]
+- [[ARCH-001]]
+- [[ARCH-009]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/GOV-003-treat-transient-context-as-evidence.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/GOV-003-treat-transient-context-as-evidence.md
@@ -1,0 +1,60 @@
+---
+id: GOV-003
+title: Treat transient context as evidence
+domain: governance
+type: principle
+status: active
+version: 1
+created: 2026-05-28
+updated: 2026-05-28
+tags: [governance, memory, evidence, durable-records]
+aliases:
+  - GOV-003
+  - session context is evidence
+  - memory is not project truth
+related: [META-006, META-007, ARCH-007]
+applies_when:
+  - using chat history, memory, rollout summaries, notes, logs, or temporary analysis
+  - turning a session conclusion into project behavior
+  - deciding whether an insight belongs in code, schema, design docs, tests, practices, or memory
+  - resuming work after compaction, interruption, or handoff
+review_required: false
+provenance: "Extracted from the memory and rollback discussions on 2026-05-28."
+---
+
+## Principle
+
+Treat transient context as evidence, not project truth. Chat history, agent memory, session summaries, temporary notes, and activity logs can suggest decisions, but durable project behavior must live in the project's canonical records.
+
+## Rationale
+
+Transient context is useful but incomplete. It can be stale, compressed, unavailable to another agent, or detached from the files that actually govern the project. If agents rely on it as truth, future work becomes inconsistent and hard to audit.
+
+## Guidance
+
+When a session produces a durable decision, place it in the right canonical home:
+
+- code or tests for executable behavior;
+- schema or config for machine-readable contracts;
+- design docs or ADRs for architectural decisions;
+- practices or assets for reusable agent behavior;
+- local logs or aggregates for usage evidence.
+
+Use memory and summaries to rediscover context, then verify against project-owned records before acting.
+
+## Watch Out For
+
+Do not write long-term behavior only into memory or a chat transcript. Do not assume another agent, machine, or future compacted session will recover the same context.
+
+## Activation
+
+- Tier: always_preflight
+- Phases: planning, resume, handoff, before_edit
+- Signals: relying on chat history, memory, rollout summary, temporary note, or compacted context as fact; turning a session conclusion into durable behavior
+- Evidence: final report names the project-owned record checked or updated instead of relying only on transient context
+
+## Related Practices
+
+- [[META-006]]
+- [[META-007]]
+- [[ARCH-007]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/GOV-004-preserve-runtime-capability.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/GOV-004-preserve-runtime-capability.md
@@ -1,0 +1,62 @@
+---
+id: GOV-004
+title: Preserve maintainability and runtime capability
+domain: governance
+type: principle
+status: active
+version: 1
+created: 2026-05-28
+updated: 2026-05-28
+tags: [governance, maintainability, runtime, degradation, safety]
+aliases:
+  - GOV-004
+  - do not degrade native agent capability
+  - preserve long-term runtime capability
+related: [GOV-002, RUNTIME-001, META-007, META-009]
+applies_when:
+  - adding capability-management mechanisms, adapters, runtime files, scripts, or automations
+  - deploying Agent Foundry content into Codex, Claude Code, Hermes, ChatGPT, or another agent runtime
+  - changing rules that affect native memory, skills, project instructions, commands, or self-improvement
+  - designing a system enhancement that must keep working across agents and machines
+review_required: false
+provenance: "Added from the user's explicit guardrail on 2026-05-28: Agent Foundry must preserve minimal maintainability and avoid degrading long-running agent runtimes."
+---
+
+## Principle
+
+Preserve maintainability and runtime capability. A capability system must enhance agent runtimes without weakening their native skills, memory, instructions, self-improvement, or user-owned configuration.
+
+## Rationale
+
+Governance systems can become harmful when they add too much structure, overwrite runtime behavior, or force every agent into one uniform model. Long-term value depends on staying lightweight, reversible, and compatible with each runtime's native strengths.
+
+## Guidance
+
+Before adding or changing a capability mechanism, verify:
+
+- it does not overwrite unmanaged runtime content;
+- it does not disable native memory, skill creation, project instructions, or self-improvement;
+- it has a clear maintenance path and validation check;
+- it can fail safely or be rolled back;
+- it avoids manual synchronization burden;
+- it improves future agent behavior enough to justify its complexity.
+
+Prefer managed blocks, namespaced files, dry-runs, adapter quality checks, and explicit local deployment manifests over direct runtime takeover.
+
+## Watch Out For
+
+Do not optimize one agent's adapter in a way that degrades another agent's native mode of operation. Do not make a rule global unless it can survive compaction, handoff, and multi-machine use without requiring hidden memory.
+
+## Activation
+
+- Tier: always_preflight
+- Phases: planning, before_runtime_write, before_adapter_publish, review
+- Signals: writing runtime files; changing agent skills, memory, project instructions, commands, hooks, or self-improvement behavior; introducing capability-management machinery
+- Evidence: final report states how native runtime capability, rollback, and maintainability were preserved
+
+## Related Practices
+
+- [[GOV-002]]
+- [[RUNTIME-001]]
+- [[META-007]]
+- [[META-009]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-001-canonical-practices-source-of-truth.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-001-canonical-practices-source-of-truth.md
@@ -1,0 +1,50 @@
+---
+id: META-001
+title: Canonical practices are the source of truth for adapters
+domain: meta
+type: principle
+status: active
+version: 1
+created: 2026-05-26
+updated: 2026-05-26
+tags: [canonical, source-of-truth, adapters]
+aliases:
+  - META-001
+  - skills are downstream
+  - adapters are not source of truth
+related: [GOV-001, META-002, META-003]
+applies_when:
+  - maintaining reusable agent practices
+  - updating agent skills or prompts
+  - porting practices across agent environments
+review_required: false
+provenance: "Initial Agent Foundry system design."
+---
+
+## Principle
+
+Within Agent Foundry, canonical practice entries are the source of truth for agent adapters. Agent-specific skills, prompts, instructions, and commands are downstream outputs.
+
+## Rationale
+
+Different agent environments use different packaging formats. If practices are edited directly inside each adapter, the system will drift and become hard to deduplicate, review, and merge.
+
+## Guidance
+
+When adding or changing a reusable practice, update the canonical entry under `practices/` first. Update Codex skills, Claude Code instructions, ChatGPT custom instructions, DeepSeek prompt packs, or Hermes prompt packs only after the canonical entry is settled.
+
+For the cross-project source-of-truth rule, apply [[GOV-001]]. This practice is the Agent Foundry-specific application of that broader governance principle.
+
+## Watch Out For
+
+Do not treat a polished `SKILL.md` as the canonical source. It is optimized for context loading and trigger behavior, not long-term knowledge governance.
+
+## Example
+
+An architecture principle should live under `practices/architecture/ARCH-*.md`. The Codex `architecture-design` skill should contain only the compact version needed during work.
+
+## Related Practices
+
+- [[GOV-001]]
+- [[META-002]]
+- [[META-003]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-002-harvest-before-publishing.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-002-harvest-before-publishing.md
@@ -1,0 +1,47 @@
+---
+id: META-002
+title: Harvest before publishing
+domain: meta
+type: principle
+status: active
+version: 1
+created: 2026-05-26
+updated: 2026-05-26
+tags: [harvesting, review, skill-rot]
+aliases:
+  - META-002
+  - do not add raw notes to skills
+  - review gate
+related: [META-001, META-003]
+applies_when:
+  - extracting lessons from a project session
+  - updating practices after coding work
+  - preventing skill rot
+review_required: false
+provenance: "Initial Agent Foundry system design."
+---
+
+## Principle
+
+Reusable lessons must be harvested, classified, deduplicated, and reviewed before being published into agent adapters.
+
+## Rationale
+
+Raw session notes often contain project-specific facts, duplicate ideas, and immature conclusions. Publishing them directly into skills bloats context and weakens future agent behavior.
+
+## Guidance
+
+Follow `workflows/harvest-practices.md`. Each candidate must receive a decision: discard, merge, create, supersede, or defer. New entries start as `candidate` or `proposed` unless the user explicitly approves activation.
+
+## Watch Out For
+
+Avoid creating a new practice for every interesting observation. Prefer strengthening existing rules with examples or sharper guidance.
+
+## Example
+
+If a session shows that UI should consume a domain summary, first search for existing frontend/domain separation practices. If one exists, merge the new case as an example rather than creating a near-duplicate.
+
+## Related Practices
+
+- [[META-001]]
+- [[META-003]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-003-borrow-external-skills-through-review.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-003-borrow-external-skills-through-review.md
@@ -1,0 +1,47 @@
+---
+id: META-003
+title: Borrow external skills through review
+domain: meta
+type: playbook
+status: active
+version: 1
+created: 2026-05-26
+updated: 2026-05-26
+tags: [external-skills, imports, security, provenance]
+aliases:
+  - META-003
+  - external skill import path
+  - borrow skills safely
+related: [META-001, META-002]
+applies_when:
+  - evaluating public skill repositories
+  - importing a community skill
+  - adapting internet prompt packs
+review_required: false
+provenance: "Initial Agent Foundry system design."
+---
+
+## Principle
+
+External skills are inputs for review, not trusted source-of-truth content.
+
+## Rationale
+
+Public skills may be useful, but they can also be generic, stale, overbroad, insecure, license-incompatible, or misaligned with personal practices. Direct import increases skill rot and supply-chain risk.
+
+## Guidance
+
+Use `workflows/import-external-skills.md`. Capture provenance, check license and scripts, extract candidate practices, deduplicate against `indexes/practice_index.yaml`, then ask for human approval before activation. After approval, publish relevant adapters automatically.
+
+## Watch Out For
+
+Never execute external scripts, install dependencies, or copy large prompt packs into active adapters without explicit approval.
+
+## Example
+
+A public Codex skill may have a good trigger description and workflow. Borrow the structure by creating a canonical candidate, not by copying its entire `SKILL.md` into your active skill directory.
+
+## Related Practices
+
+- [[META-001]]
+- [[META-002]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-004-choose-smallest-suitable-asset.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-004-choose-smallest-suitable-asset.md
@@ -1,0 +1,57 @@
+---
+id: META-004
+title: Choose the smallest suitable asset
+domain: meta
+type: principle
+status: active
+version: 1
+created: 2026-05-26
+updated: 2026-05-26
+tags: [assets, discovery, skill-rot, scope]
+aliases:
+  - META-004
+  - skill is not the default
+  - smallest suitable reusable asset
+related: [GOV-002, META-001, META-002, META-003, META-005]
+applies_when:
+  - discovering repeated workflows
+  - deciding whether to create a skill
+  - choosing between skill, subagent, automation, extend, skip, or defer
+review_required: false
+provenance: "Extracted from Agent Foundry asset lifecycle design."
+---
+
+## Principle
+
+Within Agent Foundry, package repeated work into the smallest suitable reusable asset. A skill is one possible form, not the default.
+
+## Rationale
+
+Creating a new skill for every useful observation causes overlap and skill rot. Some repeated work is better handled as an automation, a bounded subagent, an extension of an existing asset, or a skipped/deferred candidate.
+
+## Guidance
+
+For each discovered workflow, compare:
+
+- `skill`: reusable workflow or operating guide used by the current agent.
+- `subagent`: bounded delegable role or investigation/review task.
+- `automation`: scheduled or event-driven check, report, reminder, or monitor.
+- `extend_existing`: existing asset mostly covers the need.
+- `skip`: one-off, vague, sensitive, or already sufficiently covered.
+- `defer`: promising but lacks enough evidence.
+
+Prefer the smallest form that produces the intended value with clear triggers and success criteria.
+
+For the cross-project complexity-control rule, apply [[GOV-002]]. This practice only decides the smallest suitable Agent Foundry asset form.
+
+## Watch Out For
+
+Do not create a skill when a checklist in an existing skill, a recurring automation, or a specialized subagent would be narrower and easier to maintain.
+
+## Related Practices
+
+- [[GOV-002]]
+- [[META-001]]
+- [[META-002]]
+- [[META-003]]
+- [[META-005]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-005-define-asset-boundaries-before-creation.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-005-define-asset-boundaries-before-creation.md
@@ -1,0 +1,57 @@
+---
+id: META-005
+title: Define asset boundaries before creation
+domain: meta
+type: principle
+status: active
+version: 1
+created: 2026-05-26
+updated: 2026-05-26
+tags: [assets, scope, boundaries, discovery]
+aliases:
+  - META-005
+  - define skill scope before creating it
+  - asset boundaries before asset creation
+related: [GOV-002, META-001, META-002, META-004]
+applies_when:
+  - creating or extending a reusable asset
+  - deciding skill scope
+  - preventing overlap between assets
+review_required: false
+provenance: "Extracted from Agent Foundry asset lifecycle design."
+---
+
+## Principle
+
+Before creating a reusable Agent Foundry asset, define its trigger, responsibility, non-responsibility, inputs, process, outputs, and success criteria.
+
+## Rationale
+
+Assets without explicit boundaries become broad prompt piles. Boundary definitions make assets easier to trigger, publish, review, merge, or retire.
+
+## Guidance
+
+Every asset should answer:
+
+- Trigger: when should it be used?
+- Responsibility: what does it do?
+- Non-responsibility: what does it explicitly not do?
+- Inputs: what information does it need?
+- Process: what steps or checks does it follow?
+- Outputs: what should it produce?
+- Success criteria: how do we know it helped?
+
+If these cannot be answered, defer the asset instead of creating it.
+
+For broader project mechanisms, layers, tools, or abstractions, apply [[GOV-002]] and [[ARCH-001]] before creating new machinery.
+
+## Watch Out For
+
+Avoid assets with vague triggers such as "help with engineering" or "improve code". Narrow the asset or extend an existing one.
+
+## Related Practices
+
+- [[GOV-002]]
+- [[META-001]]
+- [[META-002]]
+- [[META-004]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-006-memory-is-evidence-not-source-of-truth.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-006-memory-is-evidence-not-source-of-truth.md
@@ -1,0 +1,61 @@
+---
+id: META-006
+title: Memory is evidence, not source of truth
+domain: meta
+type: principle
+status: active
+version: 1
+created: 2026-05-26
+updated: 2026-05-26
+tags: [memory, evidence, source-of-truth, governance]
+aliases:
+  - META-006
+  - memory can suggest but foundry decides
+  - memory is not canonical
+related: [GOV-003, META-001, META-002, META-004]
+applies_when:
+  - using agent memory for discovery
+  - converting session history into practices or assets
+  - deciding what belongs in canonical records
+review_required: false
+provenance: "Extracted from Agent Foundry naming and memory boundary discussion."
+---
+
+## Principle
+
+For Agent Foundry governance, memory can suggest; canonical records decide. Agent memories, session summaries, activity logs, and rollout summaries are evidence sources, not canonical source of truth for practices, assets, adapters, or lifecycle state.
+
+## Rationale
+
+Memory is useful for discovering repeated patterns, user preferences, and usage evidence. It may also be incomplete, stale, noisy, or unreviewed. Durable practices and reusable assets require explicit governance, indexing, review, and publication.
+
+## Guidance
+
+Use memory as:
+
+- discovery evidence for repeated workflows;
+- preference evidence for candidate rules;
+- usage evidence candidates for assets.
+
+Do not use memory as the only authoritative home for:
+
+- canonical practices;
+- asset records;
+- adapter mappings;
+- approval policy;
+- lifecycle state.
+
+If a memory contains a durable rule, harvest it into `practices/`. If it indicates repeated work, process it through `discover assets`. If it records useful asset or practice use, record concise evidence through `scripts/record_asset_usage.py` so raw evidence stays local and shared review uses sanitized aggregates.
+
+For the cross-project rule that transient session context is evidence rather than durable project truth, apply [[GOV-003]].
+
+## Watch Out For
+
+Do not let automatically written memory silently override approved practices or active assets.
+
+## Related Practices
+
+- [[GOV-003]]
+- [[META-001]]
+- [[META-002]]
+- [[META-004]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-007-native-agent-learning-is-candidate-input.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-007-native-agent-learning-is-candidate-input.md
@@ -1,0 +1,62 @@
+---
+id: META-007
+title: Native agent learning is candidate input
+domain: meta
+type: principle
+status: active
+version: 1
+created: 2026-05-26
+updated: 2026-05-26
+tags: [native-learning, memory, skills, hermes, governance]
+aliases:
+  - META-007
+  - native skills can suggest but foundry canonizes
+  - do not disable native self-growth
+related: [META-001, META-003, META-006]
+applies_when:
+  - using Hermes native memory or self-improvement
+  - importing agent-native generated skills
+  - reconciling native agent learning with Agent Foundry
+review_required: false
+provenance: "Extracted from Hermes self-growth and Agent Foundry boundary discussion."
+---
+
+## Principle
+
+Native agent learning should remain enabled and useful. Agent-native memories, auto-generated skills, self-improvement artifacts, and project-local instructions are candidate inputs for Agent Foundry, not replacements for it.
+
+## Rationale
+
+Systems such as Hermes may improve themselves through memory, skill creation, and local skill refinement. Disabling those capabilities would reduce the agent's local effectiveness. The risk is not native learning itself; the risk is letting native outputs silently become durable cross-agent truth without review, dedupe, provenance, and publication control.
+
+## Guidance
+
+Allow native agent systems to:
+
+- remember local context;
+- create or refine local skills;
+- search session history;
+- suggest repeated workflows;
+- produce candidate procedures or prompts.
+
+Route durable or cross-agent outputs through Agent Foundry:
+
+- native memory finding -> `discover assets` or `harvest practices`;
+- native generated skill -> `import skill <path>`;
+- native usage insight -> `record_asset_usage.py`;
+- native workflow improvement -> proposed canonical practice or asset update.
+
+Do not deploy Agent Foundry in a way that disables Hermes memory, autonomous skill creation, or local self-improvement unless the user explicitly asks for a locked-down environment.
+
+## Watch Out For
+
+Avoid two failure modes:
+
+- bypass: native generated skills become cross-agent assets without review;
+- suppression: Agent Foundry instructions prevent a capable agent from using its native memory and self-improvement tools.
+
+## Related Practices
+
+- [[META-001]]
+- [[META-003]]
+- [[META-006]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-008-route-through-assets-constrain-with-practices.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-008-route-through-assets-constrain-with-practices.md
@@ -1,0 +1,76 @@
+---
+id: META-008
+title: Route through assets, constrain with practices
+domain: meta
+type: principle
+status: active
+version: 1
+created: 2026-05-26
+updated: 2026-05-26
+tags: [assets, practices, routing, dispatch, meta]
+aliases:
+  - META-008
+  - assets perform work, practices govern rules
+  - skill vs practice boundary
+  - invoke asset, apply practice
+related: [META-001, META-004, META-005, META-006]
+applies_when:
+  - interpreting user intent at session start
+  - deciding whether to invoke a skill or apply a rule
+  - writing or updating agent adapters
+  - discovering or creating new reusable capabilities
+review_required: false
+provenance: "Harvested from the practice vs asset boundary review on 2026-05-26."
+---
+
+## Principle
+
+Route user requests through assets; constrain execution with practices. Assets are user-facing reusable workflows. Practices are canonical behavioral rules. Do not conflate them.
+
+## Rationale
+
+When an agent treats a practice as a callable workflow, it invents unnecessary skills. When it treats an asset as a behavioral rule, it misses the structured process and success criteria the asset provides. A clear boundary prevents bloat, drift, and ambiguous responsibility.
+
+## Guidance
+
+Before acting on a request, classify it:
+
+1. **Is the user asking you to execute a repeatable workflow?**
+   - Match the request to an asset `usage_trigger`.
+   - Invoke the asset: load its inputs, process, and outputs.
+   - During execution, reference the canonical practices listed in the asset's `canonical_practices`.
+2. **Is the user asking you to behave differently or apply a constraint?**
+   - Match the request to a canonical practice in the relevant domain.
+   - Apply the practice's Principle and Guidance to your current behavior.
+   - Do not invent a new asset for a one-off behavioral correction.
+3. **Is the user asking you to update, canonize, or govern agent knowledge?**
+   - This is meta-work. Invoke the Practice Harvester asset, which itself references META practices.
+
+## Use This When
+
+- The user gives a command that could match both a short command and a general domain rule.
+- You are deciding whether to create a new skill or write a new practice.
+- You are updating an adapter and need to decide whether the content belongs in a skill body or in a rules section.
+
+## Watch Out For
+
+- Do not route a request to a practice when an active asset covers it. Practices constrain behavior; they do not own end-to-end workflows.
+- Do not invoke an asset when the user only asked for a behavioral correction. For example, "stop closing issues without comments" is a practice application (COLLAB-002), not a skill invocation.
+- Do not duplicate an asset's process into a practice entry. Assets own the workflow; practices own the rules.
+
+## Example
+
+User: `"harvest practices from this session"`
+- Classification: execute repeatable workflow → invoke asset `ASSET-META-001`
+- Asset process runs; during execution it references `META-001` (canonical practices are source of truth), `META-002` (harvest before publishing), etc.
+
+User: `"I noticed you keep choosing tools before defining boundaries. Stop doing that."`
+- Classification: behavioral correction → apply practice `ARCH-001`
+- No asset is invoked. The agent adjusts its behavior according to the principle.
+
+## Related Practices
+
+- [[META-001]]
+- [[META-004]]
+- [[META-005]]
+- [[META-006]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-009-make-adapter-fidelity-executable.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-009-make-adapter-fidelity-executable.md
@@ -1,0 +1,66 @@
+---
+id: META-009
+title: Make adapter fidelity executable
+domain: meta
+type: principle
+status: active
+version: 2
+created: 2026-05-27
+updated: 2026-05-28
+tags: [adapters, fidelity, verification, testing, publishing]
+aliases:
+  - META-009
+  - test adapter meaning, not only adapter existence
+  - executable adapter quality
+  - adapter fidelity check
+related: [META-001, META-002, META-008, RUNTIME-003]
+applies_when:
+  - publishing canonical practices into agent-specific adapters
+  - reviewing whether adapters preserve canonical intent
+  - adding support for a new agent runtime
+  - changing adapter generation or adapter quality checks
+review_required: false
+provenance: "Harvested from the adapter quality work on 2026-05-27, where file-existence checks were insufficient to prove that Codex, Claude Code, Hermes, and ChatGPT adapters preserved canonical practice semantics."
+---
+
+## Principle
+
+Adapter fidelity must be executable. Do not treat an adapter as correct just because the target file exists or was regenerated. The publish path must include checks that the adapter still carries the canonical semantics needed by that agent.
+
+## Rationale
+
+Agent adapters are lossy by default: each runtime has different instruction surfaces, length tolerance, trigger behavior, and deployment mechanics. A concise adapter can accidentally drop important constraints, while a full-fidelity adapter can become too long for the target agent to follow well. If quality remains a manual impression, drift appears only when a later agent fails to apply the intended rule.
+
+Executable checks turn adapter quality into a repeatable gate. They do not replace human review, but they catch obvious loss of meaning, missing triggers, missing asset IDs, and target-specific requirements before runtime publishing.
+
+## Guidance
+
+When publishing or reviewing adapters:
+
+1. Maintain an adapter quality checklist for each supported target.
+2. Check more than file existence:
+   - user-facing trigger phrases are present
+   - active canonical practice IDs required by the adapter profile are represented
+   - published asset IDs are represented
+   - target-specific conventions are followed
+   - high-fidelity targets retain enough detail to act correctly
+3. Run the executable adapter quality check before claiming adapters are publishable.
+4. Treat failed quality checks as adapter drift, not as cosmetic formatting issues.
+5. Update the check when adding a new adapter target or changing a target's expected instruction surface.
+
+Checks must verify the exact contract surface they claim to protect. If the requirement is "practice appears in Compact Preflight", the check must inspect the Compact Preflight section, not the entire adapter file. If the requirement is "runtime managed block is intact", the check must inspect the managed block, not only the target file's existence.
+
+## Watch Out For
+
+Do not let the check become a brittle text snapshot. It should verify durable meaning signals such as IDs, trigger vocabulary, ownership markers, and required target conventions. Exact wording may vary across adapters.
+
+Do not assume all agents need identical output. Fidelity means preserving the canonical behavior in the form the target agent can actually use.
+
+Do not accept a loose proxy when the contract surface is narrower. Broad text search can hide missing behavior when the same ID appears in references, examples, or unrelated sections.
+
+## Related Practices
+
+- [[META-001]]
+- [[META-002]]
+- [[META-008]]
+- [[RUNTIME-003]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-010-review-assets-with-lifecycle-evidence.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-010-review-assets-with-lifecycle-evidence.md
@@ -1,0 +1,65 @@
+---
+id: META-010
+title: Review assets with lifecycle evidence
+domain: meta
+type: principle
+status: active
+version: 1
+created: 2026-05-27
+updated: 2026-05-27
+tags: [assets, lifecycle, evidence, review, skill-rot]
+aliases:
+  - META-010
+  - asset lifecycle review needs evidence
+  - review assets before skill rot
+  - usage evidence drives asset lifecycle
+related: [META-004, META-005, META-008, META-009]
+applies_when:
+  - reviewing existing skills, subagents, automations, or other reusable assets
+  - deciding whether to keep, revise, deprecate, archive, split, or merge an asset
+  - detecting skill rot or stale reusable workflows
+  - adding lifecycle metadata to assets
+review_required: false
+provenance: "Harvested from the asset lifecycle work on 2026-05-27, where review needed usage evidence, overlap detection, and lifecycle states instead of informal judgment."
+---
+
+## Principle
+
+Review reusable assets with lifecycle evidence. Asset status should be based on usage, overlap, coverage, stale triggers, and verification evidence, not only on whether the asset still looks useful.
+
+## Rationale
+
+Skills, subagents, and automations rot when their triggers drift, their scope overlaps with newer assets, or their instructions stop matching the current canonical practices. Without lifecycle evidence, stale assets remain active because nobody remembers why they were created, and useful assets get rewritten because their value is not visible.
+
+Lifecycle review makes asset maintenance explicit. It gives agents a narrow way to recommend keep, revise, deprecate, archive, split, merge, or create follow-up evidence without turning every review into a broad rewrite.
+
+## Guidance
+
+When reviewing assets:
+
+1. Read the asset index and each relevant asset record.
+2. Check lifecycle state, review cadence, last usage, usage count, published targets, and canonical practice coverage.
+3. Compare assets for overlapping triggers, responsibilities, or canonical practice coverage.
+4. Recommend one lifecycle decision per asset:
+   - keep active
+   - revise
+   - deprecate
+   - archive
+   - split
+   - merge
+   - gather more evidence
+5. Prefer extending an existing asset when the new workflow shares the same trigger, responsibility, and success criteria.
+6. Prefer creating a new asset when the workflow has a distinct trigger, responsibility, user-facing output, or verification loop.
+
+## Watch Out For
+
+Do not require the user to approve routine evidence logging. Evidence should be concise, non-sensitive, and automatic when an active asset is invoked.
+
+Do not promote or remove an asset only because it has low usage. Low usage is a review signal, not an automatic lifecycle decision.
+
+## Related Practices
+
+- [[META-004]]
+- [[META-005]]
+- [[META-008]]
+- [[META-009]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-011-route-artifacts-before-abstracting-practices.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-011-route-artifacts-before-abstracting-practices.md
@@ -1,0 +1,80 @@
+---
+id: META-011
+title: Route artifacts before abstracting practices
+domain: meta
+type: heuristic
+status: active
+version: 1
+created: 2026-06-08
+updated: 2026-06-08
+tags: [harvesting, artifact-routing, practice-governance, review]
+aliases:
+  - META-011
+  - route artifacts before practices
+  - do not convert every insight into a practice
+related: [META-002, META-006, META-008, META-013]
+applies_when:
+  - running a harvest practices workflow
+  - extracting lessons from session notes or handoff dumps
+  - deciding whether a session insight belongs in practices
+review_required: false
+provenance: "Corrected harvest outcome from ChatGPT memory-system design and harvest discipline discussion; source context: docs/memory-system-handoff-dump.md."
+---
+
+## Principle
+
+In any `harvest practices` task, perform artifact routing before drafting practice candidates. Do not convert every important session insight into a practice.
+
+## Rationale
+
+The failed harvest converted important memory-system design content directly into practices without first deciding whether each item was research output, design evidence, future architecture, a project-local decision, or a generalized practice.
+
+## Guidance
+
+Before abstracting a lesson, route the source artifact into one of these classes:
+
+- evidence only;
+- design note;
+- research/reference material;
+- project-local decision;
+- workflow update;
+- practice candidate;
+- skill/asset candidate;
+- adapter update;
+- discard.
+
+Only items routed to `practice candidate` should continue through practice drafting. Items routed elsewhere may still be important, but they need a different canonical destination, review path, or no write at all.
+
+## Use This When
+
+- The user says `harvest practices`, `extract lessons`, `turn this session into foundry entries`, or equivalent.
+- A session contains a mix of research, design, user corrections, future architecture, workflow feedback, and reusable agent rules.
+
+## Watch Out For
+
+- Do not treat importance as evidence that something is a practice.
+- Do not create practice entries for research notes, domain design details, project-local decisions, or future-system concepts.
+- Do not invent destination directories or schemas during routing.
+
+## Example
+
+A memory-system design session may contain a useful taxonomy for research memos. If the current repository has no implemented research-memo substrate, route that taxonomy as design or research evidence, not as a general Agent Foundry practice.
+
+## Activation
+
+- Tier: workflow_embedded
+- Phases: harvest, import, review, before_candidate_drafting
+- Signals: harvesting mixed session content; important insights include research, design, local decisions, future architecture, or workflow feedback
+- Evidence: harvest output shows artifact routing before practice candidates are drafted
+
+## Review Notes
+
+- Human approval: approved on 2026-06-08.
+- Failure prevented: practice vault pollution by research notes, domain design details, project-local decisions, and future-system concepts.
+
+## Related Practices
+
+- [[META-002]]
+- [[META-006]]
+- [[META-008]]
+- [[META-013]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-012-treat-user-corrections-as-process-evidence-before-content-evidence.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-012-treat-user-corrections-as-process-evidence-before-content-evidence.md
@@ -1,0 +1,85 @@
+---
+id: META-012
+title: Treat user corrections as process evidence before content evidence
+domain: meta
+type: heuristic
+status: active
+version: 3
+created: 2026-06-08
+updated: 2026-06-10
+tags: [feedback-learning, corrections, harvesting, process-evidence]
+aliases:
+  - META-012
+  - user corrections are process evidence first
+  - corrections reveal workflow failures
+related: [META-002, META-006, META-011, COLLAB-005]
+applies_when:
+  - harvesting lessons from a session with user corrections
+  - reviewing an agent failure or workflow drift
+  - deciding whether correction content belongs in a domain record or process rule
+review_required: false
+provenance: "Corrected harvest outcome from ChatGPT memory-system design and harvest discipline discussion; source context: docs/memory-system-handoff-dump.md."
+---
+
+## Principle
+
+When the user corrects the agent's method, first treat the correction as evidence about the process, not merely as content inside the current domain.
+
+## Rationale
+
+The session contained user corrections about drift, loss of complexity, over-emphasis on action planning, weak generalization, and confusion between proposed and current systems. These are process failures, not merely memory-system content.
+
+## Guidance
+
+Analyze corrections for:
+
+- agent failure mode;
+- workflow weakness;
+- prompting gap;
+- review checklist gap;
+- handoff risk;
+- harvest risk;
+- approval-scope confusion;
+- generalizable practice evidence.
+
+After that process analysis, decide whether the correction also contains domain content worth routing elsewhere.
+
+When a correction points out that the agent generalized a system-specific mechanism too far, preserve the system-specific boundary before extracting any generic rule. For Agent Foundry, lifecycle mechanisms such as Core/Vault split, selected-output receipts, adapter publishing, harvest routing, and runtime install semantics belong in `meta` or `runtime` only when the practice is about Agent Foundry itself. Do not recast those mechanisms as generic architecture categories. If a broader lesson exists, restate it without Agent Foundry vocabulary, pass it through [[META-013]], and route it to `governance`, `architecture`, or another non-meta domain only after the generic trigger is clear.
+
+When the correction says the agent skipped or compressed the required workflow, do not treat a later `continue`, `approved`, or `do the whole chain` response as retroactive permission to skip the missing step. First name the process failure and restore the missing review checkpoint. Once the user approves the listed items and post-approval chain, continue through canonical mutation, checks, PR/traceability, merge/apply, and adapter/runtime publish automatically unless the implementation departs from the approved list, checks fail, risk increases, or a new unlisted runtime/global target appears.
+
+## Use This When
+
+- The user says the agent drifted, oversimplified, overbuilt, lost nuance, or confused current and proposed systems.
+- A correction changes how the agent should harvest, review, plan, or hand off work.
+- The same correction could be read as both domain content and workflow feedback.
+- The user points out that the agent over-interpreted approval, skipped harvest, published before review, or explained a missed step after the fact.
+
+## Watch Out For
+
+- Do not bury method corrections inside the domain being discussed.
+- Do not treat every correction as a new practice; route it first, then apply the generalization gate.
+- Do not confuse Agent Foundry-specific `meta` rules with generic governance or architecture rules merely because the wording sounds abstract.
+- Do not convert the user's approval of a direction into approval to bypass unshown workflow steps.
+- Do not publish adapters or runtime instructions first and then use an explanation as a substitute for the missing harvest report.
+- Do not turn the restored review checkpoint into unnecessary repeated approval when the user has already approved a complete listed chain and no escalation condition appears.
+- Do not record missed activation evidence unless a specific existing practice should have triggered.
+
+## Activation
+
+- Tier: workflow_embedded
+- Phases: harvest, review, handoff, failure_analysis
+- Signals: user correction about agent method, drift, oversimplification, overbuilding, lost nuance, or capability confusion
+- Evidence: harvest or review output names the process failure before routing any domain content
+
+## Review Notes
+
+- Human approval: approved on 2026-06-08.
+- Failure prevented: missing opportunities to improve Agent Foundry workflows because user corrections were buried as domain-specific discussion.
+
+## Related Practices
+
+- [[META-002]]
+- [[META-006]]
+- [[META-011]]
+- [[COLLAB-005]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-013-apply-generalization-gate-before-promoting-insights-into-practices.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-013-apply-generalization-gate-before-promoting-insights-into-practices.md
@@ -1,0 +1,75 @@
+---
+id: META-013
+title: Apply a generalization gate before promoting insights into practices
+domain: meta
+type: checklist
+status: active
+version: 1
+created: 2026-06-08
+updated: 2026-06-08
+tags: [harvesting, generalization, practice-governance, dedupe]
+aliases:
+  - META-013
+  - generalization gate
+  - practice candidates must generalize
+related: [META-002, META-011, META-012, GOV-003]
+applies_when:
+  - converting a session insight into a practice candidate
+  - reviewing harvest output for over-specific entries
+  - deciding whether to create, merge, defer, or reject a candidate
+review_required: false
+provenance: "Corrected harvest outcome from ChatGPT memory-system design and harvest discipline discussion; source context: docs/memory-system-handoff-dump.md."
+---
+
+## Principle
+
+A session insight must pass a generalization gate before becoming a practice candidate.
+
+## Rationale
+
+The earlier harvest generated too many memory-system-specific design points as practices. Agent Foundry practices should be reusable, reviewable, and deployable across work contexts.
+
+## Guidance
+
+Before drafting or promoting a practice candidate, ask:
+
+- Would this help in unrelated future work?
+- Would it help more than one agent or runtime?
+- Does it describe a repeatable judgment or process?
+- Can it be triggered operationally?
+- Is it independent of the current domain's vocabulary?
+- Is it more than a local design decision?
+- Can it be reviewed and maintained as a durable rule?
+
+If the answer is weak, route the item to a better artifact class, merge it into an existing entry, defer it, or list it as rejected-as-practice.
+
+## Use This When
+
+- A harvest contains many interesting but domain-specific insights.
+- A candidate depends on a future architecture that is not implemented.
+- A proposed rule sounds useful only inside the session's immediate domain vocabulary.
+
+## Watch Out For
+
+- Do not confuse "important" with "generalizable."
+- Do not create durable rules that are hard to activate or maintain.
+- Do not skip duplicate search after a candidate passes the gate.
+
+## Activation
+
+- Tier: workflow_embedded
+- Phases: harvest, import, review, candidate_drafting
+- Signals: session contains many interesting insights; a candidate depends on domain vocabulary, local decisions, or future architecture
+- Evidence: harvest output records gate results or rejected-as-practice reasons before canonical drafting
+
+## Review Notes
+
+- Human approval: approved on 2026-06-08.
+- Failure prevented: practice vault expansion with local design rules that are hard to activate or maintain.
+
+## Related Practices
+
+- [[META-002]]
+- [[META-011]]
+- [[META-012]]
+- [[GOV-003]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/RUNTIME-001-treat-agent-runtimes-as-shared-environments.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/RUNTIME-001-treat-agent-runtimes-as-shared-environments.md
@@ -1,0 +1,75 @@
+---
+id: RUNTIME-001
+title: Treat agent runtimes as shared, user-owned environments
+domain: runtime
+type: principle
+status: active
+version: 2
+created: 2026-05-26
+updated: 2026-06-11
+tags: [runtime, adapters, deployment, ownership, safety]
+aliases:
+  - RUNTIME-001
+  - do not overwrite unmanaged runtime files
+  - runtime directories are shared environments
+  - publish through managed blocks and markers
+  - do not execute canonical payloads directly
+related: [META-001, META-002, META-006, GOV-007, RUNTIME-002]
+applies_when:
+  - publishing Agent Foundry adapters into local agent runtimes
+  - installing generated skills or commands
+  - installing executable payloads from canonical assets or capability packs
+  - updating shared instruction files
+  - syncing cross-agent practices into Codex, Claude Code, Hermes, or ChatGPT
+review_required: false
+provenance: "Harvested from the runtime sync conflict review on 2026-05-26, where direct writes to ~/.claude/CLAUDE.md and unmarked Codex/Hermes skill directories exposed ownership ambiguity."
+---
+
+## Principle
+
+Treat agent runtime directories and shared configuration files as user-owned, tool-shared environments. Publish Agent Foundry content through managed blocks, namespaced files, ownership markers, backups, dry-runs, and human-approved adoption; never overwrite unmanaged runtime files by default.
+
+## Rationale
+
+Agent runtimes are not private output directories. Files such as `~/.claude/CLAUDE.md` may be edited by the user, the native agent, Agent Foundry, and other automation. Skill directories under `~/.codex/skills` or `~/.hermes/skills` look isolated, but a same-name directory can still belong to another system. Without explicit ownership boundaries, a publish step can silently erase or corrupt existing agent behavior.
+
+## Guidance
+
+Keep canonical practice entries and generated adapters inside the Agent Foundry repository. When installing into a real runtime:
+
+- Use managed include blocks or imports for central shared files.
+- Store generated runtime content in namespaced files or directories.
+- Install executable canonical payloads, such as helper scripts, into managed runtime or tool directories before execution instead of running them directly from the canonical store.
+- Mark generated skill directories with `.agent-foundry-managed`.
+- Refuse to overwrite unmarked files or directories by default.
+- Run dry-runs before writes and show destination paths.
+- Back up shared files before modifying a managed block.
+- Write or update install receipts that identify source root, selected Vault, source hash or version, destination path, and install time when executable payloads are installed.
+- Require explicit human approval before adopting an existing unmanaged runtime path.
+
+## Watch Out For
+
+Do not treat "adapter output exists" as permission to overwrite runtime state. Adapter generation describes the desired package shape; the sync layer still owns merge safety, collision detection, backup, and adoption rules.
+
+Do not treat "canonical payload exists" as permission to execute from the canonical store. Canonical records and payloads are reviewable source material; runtime install is the boundary where permissions, dependencies, executable bits, wrappers, receipts, and rollback behavior become concrete.
+
+## Example
+
+For Claude Code, write generated instructions to `~/.claude/agent-foundry/CLAUDE.md` and update only a bounded Agent Foundry import block in `~/.claude/CLAUDE.md`. For Codex or Hermes, update a skill directory only when it contains `.agent-foundry-managed`, unless the user explicitly approves adopting that directory.
+
+For a future capability pack that contains helper scripts, keep the accepted asset payload in the selected User Vault, then install a managed runtime copy under an Agent Foundry-owned tools location with a receipt. Generated runtime skills should point to the managed copy, not to an arbitrary source project or unverified pack staging directory.
+
+## Activation
+
+- Tier: always_preflight
+- Phases: before_runtime_write, before_adapter_publish, verification
+- Signals: writing into `~/.codex`, `~/.claude`, `~/.hermes`, ChatGPT project instructions, or any shared agent/runtime config; adopting an existing runtime path; executable asset or pack payload is being installed or referenced
+- Evidence: final report lists managed markers, backups, dry-run/apply behavior, install receipts, or explicit adoption for touched runtime paths
+
+## Related Practices
+
+- [[META-001]]
+- [[META-002]]
+- [[META-006]]
+- [[GOV-007]]
+- [[RUNTIME-002]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/RUNTIME-002-separate-portable-adapter-intent-from-machine-local-state.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/RUNTIME-002-separate-portable-adapter-intent-from-machine-local-state.md
@@ -1,0 +1,70 @@
+---
+id: RUNTIME-002
+title: Separate portable adapter intent from machine-local deployment state
+domain: runtime
+type: principle
+status: active
+version: 2
+created: 2026-05-26
+updated: 2026-06-11
+tags: [runtime, deployment, manifest, offline-sync, portability]
+aliases:
+  - RUNTIME-002
+  - runtime manifest is machine-local
+  - keep local deployment state out of git
+  - portable snapshots exclude local runtime state
+  - runtime tools are machine-local installs
+related: [RUNTIME-001, META-001, GOV-007]
+applies_when:
+  - designing runtime manifests
+  - syncing Agent Foundry across machines
+  - exporting portable snapshots
+  - installing adapters on a new machine
+  - installing generated runtime tools from canonical asset payloads
+review_required: false
+provenance: "Harvested from the runtime manifest redesign on 2026-05-26, where a tracked manifest risked syncing one machine's enabled targets and paths to other machines."
+---
+
+## Principle
+
+Separate portable adapter intent from machine-local deployment state. Track adapter profiles and runtime templates in the repository, but keep enabled targets, detected paths, and adoption decisions in gitignored local manifests; portable snapshots must exclude machine-local runtime state by default.
+
+## Rationale
+
+Adapter profiles answer "how should this type of agent be supported?" Runtime manifests answer "where should this machine install Agent Foundry now?" These are different facts. If a local manifest is tracked or included in portable snapshots, one machine's installed agents, paths, and adoption decisions can leak into another machine and cause wrong or unsafe deployments.
+
+## Guidance
+
+Use repository-tracked files for portable intent:
+
+- adapter profiles;
+- runtime manifest templates;
+- schemas, workflows, and install scripts.
+
+Use gitignored local files for machine-specific state:
+
+- enabled or disabled targets;
+- detected runtime paths;
+- local adoption decisions;
+- machine-specific install notes.
+- installed runtime tool copies and receipts derived from canonical asset payloads.
+
+Portable snapshots should include runtime templates but exclude local runtime manifests. New machines should initialize a local manifest from the template, detect available runtimes, and require review before enabling targets.
+
+When canonical assets contain executable payloads, keep the portable source and policy in the selected Vault, but put executable copies, wrappers, chmod state, dependency probes, and install receipts in machine-local runtime/tool state. Another machine should recreate those runtime copies through refresh/install from its selected Vault rather than inheriting paths or execution state from the original machine.
+
+## Watch Out For
+
+Do not confuse a conservative template with a detected local state. Templates should be safe defaults. Local manifests may enable targets, but that choice belongs to the current machine only.
+
+## Example
+
+Track `runtime/templates/runtime_manifest.template.yaml` in git with local targets disabled by default. Keep `runtime/local/runtime_manifest.yaml` ignored by git, and exclude it from portable snapshots. On a new machine, run `runtime_manifest.py init`, then detect, enable, configure, review, and install.
+
+For a helper-script asset, the Vault may store the accepted source payload, while `~/.agent-foundry/runtime/tools/...` stores the executable installed copy and receipt for the current machine.
+
+## Related Practices
+
+- [[RUNTIME-001]]
+- [[META-001]]
+- [[GOV-007]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/RUNTIME-003-sync-operations-must-expose-unambiguous-state.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/RUNTIME-003-sync-operations-must-expose-unambiguous-state.md
@@ -1,0 +1,95 @@
+---
+id: RUNTIME-003
+title: Sync operations must expose unambiguous state
+domain: runtime
+type: principle
+status: active
+version: 1
+created: 2026-05-27
+updated: 2026-05-27
+tags: [runtime, sync, state, git, safety, visibility]
+aliases:
+  - RUNTIME-003
+  - report exact state after every sync
+  - sync without ambiguity
+  - unambiguous final report
+  - status commands are read-only
+related: [RUNTIME-001, RUNTIME-002, COLLAB-004]
+applies_when:
+  - syncing Agent Foundry with remote repositories
+  - refreshing local runtimes after canonical changes
+  - pushing or pulling across machines
+  - reporting completion after multi-step sync workflows
+  - implementing sync status, review, compare, or report commands
+review_required: false
+provenance: "Harvested from the refresh workflow redesign on 2026-05-27, where git push failures and ambiguous local-vs-remote state led to uncertainty about whether adapters and runtimes were actually in sync."
+---
+
+## Principle
+
+Sync operations must expose unambiguous state. After every sync, report the exact commit hash, unpushed commits, runtime updates applied, and next actions required. Never leave the user guessing whether canonical files, generated adapters, and local runtimes are aligned.
+
+## Rationale
+
+Safety barriers like managed blocks and dry-runs prevent accidents, but they do not tell users whether their systems are in sync. A successful git pull does not mean adapters were regenerated. A successful adapter generation does not mean runtimes were updated. A successful runtime update does not mean changes were pushed to remote. Without explicit state reporting, users must manually infer alignment from scattered tool output, which leads to skipped steps, duplicate work, and silent drift.
+
+## Guidance
+
+After any sync or refresh workflow, produce an unambiguous Final Report that answers these questions explicitly:
+
+1. **What is the canonical state?** Report the exact commit hash after any commit.
+2. **What is the remote state?** Report whether local commits were pushed successfully, or if unpushed commits remain.
+3. **What adapters changed?** List which adapters were regenerated and why.
+4. **What runtime updates occurred?** List which runtime files were created, updated, or skipped.
+5. **What should happen next?** State the exact next action the user must take, if any.
+
+Use a structured, human-readable format. Do not rely on the user reading verbose command output. Do not report "done" when there are pending pushes or unreviewed changes.
+
+When network issues prevent push, report the failure explicitly and preserve the knowledge that unpushed commits exist. Do not silently defer or hide the issue.
+
+Status, report, check, review, and compare commands are read-only by default. If local state is missing, report that it has not been initialized and suggest the explicit initialization command. Do not create or mutate local state just to display status.
+
+## Watch Out For
+
+Do not assume that because a command succeeded, the overall sync is complete. A refresh workflow may involve git pull, conditional adapter regeneration, installation to runtimes, and git commit+push. Each step can succeed independently while the overall system remains out of sync. The Final Report is the only source of truth for the aggregate state.
+
+Do not omit the commit hash. Relative terms like "latest" or "just now" lose meaning across interruptions, compaction, or multi-machine work.
+
+Do not let a supposedly read-only status operation write machine-local manifests, sync state, usage logs, or adoption records. Read-only reporting must be safe to run repeatedly before install, after install, and on an unfamiliar machine.
+
+## Example
+
+After a refresh workflow, report:
+
+```
+Final Report
+- Commit: abc1234
+- Push: 1 commit pushed to origin/main
+- Adapters regenerated: claude-code, codex, hermes (canonical practices changed)
+- Runtime updates: claude-code managed block updated; codex skills copied; hermes skills copied
+- Next action: none
+```
+
+If push failed:
+
+```
+Final Report
+- Commit: abc1234
+- Push: FAILED (network timeout). 1 commit remains unpushed.
+- Adapters regenerated: claude-code, codex, hermes
+- Runtime updates: claude-code managed block updated; codex skills copied; hermes skills copied
+- Next action: retry push with `./sync.sh push` when network recovers
+```
+
+## Activation
+
+- Tier: always_preflight
+- Phases: after_sync, after_publish, after_install, final_report
+- Signals: git pull, git push, snapshot export/import, adapter publish, runtime install, sync status, refresh command, multi-machine handoff
+- Evidence: final report includes repo commit, unpushed commits, adapter changes, runtime updates, drift status, and exact next action
+
+## Related Practices
+
+- [[RUNTIME-001]]
+- [[RUNTIME-002]]
+- [[COLLAB-004]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/RUNTIME-004-sync-aggregates-not-raw-evidence.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/RUNTIME-004-sync-aggregates-not-raw-evidence.md
@@ -1,0 +1,70 @@
+---
+id: RUNTIME-004
+title: Sync aggregates, not raw evidence
+domain: runtime
+type: principle
+status: active
+version: 2
+created: 2026-05-27
+updated: 2026-05-28
+tags: [runtime, sync, evidence, privacy, review]
+aliases:
+  - RUNTIME-004
+  - keep raw usage local
+  - sync usage aggregates
+  - aggregate evidence across machines
+related: [RUNTIME-002, RUNTIME-003, META-006, META-010]
+applies_when:
+  - recording asset or practice usage evidence
+  - reviewing assets or practices across multiple machines
+  - exporting portable snapshots
+  - deciding what operational metadata is safe to sync
+review_required: false
+provenance: "Harvested from the multi-machine usage review design on 2026-05-27, where raw local evidence needed to stay private while review statistics needed cross-agent aggregation."
+---
+
+## Principle
+
+Sync aggregate usage statistics, not raw evidence. Raw usage logs are local audit evidence. Shared review should consume sanitized aggregate rows that can be merged across machines and agents.
+
+## Rationale
+
+Asset and practice review needs usage statistics from every machine where agents run. If usage evidence stays only local, reviews undercount active practices and assets. If raw evidence is synced directly, project names, prompts, notes, and session context can leak into remote repositories or portable snapshots.
+
+A two-layer model preserves both needs. Raw logs stay local for audit and reconstruction. Aggregates provide enough cross-machine signal for lifecycle review without copying sensitive session context.
+
+## Guidance
+
+Use two evidence layers:
+
+1. Raw local evidence:
+   - stored under gitignored local paths such as `usage/local/`;
+   - may include project, trigger, short note, agent, outcome, and date;
+   - excluded from snapshots and default remote sync.
+2. Shared aggregate evidence:
+   - stored in tracked files such as `usage/usage-aggregate.yaml`;
+   - includes subject type, subject ID, month, agent, hashed machine ID, outcome counts, and last-used date;
+   - excludes raw prompt text, project names, transcripts, and detailed notes.
+
+Review scripts should use aggregates as their primary input. Raw logs are evidence sources for local audit, migration, or aggregate rebuilds.
+
+When recording usage, update local raw evidence first, then update or rebuild the aggregate. When exporting portable snapshots, include aggregates and exclude raw local evidence.
+
+Only material applied usage belongs in shared usage aggregates. Review signals such as missed activation, suspected overbuild, noisy preflight, or "should have applied" evidence should stay in local raw evidence or a separate review channel unless explicitly summarized through an approved aggregate format. Do not let review signals inflate usage counts.
+
+## Watch Out For
+
+Do not treat aggregate counts as final truth about quality. They are review signals. Low usage means investigate, not automatically deprecate.
+
+Do not store unhashed machine names or raw session notes in shared aggregate files.
+
+Do not remove legacy logs until their useful information has been migrated or summarized.
+
+Do not rebuild aggregates from local logs without respecting evidence type. A rebuild must preserve the boundary between successful/material usage and review-only signals.
+
+## Related Practices
+
+- [[RUNTIME-002]]
+- [[RUNTIME-003]]
+- [[META-006]]
+- [[META-010]]

--- a/scripts/check_capability_pack_fixtures.py
+++ b/scripts/check_capability_pack_fixtures.py
@@ -65,9 +65,6 @@ REQUIRED_PAYLOAD_FIELDS = {
 
 FORBIDDEN_PACK_TEXT = {
     "/Users/",
-    "runtime/local",
-    "usage/local",
-    "sync/local",
     "gho_",
 }
 

--- a/scripts/test_bootstrap_pack_deployment.py
+++ b/scripts/test_bootstrap_pack_deployment.py
@@ -88,21 +88,24 @@ def main() -> int:
         errors.extend(expect("optional-pack-refused", optional_result, False, "only mandatory_bootstrap packs are supported"))
 
         deploy_result = deploy_bootstrap(vault)
-        errors.extend(expect("deploy-bootstrap", deploy_result, True, "added: 2"))
+        errors.extend(expect("deploy-bootstrap", deploy_result, True, "added: 24"))
         errors.extend(expect("deploy-bootstrap-validates", deploy_result, True, "selected Vault validated"))
         for expected in [
             vault / "practices" / "meta" / "BOOT-001-bootstrap-orientation.md",
+            vault / "practices" / "meta" / "META-001-canonical-practices-source-of-truth.md",
+            vault / "practices" / "runtime" / "RUNTIME-001-treat-agent-runtimes-as-shared-environments.md",
             vault / "assets" / "skills" / "ASSET-BOOT-001-bootstrap-status.asset.yaml",
+            vault / "assets" / "skills" / "ASSET-META-001-practice-harvester.asset.yaml",
         ]:
             if not expected.exists():
                 errors.append(f"deploy-bootstrap: expected Vault record missing: {expected}")
             else:
                 text = expected.read_text(encoding="utf-8")
                 for marker in [
-                    "provenance: \"Deployed from capability pack pack.bootstrap.minimal version 0.1.0",
+                    "provenance: \"Deployed from capability pack pack.bootstrap.minimal version 0.2.0",
                     "pack_membership",
                     "pack.bootstrap.minimal",
-                    "pack_source_version: \"0.1.0\"",
+                    "pack_source_version: \"0.2.0\"",
                 ]:
                     if marker not in text:
                         errors.append(f"deploy-bootstrap: {expected} missing deployment metadata marker {marker}")
@@ -122,15 +125,15 @@ def main() -> int:
                 "--apply",
             ]
         )
-        errors.extend(expect("publish-bootstrap-vault", publish, True, "Active practices selected: 1"))
-        errors.extend(expect("publish-bootstrap-skill", publish, True, "Active assets selected: 1"))
+        errors.extend(expect("publish-bootstrap-vault", publish, True, "Active practices selected: 22"))
+        errors.extend(expect("publish-bootstrap-skill", publish, True, "Active assets selected: 2"))
         generated_text = "\n".join(path.read_text(encoding="utf-8") for path in generated.rglob("*") if path.is_file())
-        for expected in ["BOOT-001", "ASSET-BOOT-001", "Generated from the selected Agent Foundry Vault."]:
+        for expected in ["BOOT-001", "META-001", "ASSET-BOOT-001", "ASSET-META-001", "Generated from the selected Agent Foundry Vault."]:
             if expected not in generated_text:
                 errors.append(f"publish-bootstrap-vault: generated output missing {expected}")
 
         rerun = deploy_bootstrap(vault)
-        errors.extend(expect("deploy-bootstrap-rerun-skip", rerun, True, "skipped: 2"))
+        errors.extend(expect("deploy-bootstrap-rerun-skip", rerun, True, "skipped: 24"))
         errors.extend(expect("deploy-bootstrap-rerun-no-add", rerun, True, "added: 0"))
 
         record = vault / "practices" / "meta" / "BOOT-001-bootstrap-orientation.md"


### PR DESCRIPTION
## Summary

Implements #77 by turning the bootstrap fixture from a technical two-record smoke sample into a reviewed minimal first-run capability pack snapshot.

Changes:
- Expands `pack.bootstrap.minimal` to version `0.2.0` with explicit selection review metadata.
- Includes bootstrap orientation/status records plus `ASSET-META-001` and its active meta/governance/runtime canonical practices.
- Keeps optional multi-agent, architecture, provider, product-project, raw evidence, runtime manifest, and local receipt content out of the mandatory pack.
- Updates blank Vault deployment regression coverage for the 24-record bootstrap pack.
- Narrows fixture forbidden-text scanning so design references to local lanes are not confused with private path leakage.

## Verification

- `python3 scripts/check_capability_pack_fixtures.py`
- `python3 scripts/test_bootstrap_pack_deployment.py`
- `python3 scripts/check_consistency.py`
- `python3 scripts/check_adapter_quality.py`
- `python3 scripts/check_activation.py`
- `python3 scripts/test_foundry_roots.py`
- `python3 scripts/test_adapter_quality_split.py`
- `python3 -m py_compile scripts/check_capability_pack_fixtures.py scripts/deploy_capability_pack.py scripts/test_bootstrap_pack_deployment.py`

## Review Focus

- Confirm the mandatory bootstrap content is small enough and not accidentally pulling in maintainer-only history.
- Confirm `ASSET-META-001` plus its canonical practices is the right first-run baseline for harvest/refresh.
- Confirm excluding optional multi-agent and architecture/provider packs is correct for AF5 onboarding boundaries.

This PR is for review; do not merge until Reviewer/Architect acceptance.