### PR TITLE
Add operation context preflight

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -12,6 +12,7 @@ Use these short commands in day-to-day agent work.
 | `discover assets` | `发现可打包资产` | Find repeated workflows that should become skills, subagents, automations, or extensions. |
 | `import skill <source>` | `导入这个 skill <source>` | Evaluate an external skill, repo, prompt pack, article, or local folder. |
 | `publish practices` | `发布 practices` | Publish adapters from current active practices. Usually not needed manually. |
+| `check operation context` | `检查操作上下文` | Show the current Agent Foundry Core/Vault/evidence/runtime context before writes. |
 | `review practices` | `review practices` / `检查 skill rot` | Review the practice repo for duplicates, stale entries, weak or missed activation, and adapter drift. |
 | `review assets` | `review assets` / `检查 asset rot` | Review reusable assets for usage, overlap, stale triggers, and adapter coverage. |
 | `refresh practices and assets` | `刷新practices和assets` | Pull remote updates, conditionally publish adapters, and install to local runtimes. |

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -798,7 +798,7 @@ Locator semantics:
 - `vault_markers`: markers that validate a Vault before canonical writes. Required examples include `indexes/practice_index.yaml`, `indexes/asset_index.yaml`, and `usage/usage-aggregate.yaml`.
 - `canonical_markers`: deprecated compatibility field from the single-root staging state. It may be read for old local configs, but new configs should use `core_markers` and `vault_markers`.
 
-Current capability: `scripts/foundry_config.py` writes `core_root`, `vault_root`, and `repo_root` to the same path for compatibility, but emits separate Core and Vault marker lists. This is still a single-repo staging mode until later AF-3 work teaches all commands to operate on distinct roots.
+Current capability: `scripts/foundry_config.py` records separate `core_root`, `vault_root`, and compatibility `repo_root` values, and emits separate Core and Vault marker lists. Split mode is valid when both roots validate. Same-root operation remains a compatibility path, not proof that Core and Vault are the same authority.
 
 Locator precedence:
 
@@ -813,6 +813,8 @@ Do not treat a single root found through `AGENT_FOUNDRY_HOME` or current directo
 
 Do not use a product project checkout as a Vault merely because the user is working there. Do not use a Vault as Core merely because it contains practices. Do not use Core as a Vault merely because it has templates or examples.
 
+`scripts/operation_context.py` is the current preflight guard for this boundary. It reports invocation cwd, operation type, work context, evidence root, selected Core/Vault roots, generated adapter output route, manual targets, allowed reads, allowed writes, forbidden writes, root validation, and warnings. Harvest, publish, install, refresh, and status workflows should display this context before writes or installs.
+
 Operation-to-config mapping:
 
 | Operation | Required context | Reads | Writes |
@@ -821,6 +823,7 @@ Operation-to-config mapping:
 | `harvest practices` | Product project evidence plus Foundry Core and active Vault | Evidence source, Core workflow/schema, Vault index | Vault canonical records after review |
 | `refresh practices and assets` | Core plus active Vault plus local runtime manifest | Core tooling, Vault records, runtime local manifest | runtime copies and optional sanitized aggregate |
 | `publish adapters` | Core plus active Vault | Core adapter profiles, Vault practices/assets | generated adapter outputs and runtime copies after approval |
+| Operation context preflight | current cwd plus selected Core/Vault | Core/Vault markers, runtime manifest, install receipt when relevant | no writes |
 | Foundry Core maintenance | Core | Core docs/workflows/scripts/schemas | Core repo |
 | Vault maintenance | active Vault | Vault practices/assets/indexes/usage | Vault repo |
 

--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -270,6 +270,26 @@ def check_foundry_roots_script() -> list[str]:
     return output.splitlines()
 
 
