### PR TITLE
[codex] Implement fresh install status workflow

### DIFF
--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -593,6 +593,26 @@ def check_capability_pack_fixtures_script() -> list[str]:
     return output.splitlines()
 
 
+def check_bootstrap_pack_deployment_script() -> list[str]:
+    script = ROOT / "scripts" / "test_bootstrap_pack_deployment.py"
+    if not script.exists():
+        return ["Missing scripts/test_bootstrap_pack_deployment.py"]
+    result = subprocess.run(
+        ["python3", str(script)],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode == 0:
+        return []
+    output = (result.stdout + result.stderr).strip()
+    if not output:
+        return ["Bootstrap pack deployment fixture failed without output"]
+    return output.splitlines()
+
+
 def main() -> int:
     errors: list[str] = []
     errors += check_index_paths(VAULT_ROOT / "indexes" / "practice_index.yaml", VAULT_ROOT, "Practice")
@@ -613,6 +633,7 @@ def main() -> int:
     errors += check_adapter_quality_script()
     errors += check_activation_script()
     errors += check_capability_pack_fixtures_script()
+    errors += check_bootstrap_pack_deployment_script()
 
     if errors:
         print("Consistency check failed:")

--- a/scripts/install_foundry.py
+++ b/scripts/install_foundry.py
@@ -8,12 +8,18 @@ import subprocess
 from pathlib import Path
 
 from adapter_install_receipt import write_receipt
+from deploy_capability_pack import deploy as deploy_capability_pack, top_level_scalars
 from foundry_config import CONFIG_PATH, parse_config, write_config
+from init_vault import initialize
 from operation_context import print_operation_context
+from publish_adapters import publish as publish_adapters
 from runtime_manifest import parse_targets, read_manifest
+from sync_status import setup_report
 
 
 ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_BOOTSTRAP_PACK = ROOT / "fixtures" / "capability-packs" / "bootstrap-minimal"
+DEFAULT_GENERATED_ROOT = Path.home() / ".agent-foundry" / "generated" / "agent-foundry-adapters"
 
 
 def run(command: list[str], execute: bool) -> int:
@@ -44,20 +50,19 @@ def configured_roots(core_root_arg: str, vault_root_arg: str) -> tuple[Path, Pat
     return Path(core_text).expanduser().resolve(), Path(vault_text).expanduser().resolve()
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description="Install Agent Foundry adapters from runtime manifest.")
-    parser.add_argument("--apply", action="store_true", help="Write managed runtime files.")
-    parser.add_argument("--target", default="", help="Install only one target from the manifest.")
-    parser.add_argument("--skip-check", action="store_true", help="Skip consistency check.")
-    parser.add_argument("--core-root", default="", help="Core root to validate and record in the local locator.")
-    parser.add_argument("--vault-root", default="", help="Vault root to validate and record in the local locator.")
-    parser.add_argument("--adapter-root", default="", help="Adapter output root to install from. Defaults to <core-root>/adapters.")
-    args = parser.parse_args()
-    core_root, vault_root = configured_roots(args.core_root, args.vault_root)
-    adapter_root = Path(args.adapter_root).expanduser().resolve() if args.adapter_root else core_root / "adapters"
+def install(
+    *,
+    core_root: Path,
+    vault_root: Path,
+    adapter_root: Path,
+    apply: bool,
+    target: str = "",
+    skip_check: bool = False,
+    write_locator: bool = True,
+) -> int:
     print_operation_context("install", core_root=core_root, vault_root=vault_root, adapter_root=adapter_root)
 
-    if not args.skip_check:
+    if not skip_check:
         code = run(["python3", "scripts/check_consistency.py"], execute=True)
         if code != 0:
             return code
@@ -75,34 +80,141 @@ def main() -> int:
     if code != 0:
         return code
 
-    if args.apply:
+    if apply and write_locator:
         write_config(CONFIG_PATH, core_root, core_root, vault_root)
 
     targets = parse_targets(read_manifest())
-    selected = [args.target] if args.target else list(targets)
+    selected = [target] if target else list(targets)
     installed_targets: dict[str, Path] = {}
-    for target in selected:
-        if target not in targets:
-            raise SystemExit(f"Unknown target: {target}")
-        config = targets[target]
+    for selected_target in selected:
+        if selected_target not in targets:
+            raise SystemExit(f"Unknown target: {selected_target}")
+        config = targets[selected_target]
         status = config.get("status", "")
         if status == "manual":
-            print(f"\n## {target}: manual import required", flush=True)
+            print(f"\n## {selected_target}: manual import required", flush=True)
             print(f"Use adapter files under {adapter_root / 'chatgpt'} or the target's documented import path.")
             continue
         if status != "enabled":
-            print(f"\n## {target}: skipped status={status}", flush=True)
+            print(f"\n## {selected_target}: skipped status={status}", flush=True)
             continue
-        print(f"\n## {target}: {'apply' if args.apply else 'dry-run'}", flush=True)
-        code = run(sync_command(target, config.get("install_path", ""), adapter_root, args.apply), execute=True)
+        print(f"\n## {selected_target}: {'apply' if apply else 'dry-run'}", flush=True)
+        code = run(sync_command(selected_target, config.get("install_path", ""), adapter_root, apply), execute=True)
         if code != 0:
             return code
-        if args.apply:
-            installed_targets[target] = Path(config.get("install_path", "")).expanduser()
-    if args.apply and installed_targets:
+        if apply:
+            installed_targets[selected_target] = Path(config.get("install_path", "")).expanduser()
+    if apply and installed_targets:
         write_receipt(core_root=core_root, vault_root=vault_root, adapter_root=adapter_root, installed_targets=installed_targets)
         print(f"wrote adapter install receipt: {ROOT / 'runtime' / 'local' / 'adapter-install-receipt.yaml'}")
     return 0
+
+
+def has_vault_markers(vault_root: Path) -> bool:
+    return all(
+        (vault_root / marker).exists()
+        for marker in [
+            ".agent-foundry-vault.yaml",
+            "indexes/practice_index.yaml",
+            "indexes/asset_index.yaml",
+            "usage/usage-aggregate.yaml",
+        ]
+    )
+
+
+def pack_label(pack_root: Path) -> str:
+    manifest_path = pack_root / "manifest.yaml"
+    if not manifest_path.exists():
+        return str(pack_root)
+    manifest = top_level_scalars(manifest_path.read_text(encoding="utf-8"))
+    pack_id = manifest.get("pack_id", str(pack_root))
+    version = manifest.get("version", "")
+    return f"{pack_id} {version}".strip()
+
+
+def fresh_install(args: argparse.Namespace) -> int:
+    core_root = Path(args.core_root or ROOT).expanduser().resolve()
+    if not args.vault_root:
+        raise SystemExit("--vault-root is required with --fresh-install")
+    vault_root = Path(args.vault_root).expanduser().resolve()
+    adapter_root = Path(args.adapter_root).expanduser().resolve() if args.adapter_root else DEFAULT_GENERATED_ROOT
+    bootstrap_pack = Path(args.bootstrap_pack).expanduser().resolve()
+
+    print("Agent Foundry fresh install")
+    print(f"core_root: {core_root}")
+    print(f"vault_root: {vault_root}")
+    print(f"bootstrap_pack: {pack_label(bootstrap_pack)}")
+    print(f"generated_output: {adapter_root}")
+    print(f"runtime_install: {'apply' if args.runtime_apply else 'dry-run'}")
+
+    if not args.apply:
+        print("Dry-run only. Re-run with --apply to create/select the Vault, deploy bootstrap, and publish generated output.")
+        print(setup_report(core_root, vault_root, adapter_root, adapter_root / "adapter-install-receipt.yaml"))
+        return 0
+
+    if has_vault_markers(vault_root):
+        print("Selected Vault already has required markers; skipping blank Vault initialization.")
+    else:
+        initialize(vault_root, apply=True, force=args.force)
+
+    code = deploy_capability_pack(core_root, vault_root, bootstrap_pack, apply=True)
+    if code != 0:
+        return code
+
+    code = publish_adapters(core_root, vault_root, adapter_root, apply=True)
+    if code != 0:
+        return code
+
+    if not args.no_write_locator:
+        write_config(CONFIG_PATH, core_root, core_root, vault_root)
+
+    code = install(
+        core_root=core_root,
+        vault_root=vault_root,
+        adapter_root=adapter_root,
+        apply=args.runtime_apply,
+        target=args.target,
+        skip_check=args.skip_check,
+        write_locator=False,
+    )
+    if code != 0:
+        return code
+
+    receipt_path = ROOT / "runtime" / "local" / "adapter-install-receipt.yaml"
+    if not args.runtime_apply:
+        receipt_path = adapter_root / "adapter-install-receipt.yaml"
+    print(setup_report(core_root, vault_root, adapter_root, receipt_path))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Install Agent Foundry adapters from runtime manifest.")
+    parser.add_argument("--fresh-install", action="store_true", help="Run the Fresh Install setup workflow before runtime install.")
+    parser.add_argument("--apply", action="store_true", help="Write managed runtime files, or Fresh Install Vault/generated setup.")
+    parser.add_argument("--runtime-apply", action="store_true", help="With --fresh-install, write managed runtime files and receipt.")
+    parser.add_argument("--target", default="", help="Install only one target from the manifest.")
+    parser.add_argument("--skip-check", action="store_true", help="Skip consistency check.")
+    parser.add_argument("--core-root", default="", help="Core root to validate and record in the local locator.")
+    parser.add_argument("--vault-root", default="", help="Vault root to validate and record in the local locator.")
+    parser.add_argument("--adapter-root", default="", help="Adapter output root to install from. Defaults to <core-root>/adapters.")
+    parser.add_argument("--generated-root", dest="adapter_root", default="", help="Fresh Install generated adapter output root.")
+    parser.add_argument("--bootstrap-pack", default=str(DEFAULT_BOOTSTRAP_PACK), help="Mandatory bootstrap capability pack root.")
+    parser.add_argument("--force", action="store_true", help="Allow blank Vault initialization over existing marker files.")
+    parser.add_argument("--no-write-locator", action="store_true", help="With --fresh-install, do not write the machine-local locator.")
+    args = parser.parse_args()
+    if args.fresh_install:
+        return fresh_install(args)
+
+    core_root, vault_root = configured_roots(args.core_root, args.vault_root)
+    adapter_root = Path(args.adapter_root).expanduser().resolve() if args.adapter_root else core_root / "adapters"
+    return install(
+        core_root=core_root,
+        vault_root=vault_root,
+        adapter_root=adapter_root,
+        apply=args.apply,
+        target=args.target,
+        skip_check=args.skip_check,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/sync_status.py
+++ b/scripts/sync_status.py
@@ -148,7 +148,83 @@ def locator_mode() -> tuple[str, str]:
     )
 
 
-def runtime_drift_status() -> str:
+def deployed_packs(vault_root: Path) -> list[str]:
+    packs: set[str] = set()
+    for base in [vault_root / "practices", vault_root / "assets"]:
+        if not base.exists():
+            continue
+        for path in sorted(p for p in base.rglob("*") if p.is_file()):
+            text = path.read_text(encoding="utf-8")
+            if "pack.bootstrap.minimal" in text:
+                packs.add("pack.bootstrap.minimal")
+    return sorted(packs)
+
+
+def generated_output_status(adapter_root: Path) -> tuple[str, int]:
+    manifest = adapter_root / "adapter-publish-manifest.yaml"
+    if not adapter_root.exists():
+        return "missing", 0
+    files = [path for path in adapter_root.rglob("*") if path.is_file()]
+    if not manifest.exists():
+        return "missing-manifest", len(files)
+    return "ready", len(files)
+
+
+def receipt_summary(receipt_path: Path) -> list[str]:
+    receipt = read_receipt(receipt_path)
+    if receipt is None:
+        return [f"receipt: missing ({receipt_path})"]
+    state, problems = receipt_status(receipt)
+    installed = receipt.get("installed_targets", [])
+    installed_text = ", ".join(str(item) for item in installed) if isinstance(installed, list) else ""
+    lines = [
+        f"receipt: {state} ({receipt_path})",
+        f"receipt adapter_root: {receipt.get('adapter_root', '')}",
+        f"receipt installed_targets: {installed_text}",
+    ]
+    for target, (target_state, target_problems, checked) in sorted(receipt_target_statuses(receipt).items()):
+        lines.append(f"receipt target: {target} {target_state} checked={checked} problems={len(target_problems)}")
+    for problem in problems[:10]:
+        lines.append(f"receipt detail: {problem}")
+    if len(problems) > 10:
+        lines.append(f"receipt detail: ... {len(problems) - 10} more")
+    return lines
+
+
+def setup_report(core_root: Path, vault_root: Path, adapter_root: Path, receipt_path: Path = RECEIPT_PATH) -> str:
+    manifest_path = ROOT / "runtime" / "local" / "runtime_manifest.yaml"
+    targets = parse_runtime_manifest(manifest_path.read_text(encoding="utf-8")) if manifest_path.exists() else {}
+    output_state, output_count = generated_output_status(adapter_root)
+    packs = deployed_packs(vault_root)
+    lines = [
+        "Agent Foundry setup/status report",
+        text_report(build_context("status", core_root=core_root, vault_root=vault_root, adapter_root=adapter_root)),
+        "fresh install summary:",
+        f"core_root: {core_root}",
+        f"vault_root: {vault_root}",
+        f"deployed_pack: {', '.join(packs) if packs else 'none detected'}",
+        f"generated_output: {output_state} path={adapter_root} files={output_count}",
+        "runtime targets:",
+    ]
+    if not targets:
+        lines.append("- none")
+    for name, config in targets.items():
+        status = config.get("status", "")
+        path = config.get("install_path", "") or "<manual>"
+        mode = config.get("ownership_mode", "")
+        if status == "manual":
+            lines.append(f"- {name}: manual import required path={path} ownership={mode}")
+        elif status == "enabled":
+            lines.append(f"- {name}: enabled path={path} ownership={mode}")
+        else:
+            lines.append(f"- {name}: skipped status={status} path={path} ownership={mode}")
+    lines.extend(receipt_summary(receipt_path))
+    lines.append("first_usable_command: python3 scripts/sync_status.py")
+    lines.append("chatgpt_manual_import: explicit; import generated ChatGPT files manually when desired")
+    return "\n".join(lines)
+
+
+def runtime_drift_status(receipt_path: Path = RECEIPT_PATH) -> str:
     manifest_path = ROOT / "runtime" / "local" / "runtime_manifest.yaml"
     if not manifest_path.exists():
         return "no local runtime manifest"
@@ -158,7 +234,7 @@ def runtime_drift_status() -> str:
         f"mode: {mode}",
     ]
     if mode == "split":
