### PR TITLE
Define optional multi-agent capability pack candidate

### DIFF
--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -736,6 +736,31 @@ Migration path:
 
 The Tiny IPA role-generic GitHub helpers are a validation case for this model. Tiny IPA remains the evidence source. The reusable multi-agent helper subset can become a candidate optional capability pack only after AF-5 defines pack snapshot, provenance, project-local overlay, executable payload, and runtime install boundaries.
 
+#### Optional Multi-Agent Pack Candidate Evidence
+
+Issue #79 uses the Tiny IPA `tools/agents/` helpers and companion design docs as product-project evidence for the first optional capability pack candidate. The evidence is useful because it has already exercised role-generic routing, fast label inboxes, dry-run pickup and handoff, contract parsing, and read-only audit checks in a real multi-agent project. It is not canonical Agent Foundry content by itself, and Tiny IPA must not become a hidden runtime dependency after packaging.
+
+Reusable candidate nucleus:
+
+| Candidate area | Candidate contents | Packaging stance |
+| --- | --- | --- |
+| Practices | role-generic `needs:<role>` routing, durable handoff comments, explicit Execution Contract fields, dependency-gated ready queues, dry-run before mutation, read-only audit first | Candidate or proposed Vault records after review; not active by default merely because the pack is deployed. |
+| Asset | role-generic GitHub scheduler helper set for inbox, ready queue, pickup, handoff, audit, label routing, and context summary | Candidate asset that declares permissions, dependencies, supported roles, dry-run behavior, and install boundary. |
+| Docs/templates | role routing configuration guide, Execution Contract template, pickup/handoff comment templates, reviewer/architect handoff examples | Pack docs or templates copied into the Vault/import surface as examples, not Core defaults. |
+| Scripts | `agent-inbox`, `agent-ready-queue`, `agent-pickup`, `agent-handoff`, `agent-audit`, `agent-issue-context`, `agent-pr-context`, `agent-label`, `agent-role-config`, `gh-retry`, shared role config library, and tests | Executable payload candidates only. They remain inert in the pack snapshot and require managed runtime/tool install before use. |
+| Optional overlay | Project v2 status sync, roadmap status mapping, project ids, status option ids, issue type labels, and cache paths | Project-local overlay, not reusable defaults. Omitted unless a target project explicitly configures them. |
+
+Rejected-as-pack for this candidate:
+
+- Tiny IPA's default `GH_REPO`, GitHub Project id, status field ids, status option ids, `.agent-cache` files, issue numbers, branch names, and current project-specific label/status conventions.
+- Mutating `--apply` behavior before the helper install and permission boundary is implemented.
+- Treating Project v2 as the scheduler source of truth.
+- Copying helper scripts into Core `scripts/` as platform tooling.
+- Executing helpers from Tiny IPA, pack staging, or canonical Vault payload paths after import.
+- Packaging Tiny IPA design notes as active Agent Foundry practices without a separate harvest review.
+
+The candidate pack should therefore be evaluated as a reviewed snapshot: evidence from Tiny IPA, optional public pack fixture, stage-only included records, inert executable payload declarations, no runtime install, and no private path leakage. If later implementation imports the pack, the selected User Vault owns the resulting records and payload metadata; the pack remains provenance and update-comparison evidence, not a live authority.
+
 ## Operating Context Separation
 
 Agent Foundry must remain safe when it is used inside another software project. Users and agents regularly operate in nested contexts:

--- a/fixtures/capability-packs/optional-multi-agent/manifest.yaml
+++ b/fixtures/capability-packs/optional-multi-agent/manifest.yaml
@@ -1,16 +1,67 @@
 manifest_schema_version: 1
 pack_id: pack.multi-agent.optional
 title: Optional Multi-Agent Collaboration Pack
-description: Minimal optional capability snapshot with inert helper payload metadata.
+description: Candidate optional capability snapshot for role-generic GitHub multi-agent coordination helpers.
 lifecycle_status: candidate
-version: 0.1.0
-exported_at: 2026-06-11
+version: 0.2.0
+exported_at: 2026-06-12
 distribution_type: optional_capability
-source_provenance: "Agent Foundry public Core fixture for issue #75"
+source_provenance: "Agent Foundry public Core fixture for issue #79; Tiny IPA helper work used as evidence only."
 maintainer_contact: "https://github.com/farmerhunter/agent-foundry"
 license: "repository license"
 sensitivity: public
 review_state: unreviewed