+def check_operation_context_script() -> list[str]:
+    script = ROOT / "scripts" / "test_operation_context.py"
+    if not script.exists():
+        return ["Missing scripts/test_operation_context.py"]
+    result = subprocess.run(
+        ["python3", str(script)],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode == 0:
+        return []
+    output = (result.stdout + result.stderr).strip()
+    if not output:
+        return ["Operation-context fixture failed without output"]
+    return output.splitlines()
+
+
 def parse_simple_targets(text: str) -> dict[str, dict[str, str]]:
     targets: dict[str, dict[str, str]] = {}
     current: str | None = None
@@ -584,6 +604,7 @@ def main() -> int:
     errors += check_no_deepseek_direct_adapter()
     errors += check_usage_aggregate()
     errors += check_foundry_roots_script()
+    errors += check_operation_context_script()
     errors += check_runtime_manifest()
     errors += check_claude_managed_block_integrity()
     errors += check_cross_references()

--- a/scripts/install_foundry.py
+++ b/scripts/install_foundry.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from adapter_install_receipt import write_receipt
 from foundry_config import CONFIG_PATH, parse_config, write_config
+from operation_context import print_operation_context
 from runtime_manifest import parse_targets, read_manifest
 
 
@@ -54,6 +55,7 @@ def main() -> int:
     args = parser.parse_args()
     core_root, vault_root = configured_roots(args.core_root, args.vault_root)
     adapter_root = Path(args.adapter_root).expanduser().resolve() if args.adapter_root else core_root / "adapters"
+    print_operation_context("install", core_root=core_root, vault_root=vault_root, adapter_root=adapter_root)
 
     if not args.skip_check:
         code = run(["python3", "scripts/check_consistency.py"], execute=True)

--- a/scripts/operation_context.py
+++ b/scripts/operation_context.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Report Agent Foundry operation context before writes or installs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from check_foundry_roots import validate
+from foundry_config import CONFIG_PATH, ROOT, parse_config
+from runtime_manifest import LOCAL_MANIFEST, parse_targets
+
+
+CONTEXT_PRODUCT = "product_project_evidence"
+CONTEXT_CORE = "foundry_core_maintenance"
+CONTEXT_VAULT = "foundry_vault_operation"
+CONTEXT_GENERATED = "generated_adapter_output"
+CONTEXT_RUNTIME = "runtime_install_state"
+CONTEXT_LOCAL = "local_private_state"
+
+
+def is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve().relative_to(parent.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def configured_roots(core_root_arg: str = "", vault_root_arg: str = "") -> tuple[Path, Path]:
+    data = parse_config(CONFIG_PATH)
+    core_text = core_root_arg or str(data.get("core_root", "") or ROOT)
+    vault_text = vault_root_arg or str(data.get("vault_root", "") or "")
+    core_root = Path(core_text).expanduser().resolve()
+    vault_root = Path(vault_text).expanduser().resolve() if vault_text else core_root
+    return core_root, vault_root
+
+
+def runtime_paths() -> list[Path]:
+    paths: list[Path] = []
+    targets = read_runtime_targets()
+    for config in targets.values():
+        install_path = config.get("install_path", "")
+        if install_path:
+            paths.append(Path(install_path).expanduser().resolve())
+    paths.extend(
+        [
+            Path.home() / ".codex",
+            Path.home() / ".claude",
+            Path.home() / ".hermes",
+        ]
+    )
+    unique: list[Path] = []
+    seen: set[str] = set()
+    for path in paths:
+        key = str(path)
+        if key not in seen:
+            seen.add(key)
+            unique.append(path)
+    return unique
+
+
+def nearest_generated_root(cwd: Path, adapter_root: Path | None) -> Path | None:
+    if adapter_root and adapter_root.exists() and is_relative_to(cwd, adapter_root):
+        return adapter_root.resolve()
+    for path in [cwd.resolve(), *cwd.resolve().parents]:
+        if (path / "adapter-publish-manifest.yaml").exists():
+            return path
+    return None
+
+
+def has_managed_runtime_marker(cwd: Path) -> bool:
+    for path in [cwd.resolve(), *cwd.resolve().parents]:
+        if (path / ".agent-foundry-managed").exists():
+            return True
+    return False
+
+
+def classify_context(cwd: Path, core_root: Path, vault_root: Path, adapter_root: Path | None) -> str:
+    cwd = cwd.resolve()
+    if nearest_generated_root(cwd, adapter_root):
+        return CONTEXT_GENERATED
+    if has_managed_runtime_marker(cwd):
+        return CONTEXT_RUNTIME
+    for runtime_path in runtime_paths():
+        if runtime_path.exists() and is_relative_to(cwd, runtime_path):
+            return CONTEXT_RUNTIME
+    if is_relative_to(cwd, vault_root):
+        return CONTEXT_VAULT
+    if is_relative_to(cwd, core_root):
+        return CONTEXT_CORE
+    local_root = Path.home() / ".agent-foundry"
+    if local_root.exists() and is_relative_to(cwd, local_root):
+        return CONTEXT_LOCAL
+    if ".agent-foundry" in cwd.parts:
+        return CONTEXT_LOCAL
+    return CONTEXT_PRODUCT
+
+
+def manual_targets() -> list[str]:
+    targets = read_runtime_targets()
+    return sorted(name for name, config in targets.items() if config.get("status") == "manual")
+
+
+def read_runtime_targets() -> dict[str, dict[str, str]]:
+    if not LOCAL_MANIFEST.exists():
+        return {}
+    return parse_targets(LOCAL_MANIFEST.read_text(encoding="utf-8").splitlines())
+
+
+def operation_routes(operation: str, context: str, cwd: Path, core_root: Path, vault_root: Path, adapter_root: Path) -> dict[str, list[str] | str]:
+    evidence_root = str(cwd.resolve()) if context == CONTEXT_PRODUCT else ""
+    if operation == "harvest":
+        return {
+            "evidence_root": evidence_root or "explicit evidence source required when not invoked from product project",
+            "allowed_reads": [
+                "evidence root",
+                str(core_root / "workflows"),
+                str(core_root / "schemas"),
+                str(vault_root / "indexes"),
+            ],
+            "allowed_writes": [
+                str(vault_root / "practices"),
+                str(vault_root / "assets"),
+                str(vault_root / "indexes"),
+                str(vault_root / "usage"),
+            ],
+            "forbidden_writes": [
+                "product project files unless explicitly requested",
+                "Core source files unless doing Core maintenance",
+                "generated adapter output before approval",
+                "runtime files before publish/install",
+            ],
+        }
+    if operation == "publish":
+        return {
+            "evidence_root": "",
+            "allowed_reads": [str(core_root / "adapters"), str(vault_root / "practices"), str(vault_root / "assets")],
+            "allowed_writes": [str(adapter_root)],
+            "forbidden_writes": [
+                str(core_root / "adapters"),
+                "runtime install paths",
+                "product project files",
+                "Vault canonical records",
+            ],
+        }
+    if operation in {"install", "refresh"}:
+        return {
+            "evidence_root": "",
+            "allowed_reads": [str(core_root), str(vault_root), str(adapter_root), str(core_root / "runtime/local/runtime_manifest.yaml")],
+            "allowed_writes": [
+                "managed runtime files only",
+                str(core_root / "runtime/local/adapter-install-receipt.yaml"),
+                str(CONFIG_PATH),
+            ],
+            "forbidden_writes": [
+                "unmanaged runtime files",
+                "product project files",
+                "Vault canonical records",
+                "Core source files other than machine-local runtime receipt",
+            ],
+        }
+    if operation == "status":
+        return {
+            "evidence_root": "",
+            "allowed_reads": [str(core_root), str(vault_root), "runtime manifest", "adapter install receipt"],
+            "allowed_writes": [],
+            "forbidden_writes": ["all project, Vault, Core, generated, and runtime files"],
+        }
+    if operation == "core-maintenance":
+        return {
+            "evidence_root": "",
+            "allowed_reads": [str(core_root), str(vault_root)],
+            "allowed_writes": [str(core_root)],
+            "forbidden_writes": ["Vault canonical records unless explicitly part of a harvest", "runtime files", "product project files"],
+        }
+    if operation == "vault-maintenance":
+        return {
+            "evidence_root": "",
+            "allowed_reads": [str(core_root), str(vault_root)],
+            "allowed_writes": [str(vault_root)],
+            "forbidden_writes": ["Core source files", "runtime files", "product project files"],
+        }
+    return {
+        "evidence_root": evidence_root,
+        "allowed_reads": [str(core_root), str(vault_root)],
+        "allowed_writes": [],
+        "forbidden_writes": ["unknown operation: writes require explicit contract"],
+    }
+
+
+def build_context(
+    operation: str,
+    cwd: Path | None = None,
+    core_root: Path | None = None,
+    vault_root: Path | None = None,
+    adapter_root: Path | None = None,
+) -> dict[str, Any]:
+    cwd = (cwd or Path.cwd()).expanduser().resolve()
+    core_root = (core_root or ROOT).expanduser().resolve()
+    vault_root = (vault_root or core_root).expanduser().resolve()
+    adapter_root = (adapter_root or (core_root / "adapters")).expanduser().resolve()
+    context = classify_context(cwd, core_root, vault_root, adapter_root)
+    root_errors = validate(core_root, vault_root)
+    routes = operation_routes(operation, context, cwd, core_root, vault_root, adapter_root)
+    warnings: list[str] = []
+    if context == CONTEXT_PRODUCT and operation not in {"harvest", "status"}:
+        warnings.append("invoked from product project context; writes must go only to the declared Agent Foundry targets")
+    if operation == "publish" and adapter_root == (core_root / "adapters").resolve():
+        warnings.append("publish output points at Core adapters; apply should refuse Core template overwrite")
+    if operation in {"install", "refresh"} and not (adapter_root / "adapter-publish-manifest.yaml").exists():
+        warnings.append("adapter_root has no adapter-publish-manifest.yaml; selected-output install receipt may be unavailable")
+    return {
+        "schema_version": 1,
+        "operation": operation,
+        "invocation_cwd": str(cwd),
+        "work_context": context,
+        "evidence_root": routes["evidence_root"],
+        "core_root": str(core_root),
+        "vault_root": str(vault_root),
+        "adapter_root": str(adapter_root),
+        "manual_targets": manual_targets(),
+        "allowed_reads": routes["allowed_reads"],
+        "allowed_writes": routes["allowed_writes"],
+        "forbidden_writes": routes["forbidden_writes"],
+        "root_validation": "passed" if not root_errors else "failed",
+        "root_validation_errors": root_errors,
+        "warnings": warnings,
+        "safe_to_write": not root_errors,
+    }
+
+
+def text_report(report: dict[str, Any]) -> str:
+    lines = [
+        "Agent Foundry operation context:",
+        f"operation: {report['operation']}",
+        f"work_context: {report['work_context']}",
+        f"invocation_cwd: {report['invocation_cwd']}",
+        f"evidence_root: {report['evidence_root']}",
+        f"core_root: {report['core_root']}",
+        f"vault_root: {report['vault_root']}",
+        f"adapter_root: {report['adapter_root']}",
+        f"root_validation: {report['root_validation']}",
+    ]
+    manual = report.get("manual_targets") or []
+    if manual:
+        lines.append("manual_targets: " + ", ".join(manual))
+    for key in ["allowed_reads", "allowed_writes", "forbidden_writes", "warnings", "root_validation_errors"]:
+        values = report.get(key) or []
+        lines.append(f"{key}:")
+        if not values:
+            lines.append("  - none")
+        else:
+            lines.extend(f"  - {value}" for value in values)
+    lines.append(f"safe_to_write: {'yes' if report['safe_to_write'] else 'no'}")
+    return "\n".join(lines)
+
+
+def print_operation_context(
+    operation: str,
+    cwd: Path | None = None,
+    core_root: Path | None = None,
+    vault_root: Path | None = None,
+    adapter_root: Path | None = None,
+) -> dict[str, Any]:
+    report = build_context(operation, cwd, core_root, vault_root, adapter_root)
+    print(text_report(report), flush=True)
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Report Agent Foundry operation context before writes or installs.")
+    parser.add_argument(
+        "operation",
+        choices=["harvest", "publish", "install", "refresh", "status", "core-maintenance", "vault-maintenance"],
+        help="Operation type to preflight.",
+    )
+    parser.add_argument("--cwd", default="", help="Invocation directory. Defaults to current directory.")
+    parser.add_argument("--core-root", default="", help="Agent Foundry Core root. Defaults to configured core_root.")
+    parser.add_argument("--vault-root", default="", help="Selected Agent Foundry Vault root. Defaults to configured vault_root.")
+    parser.add_argument("--adapter-root", default="", help="Generated adapter output root. Defaults to <core-root>/adapters.")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    args = parser.parse_args()
+
+    core_root, vault_root = configured_roots(args.core_root, args.vault_root)
+    adapter_root = Path(args.adapter_root).expanduser().resolve() if args.adapter_root else core_root / "adapters"
+    cwd = Path(args.cwd).expanduser().resolve() if args.cwd else Path.cwd()
+    report = build_context(args.operation, cwd, core_root, vault_root, adapter_root)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(text_report(report))
+    return 0 if report["root_validation"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/publish_adapters.py
+++ b/scripts/publish_adapters.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from check_foundry_roots import validate
 from foundry_config import ROOT
+from operation_context import configured_roots, print_operation_context
 
 
 ACTIVE_STATUSES = {"active", "revised"}
@@ -361,6 +362,7 @@ def write_generated_skill_outputs(
 
 
 def publish(core_root: Path, vault_root: Path, output_root: Path, apply: bool) -> int:
+    print_operation_context("publish", core_root=core_root, vault_root=vault_root, adapter_root=output_root)
     errors = validate(core_root, vault_root)
     if errors:
         print("Adapter publish failed root validation:")
@@ -394,14 +396,13 @@ def publish(core_root: Path, vault_root: Path, output_root: Path, apply: bool) -
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Publish adapters from a selected Agent Foundry Vault.")
-    parser.add_argument("--core-root", default=str(ROOT), help="Agent Foundry Core root.")
-    parser.add_argument("--vault-root", default=str(ROOT), help="Selected Agent Foundry Vault root.")
+    parser.add_argument("--core-root", default="", help="Agent Foundry Core root. Defaults to configured core_root.")
+    parser.add_argument("--vault-root", default="", help="Selected Agent Foundry Vault root. Defaults to configured vault_root.")
     parser.add_argument("--output-root", default="", help="Adapter output directory. Defaults to <core-root>/adapters.")
     parser.add_argument("--apply", action="store_true", help="Write files. Default is dry-run.")
     args = parser.parse_args()
 
-    core_root = Path(args.core_root).expanduser().resolve()
-    vault_root = Path(args.vault_root).expanduser().resolve()
+    core_root, vault_root = configured_roots(args.core_root, args.vault_root)
     output_root = Path(args.output_root).expanduser().resolve() if args.output_root else core_root / "adapters"
     return publish(core_root, vault_root, output_root, args.apply)
 

--- a/scripts/sync_status.py
+++ b/scripts/sync_status.py
@@ -10,6 +10,7 @@ import tarfile
 from pathlib import Path
 from adapter_install_receipt import RECEIPT_PATH, read_receipt, receipt_status, receipt_target_statuses
 from foundry_config import CONFIG_PATH, parse_config, validate as validate_config
+from operation_context import text_report, build_context
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -213,6 +214,7 @@ def runtime_drift_status() -> str:
 
 
 def main() -> int:
+    print(text_report(build_context("status", core_root=ROOT, vault_root=Path(str(parse_config(CONFIG_PATH).get("vault_root", "") or ROOT)).expanduser().resolve())))
     print(f"root: {ROOT}")
     print(f"git branch: {run_git(['branch', '--show-current'])}")
     print("git remotes:")

--- a/scripts/test_operation_context.py
+++ b/scripts/test_operation_context.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Regression fixtures for operation-context preflight."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import operation_context
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INIT = ROOT / "scripts" / "init_vault.py"
+CONTEXT = ROOT / "scripts" / "operation_context.py"
+PUBLISH = ROOT / "scripts" / "publish_adapters.py"
+INSTALL = ROOT / "scripts" / "install_foundry.py"
+STATUS = ROOT / "scripts" / "sync_status.py"
+
+
+def run(args: list[str], cwd: Path, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, *args],
+        cwd=cwd,
+        env=env,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def init_blank(vault_root: Path) -> subprocess.CompletedProcess[str]:
+    return run([str(INIT), str(vault_root), "--core-root", str(ROOT), "--apply"], ROOT)
+
+
+def context_json(operation: str, cwd: Path, vault: Path, adapter: Path) -> subprocess.CompletedProcess[str]:
+    return run(
+        [
+            str(CONTEXT),
+            operation,
+            "--cwd",
+            str(cwd),
+            "--core-root",
+            str(ROOT),
+            "--vault-root",
+            str(vault),
+            "--adapter-root",
+            str(adapter),
+            "--json",
+        ],
+        cwd,
+    )
+
+
+def expect_context(name: str, result: subprocess.CompletedProcess[str], expected: str) -> list[str]:
+    if result.returncode != 0:
+        return [f"{name}: context command failed\n{result.stdout}{result.stderr}"]
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        return [f"{name}: invalid json {exc}\n{result.stdout}"]
+    errors: list[str] = []
+    if data.get("work_context") != expected:
+        errors.append(f"{name}: expected {expected}, got {data.get('work_context')}")
+    if data.get("core_root") != str(ROOT.resolve()):
+        errors.append(f"{name}: wrong core_root {data.get('core_root')}")
+    if data.get("root_validation") != "passed":
+        errors.append(f"{name}: root validation failed {data.get('root_validation_errors')}")
+    return errors
+
+
+def expect_text(name: str, result: subprocess.CompletedProcess[str], expected: str) -> list[str]:
+    output = result.stdout + result.stderr
+    if result.returncode == 0 and expected in output:
+        print(f"{name}: ok")
+        return []
+    return [f"{name}: expected pass containing {expected!r}, got {result.returncode}\n{output}"]
+
+
+def write_locator(home: Path, core: Path, vault: Path) -> dict[str, str]:
+    config = home / ".agent-foundry" / "config.yaml"
+    config.parent.mkdir(parents=True, exist_ok=True)
+    config.write_text(
+        "\n".join(
+            [
+                "schema_version: 1",
+                f'repo_root: "{core}"',
+                f'core_root: "{core}"',
+                f'vault_root: "{vault}"',
+                "core_markers:",
+                "  - .agent-foundry-core.yaml",
+                "  - workflows/harvest-practices.md",
+                "  - schemas/practice-entry.schema.yaml",
+                "  - scripts/foundry_config.py",
+                "vault_markers:",
+                "  - .agent-foundry-vault.yaml",
+                "  - indexes/practice_index.yaml",
+                "  - indexes/asset_index.yaml",
+                "  - usage/usage-aggregate.yaml",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    return env
+
+
+def main() -> int:
+    errors: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="agent-foundry-operation-context-") as tmp:
+        base = Path(tmp)
+        vault = base / "vault"
+        product = base / "product-project"
+        generated = base / "generated-adapters"
+        runtime = base / "runtime" / "skills" / "agent-collaboration"
+        local_private = base / ".agent-foundry" / "local"
+        fake_home = base / "home"
+        for path in [product, generated, runtime, local_private]:
+            path.mkdir(parents=True)
+        (product / "README.md").write_text("# Product fixture\n", encoding="utf-8")
+        (generated / "adapter-publish-manifest.yaml").write_text("schema_version: 1\n", encoding="utf-8")
+        (runtime / ".agent-foundry-managed").write_text("managed by fixture\n", encoding="utf-8")
+
+        init = init_blank(vault)
+        errors.extend(expect_text("init-blank-vault", init, "Blank Vault initialized and validated."))
+
+        original_manifest = operation_context.LOCAL_MANIFEST
+        missing_manifest = base / "missing-runtime" / "runtime_manifest.yaml"
+        operation_context.LOCAL_MANIFEST = missing_manifest
+        try:
+            report = operation_context.build_context("status", product, ROOT.resolve(), vault.resolve(), generated.resolve())
+            if missing_manifest.exists():
+                errors.append("missing-runtime-manifest: operation context created a runtime manifest")
+            if report.get("manual_targets") != []:
+                errors.append(f"missing-runtime-manifest: expected no manual targets, got {report.get('manual_targets')}")
+        finally:
+            operation_context.LOCAL_MANIFEST = original_manifest
+
+        for name, operation, cwd, expected in [
+            ("product-harvest", "harvest", product, "product_project_evidence"),
+            ("core-status", "status", ROOT, "foundry_core_maintenance"),
+            ("vault-maintenance", "vault-maintenance", vault, "foundry_vault_operation"),
+            ("generated-publish", "publish", generated, "generated_adapter_output"),
+            ("runtime-install", "install", runtime, "runtime_install_state"),
+            ("local-private-status", "status", local_private, "local_private_state"),
+        ]:
+            errors.extend(expect_context(name, context_json(operation, cwd, vault, generated), expected))
+
+        publish = run(
+            [
+                str(PUBLISH),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(vault),
+                "--output-root",
+                str(generated),
+            ],
+            product,
+        )
+        errors.extend(expect_text("publish-context-banner", publish, "work_context: product_project_evidence"))
+        errors.extend(expect_text("publish-context-route", publish, f"allowed_writes:\n  - {generated.resolve()}"))
+
+        default_generated = base / "default-locator-generated"
+        default_env = write_locator(fake_home, ROOT.resolve(), vault.resolve())
+        default_publish = run(
+            [
+                str(PUBLISH),
+                "--output-root",
+                str(default_generated),
+            ],
+            product,
+            env=default_env,
+        )
+        errors.extend(expect_text("publish-default-locator-context", default_publish, "work_context: product_project_evidence"))
+        errors.extend(expect_text("publish-default-locator-vault", default_publish, f"vault_root: {vault.resolve()}"))
+
+        install = run(
+            [
+                str(INSTALL),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(vault),
+                "--adapter-root",
+                str(generated),
+                "--skip-check",
+                "--target",
+                "chatgpt",
+            ],
+            product,
+        )
+        errors.extend(expect_text("install-context-banner", install, "operation: install"))
+        errors.extend(expect_text("install-context-route", install, "managed runtime files only"))
+
+        status = run([str(STATUS)], product)
+        errors.extend(expect_text("status-context-banner", status, "Agent Foundry operation context:"))
+        errors.extend(expect_text("status-context-readonly", status, "operation: status"))
+
+    if errors:
+        print("Operation-context fixture failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("Operation-context fixture passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflows/check-consistency.md
+++ b/workflows/check-consistency.md
@@ -27,6 +27,7 @@ For Core/Vault root selection checks, also run:
 ```bash
 python3 scripts/foundry_config.py status
 python3 scripts/check_foundry_roots.py --core-root . --vault-root ~/.agent-foundry/vault/my-agent-foundry-vault
+python3 scripts/operation_context.py status --core-root . --vault-root ~/.agent-foundry/vault/my-agent-foundry-vault
 ```
 
 This checks:
@@ -39,11 +40,13 @@ This checks:
 - missing or corrupt Vault indexes fail with actionable messages.
 - blank Vault publishing reports nothing to publish;
 - populated Vault publishing can produce adapter outputs in a temporary output root.
+- operation-context status reports Core, selected Vault, allowed reads, and read-only forbidden writes.
 
 To exercise deterministic same-root, blank Vault, maintainer-like Vault, and failure fixtures, run:
 
 ```bash
 python3 scripts/test_foundry_roots.py
+python3 scripts/test_operation_context.py
 ```
 
 ## Manual Fallback

--- a/workflows/harvest-practices.md
+++ b/workflows/harvest-practices.md
@@ -35,6 +35,14 @@ During AF-3 compatibility mode, Core and Vault may share one root. After the phy
 
 If the Vault is locked, dirty in a conflicting way, or unavailable, produce candidate recommendations only and do not write files.
 
+Before any canonical write, display or run the operation-context preflight so nested use cannot confuse the current product project with Agent Foundry Core or the selected Vault:
+
+```bash
+python3 <core-root>/scripts/operation_context.py harvest --cwd . --core-root <core-root> --vault-root <vault-root>
+```
+
+The report must show the current project as evidence source when harvesting from another repository, Core as tooling/schema/workflow source, and the selected Vault as the canonical write target.
+
 ## 1. Current Capability Check
 
 Before routing or drafting, distinguish current repository capability from proposed or future architecture.

--- a/workflows/install-adapters.md
+++ b/workflows/install-adapters.md
@@ -59,6 +59,8 @@ runtime/local/runtime_manifest.yaml
    python3 scripts/install_foundry.py
    ```
 
+   The dry run prints an operation-context preflight. Confirm that Core, selected Vault, generated adapter output, managed runtime writes, manual targets, and forbidden writes are visible before applying.
+
 7. Apply only when destinations are correct:
 
    ```bash

--- a/workflows/publish-adapters.md
+++ b/workflows/publish-adapters.md
@@ -22,6 +22,14 @@ Example:
 python3 scripts/publish_adapters.py --core-root . --vault-root ~/.agent-foundry/vault/my-agent-foundry-vault --output-root /tmp/agent-foundry-adapters --apply
 ```
 
+The publish script prints an operation-context preflight before writing. If running the workflow manually, verify the report says:
+
+- operation: `publish`;
+- Core is the tooling/profile source;
+- Vault is the selected canonical record source;
+- allowed writes are limited to the generated adapter output root;
+- runtime install paths are forbidden until the install workflow runs.
+
 ## 1. Select Practices
 
 Publish only practices with:

--- a/workflows/refresh.md
+++ b/workflows/refresh.md
@@ -25,6 +25,14 @@ If the current working directory is inside the agent-foundry repo, use it. Other
 
 Change into the repo root before proceeding.
 
+Run a read-only operation-context preflight and keep the output in the final report:
+
+```bash
+python3 scripts/operation_context.py status
+```
+
+If the report cannot identify Core and the selected Vault, stop before pull, publish, or install. If the command is invoked from a product project, the report must show that project as evidence context only; refresh writes must stay within Core machine-local state, generated adapter output, and managed runtime targets.
+
 ---
 
 ## Step 1: Determine Local State


### PR DESCRIPTION
## Summary

Implements #89 operation-context preflight and nested-context guard.

Changes:
- Add `scripts/operation_context.py` with text and JSON output for operation context preflight.
- Classify invocation cwd as product project evidence, Foundry Core maintenance, selected Vault operation, generated adapter output, runtime install state, or local private state.
- Report evidence root, selected Core/Vault roots, generated adapter root, manual targets, allowed reads/writes, forbidden writes, warnings, and root validation.
- Print preflight context from `publish_adapters.py`, `install_foundry.py`, and `sync_status.py`.
- Add `scripts/test_operation_context.py` and wire it into `check_consistency.py`.
- Update existing workflows/docs to require/display operation context before harvest canonical writes, publish, install, refresh, and status checks.

## Verification

- `python3 scripts/check_consistency.py`
- `python3 scripts/check_adapter_quality.py --surface selected-output --generated-root '/Users/jinghuliu/.agent-foundry/generated/agent-foundry-adapters'`
- `python3 scripts/check_activation.py`
- `python3 scripts/test_operation_context.py`
- `python3 scripts/test_foundry_roots.py`
- `python3 scripts/test_bootstrap_pack_deployment.py`
- `python3 -m py_compile scripts/operation_context.py scripts/publish_adapters.py scripts/install_foundry.py scripts/sync_status.py scripts/check_consistency.py scripts/test_operation_context.py`
- `git diff --check`

## Residual Risks

- This adds preflight reporting and fixtures; it does not yet force every possible Agent Foundry command to call the preflight helper.
- Harvest remains workflow-level plus agent behavior; there is no dedicated harvest CLI to enforce preflight mechanically.
- Runtime classification uses managed markers and known runtime paths; unusual custom runtime locations still depend on explicit roots/routes.

## Review Handoff

Review target: separate Reviewer agent
Review surface: PR and issue #89
Producer role: Architect
Completion handoff: to:reviewer

Reviewer focus:
1. Confirm #89 acceptance criteria are met for nested context reporting.
2. Check that product project cwd, Core cwd, Vault cwd, generated output cwd, runtime marker cwd, and local private cwd are covered.
3. Check that publish/install/status reports are useful without creating misleading authority boundaries.
4. Check that `check_consistency.py` embedding this fixture is acceptable and not too heavy.
5. Confirm no runtime apply, Vault mutation, or private path leakage is introduced by fixtures.