-        receipt = read_receipt(RECEIPT_PATH)
+        receipt = read_receipt(receipt_path)
         if receipt is None:
             lines.append(f"comparison: {note}")
             lines.append("selected-output: selected-output-unknown reason=install receipt missing")
@@ -214,7 +290,22 @@ def runtime_drift_status() -> str:
 
 
 def main() -> int:
-    print(text_report(build_context("status", core_root=ROOT, vault_root=Path(str(parse_config(CONFIG_PATH).get("vault_root", "") or ROOT)).expanduser().resolve())))
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Print local Agent Foundry sync status for offline and remote workflows.")
+    parser.add_argument("--core-root", default="", help="Agent Foundry Core root. Defaults to configured core_root.")
+    parser.add_argument("--vault-root", default="", help="Selected Agent Foundry Vault root. Defaults to configured vault_root.")
+    parser.add_argument("--adapter-root", default="", help="Generated adapter output root. Defaults to <core-root>/adapters.")
+    parser.add_argument("--receipt-path", default="", help="Adapter install receipt path. Defaults to runtime/local receipt.")
+    args = parser.parse_args()
+
+    config = parse_config(CONFIG_PATH)
+    core_root = Path(args.core_root or str(config.get("core_root", "") or ROOT)).expanduser().resolve()
+    vault_root = Path(args.vault_root or str(config.get("vault_root", "") or core_root)).expanduser().resolve()
+    adapter_root = Path(args.adapter_root).expanduser().resolve() if args.adapter_root else core_root / "adapters"
+    receipt_path = Path(args.receipt_path).expanduser().resolve() if args.receipt_path else RECEIPT_PATH
+
+    print(setup_report(core_root, vault_root, adapter_root, receipt_path))
     print(f"root: {ROOT}")
     print(f"git branch: {run_git(['branch', '--show-current'])}")
     print("git remotes:")