+
+pack_contract:
+  promised_use_case: "Help a project operate GitHub issues, PRs, labels, comments, and optional Project status as a lightweight multi-agent scheduler."
+  deployment_role: "optional user-selected capability after bootstrap"
+  source_authority_after_deployment: "selected User Vault records and managed runtime/tool install receipts"
+  not_runtime_authority: "pack staging, product project evidence, and Core fixture paths"
+
+evidence_sources:
+  - "Tiny IPA tools/agents helper suite"
+  - "Tiny IPA role-generic agent helper design notes"
+  - "Agent Foundry #53 executable helper boundary"
+
+candidate_contents:
+  practices:
+    - "role-generic needs:<role> routing"
+    - "durable pickup and handoff comments"
+    - "explicit Execution Contract role fields"
+    - "dependency-gated ready queues"
+    - "read-only audit before write automation"
+  assets:
+    - "role-generic GitHub scheduler helper set"
+  docs_templates:
+    - "role routing config example"
+    - "Execution Contract template"
+    - "pickup and handoff comment templates"
+  executable_payload_candidates:
+    - "agent-inbox"
+    - "agent-ready-queue"
+    - "agent-pickup"
+    - "agent-handoff"
+    - "agent-audit"
+    - "agent-issue-context"
+    - "agent-pr-context"
+    - "agent-label"
+    - "agent-role-config"
+    - "gh-retry"
+    - "role routing library and config"
+
+project_local_overlays:
+  - "GH_REPO default repository"
+  - "GitHub Project ids, field ids, and status option ids"
+  - "Roadmap Status mapping"
+  - "issue type labels and project-specific label policy"
+  - "Project cache paths"
+
+rejected_as_pack:
+  - "Tiny IPA issue numbers, branch names, Project ids, and local cache files"
+  - "Project v2 as the scheduler source of truth"
+  - "mutating apply behavior before managed helper install exists"
+  - "execution from product project paths, pack staging, or canonical Vault payload paths"
+  - "active Agent Foundry practices without separate harvest review"
 
 compatibility:
   core_schema_version_min: 1
@@ -23,8 +74,8 @@ included_records:
     kind: practice
     lifecycle_status: candidate
     path: records/practices/COLLAB-PACK-001-review-handoff.md
-    source_version: 1
-    content_sha256: "cff47b12ef1fdda1cc975433226cd4c8d10124b87d71c7feb2659f7d4aaceed9"
+    source_version: 2
+    content_sha256: "3d68186c067db71927fd4861842c8c7f446e435c1dc0f17176cfdc18222a2116"
     destination_layer: canonical_vault_record
     membership_role: optional_member
     activation_default: manual_review
@@ -33,8 +84,8 @@ included_records:
     kind: asset
     lifecycle_status: candidate
     path: records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
-    source_version: 1
-    content_sha256: "aa875a255de4818d07e8f6af38490782a990a403150e83570d006f2e622d5e51"
+    source_version: 2
+    content_sha256: "e43c1f9205a51ccf796eba87ec16dc15f9a70255ad83e31322ffdd92f9495eb4"
     destination_layer: canonical_vault_record
     membership_role: optional_member
     activation_default: manual_review
@@ -42,7 +93,7 @@ included_records:
 
 executable_payloads:
   - id: helper.review-handoff-summary
-    title: Review Handoff Summary Helper
+    title: Review Handoff Summary Helper Fixture
     lifecycle_status: candidate
     path: payloads/helpers/review_handoff_summary.py
     source_sha256: "61ebb3b134a4ce82bba92103b8033a4474688057bfbf5be68e908d8322a1b334"
@@ -51,7 +102,7 @@ executable_payloads:
     install_boundary: managed_runtime_copy_required
     permissions: [filesystem-read]
     dependencies: []
-    runtime_impact: "May read reviewed issue or PR handoff text only after managed install."
+    runtime_impact: "Fixture payload stands in for the broader helper set and may read reviewed issue or PR handoff text only after managed install."
 
 conflict_policy:
   id_collision: fail_closed

--- a/fixtures/capability-packs/optional-multi-agent/records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
+++ b/fixtures/capability-packs/optional-multi-agent/records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
@@ -1,27 +1,41 @@
 id: ASSET-COLLAB-PACK-001
-title: Review Handoff Summary Helper
+title: Role-Generic GitHub Scheduler Helper Set
 asset_type: skill
 status: candidate
-version: 1
+version: 2
 created: 2026-06-11
-updated: 2026-06-11
-purpose: Draft a concise issue and PR completion handoff from reviewed local evidence.
-responsibility: Summarize scope, verification, residual risks, and reviewer target.
-non_responsibility: Does not post comments, mutate GitHub labels, install helpers, or execute from pack staging.
+updated: 2026-06-12
+purpose: Provide reviewed helper surfaces for role-generic GitHub issue and PR coordination.
+responsibility: Support inbox, ready-queue, pickup, handoff, audit, label routing, issue context, PR context, and retry wrappers after managed install.
+non_responsibility: Does not decide product scope, override issue contracts, make Project v2 the scheduler authority, install helpers, or execute from pack staging.
 inputs:
   - issue number
   - PR number
-  - verification results
+  - role name
+  - Execution Contract text
+  - GitHub label and comment state
+  - optional project-local routing config
 process:
-  - Read provided handoff evidence.
-  - Build a concise completion summary.
-  - Leave posting and label changes to Core or GitHub workflow tooling.
+  - Read durable GitHub issue, PR, label, and comment state.
+  - Resolve role labels and completion handoff from explicit configuration and contracts.
+  - Print dry-run plans before any mutating helper behavior is allowed.
+  - Keep Project status updates optional and project-configured.
+  - Leave installation and runtime exposure to managed Agent Foundry tooling.
 outputs:
-  - Handoff summary draft
+  - role inbox report
+  - ready queue report
+  - pickup or handoff dry-run
+  - audit report
+  - issue or PR context summary
 canonical_practices:
   - COLLAB-PACK-001
 published_to: []
 usage_triggers:
-  - review handoff summary
+  - agent inbox
+  - role handoff
+  - GitHub issue scheduler
+  - multi-agent ready queue
 success_criteria:
-  - The helper can be reviewed as source without being executed from the pack snapshot.
+  - The helper set can be reviewed as source without being executed from the pack snapshot.
+  - Project-specific defaults are represented as overlays rather than reusable pack defaults.
+  - Mutating actions remain disabled until managed install, permissions, and receipts exist.

--- a/fixtures/capability-packs/optional-multi-agent/records/practices/COLLAB-PACK-001-review-handoff.md
+++ b/fixtures/capability-packs/optional-multi-agent/records/practices/COLLAB-PACK-001-review-handoff.md
@@ -1,27 +1,31 @@
 ---
 id: COLLAB-PACK-001
-title: Review Handoff Discipline
+title: Role-Generic GitHub Handoff Routing
 domain: agent-collaboration
 type: checklist
 status: candidate
-version: 1
+version: 2
 created: 2026-06-11
-updated: 2026-06-11
-tags: [multi-agent, review, handoff]
+updated: 2026-06-12
+tags: [multi-agent, review, handoff, scheduler]
 aliases: [COLLAB-PACK-001]
 review_required: true
 ---
 
 ## Principle
 
-When an Implementer hands work to a Reviewer, durable issue and PR comments must identify scope, verification, residual risks, and the expected review target.
+Multi-agent GitHub work should route through explicit role labels, durable comments, and Execution Contract fields rather than relying on transient chat history or Project board status.
 
 ## Rationale
 
-Multi-agent work loses continuity when completion evidence lives only in a chat thread.
+Multi-agent work loses continuity when completion evidence lives only in a chat thread. A project-local helper suite can make handoff faster, but the reusable rule is the role-generic coordination model: `needs:<role>` labels identify the next actor, comments preserve context, and Project status remains a visual mirror rather than the scheduler source of truth.
 
 ## Guidance
 
-- Put handoff evidence on both the issue and PR when a PR exists.
-- Include exact verification commands and outcomes.
-- Mark unresolved risks explicitly instead of implying independent review has already happened.
+- Use one primary `needs:<role>` next-action label unless the issue contract explicitly allows parallel actors.
+- Put pickup and handoff evidence on durable issue and PR surfaces when a PR exists.
+- Include scope, verification commands and outcomes, residual risks, and the expected next role.
+- Parse explicit Execution Contract fields for owner role, review role, acceptance role, dependency gates, branch strategy, and completion handoff.
+- Prefer read-only inbox, ready-queue, pickup, handoff, and audit dry-runs before write automation.
+- Keep Project status and roadmap status as mirrors or reports unless a project explicitly configures them as managed outputs.
+- Treat project-specific repository names, Project ids, branch names, issue numbers, and status mappings as overlays, not reusable pack defaults.


### PR DESCRIPTION
## Summary

Closes #79.

- Documents Tiny IPA role-generic helper work as product-project evidence for the optional multi-agent capability pack candidate.
- Expands the optional multi-agent pack fixture from a single review handoff helper into a candidate role-generic GitHub scheduler helper boundary.
- Separates reusable candidate practices/assets/docs/scripts from project-local overlays and rejected-as-pack material.
- Keeps all helper payloads inert: no runtime install, no Core script copy, no product-project dependency.

## Candidate Included Boundary

- Practices: role-generic `needs:<role>` routing, durable handoff comments, explicit Execution Contract role fields, dependency-gated ready queues, dry-run before mutation, read-only audit first.
- Asset: role-generic GitHub scheduler helper set.
- Docs/templates: role routing config, Execution Contract template, pickup/handoff comment templates.
- Script candidates: inbox, ready queue, pickup, handoff, audit, issue/PR context, label routing, role config, retry wrapper, shared role config library.

## Rejected / Overlay Boundary

- Tiny IPA repository defaults, issue numbers, branch names, Project ids, status field ids, status options, cache files, and project-specific label/status policy.
- Mutating `--apply` before managed helper install exists.
- Project v2 as source of truth.
- Execution from product project paths, pack staging, or canonical Vault payload paths.

## Verification

- `python3 scripts/operation_context.py harvest --cwd /path/to/tiny-ipa --core-root /path/to/agent-foundry --vault-root /path/to/selected-vault`
- `python3 scripts/check_capability_pack_fixtures.py`
- `python3 scripts/check_consistency.py`
- `python3 scripts/test_operation_context.py`
- `git diff --check`
- no private absolute path leakage found in the changed pack fixture

## Residual Risk

This is a candidate/proposal boundary only. It does not implement optional-pack deployment for this pack and does not install executable helpers. Runtime install remains gated by #53/#80 follow-up work.