@@ -228,7 +319,7 @@ def main() -> int:
     print("runtime manifest:")
     print(runtime_status())
     print("runtime adapter drift:")
-    print(runtime_drift_status())
+    print(runtime_drift_status(receipt_path))
     return 0
 
 

--- a/scripts/test_bootstrap_pack_deployment.py
+++ b/scripts/test_bootstrap_pack_deployment.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import tempfile
@@ -13,15 +14,17 @@ ROOT = Path(__file__).resolve().parents[1]
 CHECK = ROOT / "scripts" / "check_foundry_roots.py"
 DEPLOY = ROOT / "scripts" / "deploy_capability_pack.py"
 INIT = ROOT / "scripts" / "init_vault.py"
+INSTALL = ROOT / "scripts" / "install_foundry.py"
 PUBLISH = ROOT / "scripts" / "publish_adapters.py"
 BOOTSTRAP_PACK = ROOT / "fixtures" / "capability-packs" / "bootstrap-minimal"
 OPTIONAL_PACK = ROOT / "fixtures" / "capability-packs" / "optional-multi-agent"
 
 
-def run(args: list[str]) -> subprocess.CompletedProcess[str]:
+def run(args: list[str], env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, *args],
         cwd=ROOT,
+        env=env,
         check=False,
         text=True,
         stdout=subprocess.PIPE,
@@ -73,6 +76,52 @@ def main() -> int:
             errors.append("init-blank-vault: practice index was not blank")
         if "assets: []" not in blank_asset_index:
             errors.append("init-blank-vault: asset index was not blank")
+
+        fresh_vault = base / "fresh-vault"
+        fresh_generated = base / "fresh-generated-adapters"
+        fake_home = base / "home"
+        fake_home.mkdir()
+        fresh_env = os.environ.copy()
+        fresh_env["HOME"] = str(fake_home)
+        fresh = run(
+            [
+                str(INSTALL),
+                "--fresh-install",
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(fresh_vault),
+                "--generated-root",
+                str(fresh_generated),
+                "--apply",
+                "--skip-check",
+            ],
+            env=fresh_env,
+        )
+        errors.extend(expect("fresh-install-report", fresh, True, "Agent Foundry setup/status report"))
+        for expected in [
+            "deployed_pack: pack.bootstrap.minimal",
+            f"generated_output: ready path={fresh_generated.resolve()}",
+            "- chatgpt: manual import required",
+            "receipt: missing",
+            "first_usable_command: python3 scripts/sync_status.py",
+            "chatgpt_manual_import: explicit",
+        ]:
+            errors.extend(expect(f"fresh-install-report-{expected}", fresh, True, expected))
+        if not (fresh_generated / "adapter-publish-manifest.yaml").exists():
+            errors.append("fresh-install-report: generated adapter manifest missing")
+        locator = fake_home / ".agent-foundry" / "config.yaml"
+        if not locator.exists():
+            errors.append("fresh-install-report: temp HOME locator was not written")
+        elif str(fresh_vault.resolve()) not in locator.read_text(encoding="utf-8"):
+            errors.append("fresh-install-report: temp HOME locator did not select fresh Vault")
+        for runtime_path in [
+            fake_home / ".codex" / "skills",
+            fake_home / ".claude",
+            fake_home / ".hermes" / "skills",
+        ]:
+            if runtime_path.exists():
+                errors.append(f"fresh-install-report: runtime dry-run unexpectedly wrote {runtime_path}")
 
         optional_result = run(
             [


### PR DESCRIPTION
## Summary

Implements #78 Fresh Install command and status report on top of the existing AF5 tooling.

- Adds `scripts/install_foundry.py --fresh-install` as a narrow setup workflow that initializes/selects a Vault, deploys the mandatory bootstrap pack, publishes selected-Vault generated adapters, writes the machine-local locator when applying setup, and runs runtime install in dry-run unless `--runtime-apply` is explicit.
- Extends `scripts/sync_status.py` with a parameterized setup/status report that includes operation-context output, Core/Vault/generated roots, deployed bootstrap pack, enabled/skipped/manual runtime targets, receipt status, and first usable command.
- Keeps ChatGPT manual import explicit in install and status output.
- Extends the bootstrap fixture with a temp HOME/Vault/generated fresh-install path and includes that fixture in `check_consistency.py`.

## Verification

- `python3 -m py_compile scripts/check_consistency.py scripts/install_foundry.py scripts/sync_status.py scripts/test_bootstrap_pack_deployment.py`
- `python3 scripts/test_bootstrap_pack_deployment.py`
- `python3 scripts/test_operation_context.py`
- `python3 scripts/test_foundry_roots.py`
- `python3 scripts/test_adapter_install_receipt.py`
- `python3 scripts/check_capability_pack_fixtures.py`
- `python3 scripts/check_consistency.py`
- `python3 scripts/check_adapter_quality.py --surface selected-output --generated-root '/Users/jinghuliu/.agent-foundry/generated/agent-foundry-adapters'`
- `python3 scripts/check_activation.py`
- `git diff --check`

## Residual Risks / Reviewer Focus

- Fresh Install runtime apply remains opt-in via `--runtime-apply`; default fixture validates dry-run and missing receipt semantics rather than writing runtime files.
- Status report detects the current mandatory bootstrap pack by deployed pack marker text; this is intentionally narrow for AF5 bootstrap MVP.
- PR is scoped to mandatory bootstrap Fresh Install only; optional packs and marketplace UX remain out of scope.