### PR TITLE
[codex] Runtime asset import path

### DIFF
--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -613,6 +613,26 @@ def check_bootstrap_pack_deployment_script() -> list[str]:
     return output.splitlines()
 
 
+def check_runtime_import_script() -> list[str]:
+    script = ROOT / "scripts" / "test_import_runtime_assets.py"
+    if not script.exists():
+        return ["Missing scripts/test_import_runtime_assets.py"]
+    result = subprocess.run(
+        ["python3", str(script)],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode == 0:
+        return []
+    output = (result.stdout + result.stderr).strip()
+    if not output:
+        return ["Runtime import fixture failed without output"]
+    return output.splitlines()
+
+
 def main() -> int:
     errors: list[str] = []
     errors += check_index_paths(VAULT_ROOT / "indexes" / "practice_index.yaml", VAULT_ROOT, "Practice")
@@ -634,6 +654,7 @@ def main() -> int:
     errors += check_activation_script()
     errors += check_capability_pack_fixtures_script()
     errors += check_bootstrap_pack_deployment_script()
+    errors += check_runtime_import_script()
 
     if errors:
         print("Consistency check failed:")

--- a/scripts/import_runtime_assets.py
+++ b/scripts/import_runtime_assets.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Stage explicit runtime/source files as reviewed import evidence."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from operation_context import (
+    CONTEXT_CORE,
+    CONTEXT_GENERATED,
+    CONTEXT_VAULT,
+    build_context,
+    classify_context,
+    configured_roots,
+    is_relative_to,
+    text_report,
+)
+
+
+RUNTIMES = {"codex", "claude-code", "hermes", "chatgpt", "prompts", "helper-files", "other"}
+ROUTES = {
+    "practice_candidate",
+    "asset_candidate",
+    "pack_candidate",
+    "project_local_decision",
+    "design_note",
+    "discard",
+    "future_work",
+}
+TEXT_EXTENSIONS = {
+    ".cfg",
+    ".cjs",
+    ".ini",
+    ".js",
+    ".json",
+    ".jsx",
+    ".md",
+    ".mjs",
+    ".prompt",
+    ".py",
+    ".sh",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+SCRIPT_EXTENSIONS = {".cjs", ".js", ".jsx", ".mjs", ".py", ".sh", ".ts", ".tsx"}
+DEFAULT_MAX_BYTES = 200_000
+
+
+@dataclass
+class SourceRecord:
+    path: Path
+    source_context: str
+    status: str
+    routing: str
+    reason: str
+    text: str
+    size_bytes: int
+    sha256: str
+    has_script_surface: bool
+
+
+def yaml_scalar(value: object) -> str:
+    text = str(value).replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{text}"'
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9]+", "-", value).strip("-").lower()
+    return slug[:80] or "runtime-import"
+
+
+def fence_for(text: str) -> str:
+    longest = 2
+    for match in re.finditer(r"`+", text):
+        longest = max(longest, len(match.group(0)))
+    return "`" * (longest + 1)
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def looks_like_script(path: Path, text: str) -> bool:
+    if path.suffix.lower() in SCRIPT_EXTENSIONS:
+        return True
+    first_line = text.splitlines()[0] if text.splitlines() else ""
+    return first_line.startswith("#!")
+
+
+def infer_routing(path: Path, runtime: str, has_script_surface: bool, rejected: bool) -> str:
+    if rejected:
+        return "discard"
+    name = path.name.lower()
+    suffix = path.suffix.lower()
+    if has_script_surface:
+        return "asset_candidate"
+    if name in {"skill.md", "agents.md", "claude.md"}:
+        return "practice_candidate"
+    if "prompt" in name or runtime in {"chatgpt", "prompts"}:
+        return "pack_candidate"
+    if suffix in {".json", ".yaml", ".yml", ".toml"}:
+        return "design_note"
+    return "asset_candidate"
+
+
+def collect_sources(paths: list[Path], recursive: bool) -> list[Path]:
+    sources: list[Path] = []
+    seen: set[Path] = set()
+    for source in paths:
+        source = source.expanduser().resolve()
+        if source.is_file():
+            candidates = [source]
+        elif source.is_dir():
+            iterator = source.rglob("*") if recursive else source.iterdir()
+            candidates = [path.resolve() for path in iterator if path.is_file() and not path.name.startswith(".")]
+        else:
+            candidates = [source]
+        for candidate in sorted(candidates):
+            if candidate not in seen:
+                seen.add(candidate)
+                sources.append(candidate)
+    return sources
+
+
+def read_source(
+    path: Path,
+    core_root: Path,
+    vault_root: Path,
+    adapter_root: Path,
+    max_bytes: int,
+    source_runtime: str,
+    routing_override: str,
+) -> SourceRecord:
+    source_context = classify_context(path.parent if path.is_file() else path, core_root, vault_root, adapter_root)
+    if source_context in {CONTEXT_CORE, CONTEXT_VAULT, CONTEXT_GENERATED}:
+        return SourceRecord(
+            path=path,
+            source_context=source_context,
+            status="rejected",
+            routing="discard",
+            reason=f"source context {source_context} is not a runtime or evidence input",
+            text="",
+            size_bytes=0,
+            sha256="",
+            has_script_surface=False,
+        )
+    if not path.exists() or not path.is_file():
+        return SourceRecord(
+            path=path,
+            source_context=source_context,
+            status="rejected",
+            routing="discard",
+            reason="source file does not exist or is not a file",
+            text="",
+            size_bytes=0,
+            sha256="",
+            has_script_surface=False,
+        )
+
+    data = path.read_bytes()
+    digest = sha256_bytes(data)
+    if len(data) > max_bytes:
+        return SourceRecord(
+            path=path,
+            source_context=source_context,
+            status="rejected",
+            routing="discard",
+            reason=f"source file exceeds max_bytes={max_bytes}",
+            text="",
+            size_bytes=len(data),
+            sha256=digest,
+            has_script_surface=path.suffix.lower() in SCRIPT_EXTENSIONS,
+        )
+    if path.suffix.lower() not in TEXT_EXTENSIONS:
+        return SourceRecord(
+            path=path,
+            source_context=source_context,
+            status="rejected",
+            routing="discard",
+            reason=f"unsupported text extension: {path.suffix or '<none>'}",
+            text="",
+            size_bytes=len(data),
+            sha256=digest,
+            has_script_surface=False,
+        )
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        return SourceRecord(
+            path=path,
+            source_context=source_context,
+            status="rejected",
+            routing="discard",
+            reason="source file is not valid UTF-8 text",
+            text="",
+            size_bytes=len(data),
+            sha256=digest,
+            has_script_surface=False,
+        )
+
+    has_script_surface = looks_like_script(path, text)
+    routing = routing_override or infer_routing(path, source_runtime, has_script_surface, rejected=False)
+    return SourceRecord(
+        path=path,
+        source_context=source_context,
+        status="candidate",
+        routing=routing,
+        reason="explicit source path staged for human review",
+        text=text,
+        size_bytes=len(data),
+        sha256=digest,
+        has_script_surface=has_script_surface,
+    )
+
+
+def render_record(
+    record: SourceRecord,
+    source_runtime: str,
+    sensitivity: str,
+    license_status: str,
+    retrieved_at: str,
+) -> str:
+    lines = [
+        "---",
+        "schema_version: 1",
+        "record_type: runtime_import_evidence",
+        f"status: {record.status}",
+        f"source_runtime: {source_runtime}",
+        f"source_context: {record.source_context}",
+        f"source_path: {yaml_scalar(record.path)}",
+        f"source_sha256: {yaml_scalar(record.sha256)}",
+        f"source_size_bytes: {record.size_bytes}",
+        f"retrieved_at: {retrieved_at}",
+        f"license_status: {yaml_scalar(license_status)}",
+        f"sensitivity: {yaml_scalar(sensitivity)}",
+        "review_required: true",
+        f"routing_recommendation: {record.routing}",
+        f"has_script_surface: {'true' if record.has_script_surface else 'false'}",
+        "runtime_source_preserved: true",
+        "activation_performed: false",
+        "runtime_write_performed: false",
+        "---",
+        "",
+        "# Runtime Import Evidence",
+        "",
+        "## Provenance",
+        "",
+        f"- Source runtime: `{source_runtime}`",
+        f"- Source path: `{record.path}`",
+        f"- Source context: `{record.source_context}`",
+        f"- Source SHA-256: `{record.sha256}`",
+        f"- Retrieved at: `{retrieved_at}`",
+        "",
+        "## Review Routing",
+        "",
+        f"- Status: `{record.status}`",
+        f"- Recommendation: `{record.routing}`",
+        f"- Reason: {record.reason}",
+        f"- Sensitivity: `{sensitivity}`",
+        f"- License: `{license_status}`",
+        f"- Script or executable surface present: `{'yes' if record.has_script_surface else 'no'}`",
+        "",
+        "## Safety Notes",
+        "",
+        "- Imported content is review evidence only.",
+        "- Do not execute bundled scripts or helper files during review.",
+        "- Do not activate, publish, or install this content without human approval.",
+        "- Preserve the native runtime/source file.",
+    ]
+    if record.text:
+        fence = fence_for(record.text)
+        lines.extend(["", "## Source Snapshot", "", fence, record.text.rstrip("\n"), fence])
+    else:
+        lines.extend(["", "## Source Snapshot", "", f"Content omitted: {record.reason}"])
+    return "\n".join(lines) + "\n"
+
+
+def plan_records(
+    args: argparse.Namespace,
+    core_root: Path,
+    vault_root: Path,
+    adapter_root: Path,
+) -> tuple[Path, list[tuple[SourceRecord, Path, str]]]:
+    staging_root = (vault_root / "imports" / "inbox").resolve()
+    if not is_relative_to(staging_root, vault_root / "imports" / "inbox"):
+        raise SystemExit(f"Refusing staging root outside Vault imports/inbox: {staging_root}")
+
+    explicit_paths = [Path(path) for path in args.source]
+    sources = collect_sources(explicit_paths, args.recursive)
+    if not sources:
+        raise SystemExit("No source files found from explicit source paths.")
+    if len(sources) > args.max_files:
+        raise SystemExit(f"Refusing to stage {len(sources)} files; pass a narrower path or raise --max-files.")
+
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    records: list[tuple[SourceRecord, Path, str]] = []
+    used_names: set[str] = set()
+    for source in sources:
+        record = read_source(
+            source,
+            core_root,
+            vault_root,
+            adapter_root,
+            args.max_bytes,
+            args.source_runtime,
+            args.routing or "",
+        )
+        slug = slugify(f"{args.source_runtime}-{source.stem}-{record.sha256[:10] or record.status}")
+        name = f"runtime-import-{now[:10]}-{slug}.md"
+        counter = 2
+        while name in used_names:
+            name = f"runtime-import-{now[:10]}-{slug}-{counter}.md"
+            counter += 1
+        used_names.add(name)
+        content = render_record(record, args.source_runtime, args.sensitivity, args.license, now)
+        records.append((record, staging_root / name, content))
+    return staging_root, records
+
+
+def parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Stage explicit runtime/source paths as import evidence.")
+    parser.add_argument("--source", action="append", required=True, help="Explicit runtime/source file or directory.")
+    parser.add_argument("--source-runtime", required=True, choices=sorted(RUNTIMES), help="Runtime or source family.")
+    parser.add_argument("--routing", choices=sorted(ROUTES), default="", help="Override routing recommendation.")
+    parser.add_argument("--sensitivity", default="unknown-review-required", help="Sensitivity review status.")
+    parser.add_argument("--license", default="unknown-review-required", help="License review status.")
+    parser.add_argument("--core-root", default="", help="Agent Foundry Core root.")
+    parser.add_argument("--vault-root", default="", help="Selected Vault root. Writes go to imports/inbox only.")
+    parser.add_argument("--adapter-root", default="", help="Generated adapter output root.")
+    parser.add_argument("--recursive", action="store_true", help="Read files recursively under explicit directories.")
+    parser.add_argument("--max-files", type=int, default=20, help="Maximum source files to stage.")
+    parser.add_argument("--max-bytes", type=int, default=DEFAULT_MAX_BYTES, help="Maximum bytes copied per source file.")
+    parser.add_argument("--apply", action="store_true", help="Write staged records. Default is dry-run.")
+    parser.add_argument("--quiet-context", action="store_true", help="Do not print operation context report.")
+    return parser
+
+
+def main() -> int:
+    args = parser().parse_args()
+    core_root, vault_root = configured_roots(args.core_root, args.vault_root)
+    adapter_root = Path(args.adapter_root).expanduser().resolve() if args.adapter_root else core_root / "adapters"
+    context = build_context("import", Path.cwd(), core_root, vault_root, adapter_root)
+    if not args.quiet_context:
+        print(text_report(context))
+    if context["root_validation"] != "passed":
+        print("Refusing import staging because Core/Vault root validation failed.", file=sys.stderr)
+        return 1
+
+    staging_root, records = plan_records(args, core_root, vault_root, adapter_root)
+    print(f"{'write' if args.apply else 'would write'} staging root: {staging_root}")
+    for record, output_path, content in records:
+        print(f"{'write' if args.apply else 'would write'}: {output_path}")
+        print(f"  source: {record.path}")
+        print(f"  status: {record.status}")
+        print(f"  routing: {record.routing}")
+        print(f"  reason: {record.reason}")
+        if args.apply:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(content, encoding="utf-8")
+    if not args.apply:
+        print("Dry-run only. Re-run with --apply to stage records.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/operation_context.py
+++ b/scripts/operation_context.py
@@ -146,6 +146,27 @@ def operation_routes(operation: str, context: str, cwd: Path, core_root: Path, v
                 "Vault canonical records",
             ],
         }
+    if operation == "import":
+        return {
+            "evidence_root": "explicit runtime/source paths only",
+            "allowed_reads": [
+                "explicit runtime/source paths",
+                str(core_root / "workflows" / "import-external-skills.md"),
+                str(core_root / "workflows" / "discover-assets.md"),
+                str(core_root / "schemas" / "asset-candidate.schema.yaml"),
+                str(vault_root / "indexes"),
+            ],
+            "allowed_writes": [str(vault_root / "imports" / "inbox")],
+            "forbidden_writes": [
+                "runtime source files",
+                "runtime adapter install paths",
+                str(core_root / "adapters"),
+                str(vault_root / "practices"),
+                str(vault_root / "assets"),
+                str(vault_root / "indexes"),
+                "generated adapter output",
+            ],
+        }
     if operation in {"install", "refresh"}:
         return {
             "evidence_root": "",
@@ -206,7 +227,7 @@ def build_context(
     root_errors = validate(core_root, vault_root)
     routes = operation_routes(operation, context, cwd, core_root, vault_root, adapter_root)
     warnings: list[str] = []
-    if context == CONTEXT_PRODUCT and operation not in {"harvest", "status"}:
+    if context == CONTEXT_PRODUCT and operation not in {"harvest", "import", "status"}:
         warnings.append("invoked from product project context; writes must go only to the declared Agent Foundry targets")
     if operation == "publish" and adapter_root == (core_root / "adapters").resolve():
         warnings.append("publish output points at Core adapters; apply should refuse Core template overwrite")
@@ -274,7 +295,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Report Agent Foundry operation context before writes or installs.")
     parser.add_argument(
         "operation",
-        choices=["harvest", "publish", "install", "refresh", "status", "core-maintenance", "vault-maintenance"],
+        choices=["harvest", "import", "publish", "install", "refresh", "status", "core-maintenance", "vault-maintenance"],
         help="Operation type to preflight.",
     )
     parser.add_argument("--cwd", default="", help="Invocation directory. Defaults to current directory.")

--- a/scripts/test_import_runtime_assets.py
+++ b/scripts/test_import_runtime_assets.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Regression fixtures for runtime import staging."""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INIT = ROOT / "scripts" / "init_vault.py"
+IMPORT = ROOT / "scripts" / "import_runtime_assets.py"
+
+
+def run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, *args],
+        cwd=cwd,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def digest_tree(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+    digests: dict[str, str] = {}
+    for file_path in sorted(p for p in path.rglob("*") if p.is_file()):
+        rel = str(file_path.relative_to(path))
+        digests[rel] = hashlib.sha256(file_path.read_bytes()).hexdigest()
+    return digests
+
+
+def expect_contains(name: str, result: subprocess.CompletedProcess[str], expected: str) -> list[str]:
+    output = result.stdout + result.stderr
+    if result.returncode == 0 and expected in output:
+        print(f"{name}: ok")
+        return []
+    return [f"{name}: expected pass containing {expected!r}, got {result.returncode}\n{output}"]
+
+
+def init_blank(vault_root: Path) -> subprocess.CompletedProcess[str]:
+    return run([str(INIT), str(vault_root), "--core-root", str(ROOT), "--apply"], ROOT)
+
+
+def main() -> int:
+    errors: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="agent-foundry-runtime-import-") as tmp:
+        base = Path(tmp)
+        vault = base / "vault"
+        runtime = base / "runtime" / "codex" / "skills" / "sample-skill"
+        generated = base / "generated-adapters"
+        runtime.mkdir(parents=True)
+        generated.mkdir(parents=True)
+        (runtime / ".agent-foundry-managed").write_text("managed fixture\n", encoding="utf-8")
+        (generated / "adapter-publish-manifest.yaml").write_text("schema_version: 1\n", encoding="utf-8")
+        skill = runtime / "SKILL.md"
+        helper = runtime / "helper.py"
+        write(
+            skill,
+            "\n".join(
+                [
+                    "---",
+                    "name: sample-skill",
+                    "---",
+                    "",
+                    "# Sample Skill",
+                    "",
+                    "Use this as review evidence only.",
+                    "",
+                ]
+            ),
+        )
+        write(helper, "#!/usr/bin/env python3\nprint('not executed by import staging')\n")
+
+        init = init_blank(vault)
+        errors.extend(expect_contains("init-temp-vault", init, "Blank Vault initialized and validated."))
+
+        source_before = digest_tree(runtime)
+        vault_canonical_before = digest_tree(vault / "practices") | digest_tree(vault / "assets")
+        adapter_before = digest_tree(generated)
+
+        dry_run = run(
+            [
+                str(IMPORT),
+                "--source",
+                str(runtime),
+                "--source-runtime",
+                "codex",
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(vault),
+                "--adapter-root",
+                str(generated),
+                "--quiet-context",
+            ],
+            ROOT,
+        )
+        errors.extend(expect_contains("dry-run", dry_run, "Dry-run only. Re-run with --apply to stage records."))
+        if list((vault / "imports" / "inbox").glob("runtime-import-*.md")):
+            errors.append("dry-run: unexpectedly wrote import records")
+
+        apply = run(
+            [
+                str(IMPORT),
+                "--source",
+                str(runtime),
+                "--source-runtime",
+                "codex",
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(vault),
+                "--adapter-root",
+                str(generated),
+                "--apply",
+                "--quiet-context",
+            ],
+            ROOT,
+        )
+        errors.extend(expect_contains("apply", apply, "write staging root:"))
+        staged = sorted((vault / "imports" / "inbox").glob("runtime-import-*.md"))
+        if len(staged) != 2:
+            errors.append(f"apply: expected 2 staged records, got {len(staged)}")
+        combined = "\n".join(path.read_text(encoding="utf-8") for path in staged)
+        for expected in [
+            "record_type: runtime_import_evidence",
+            "source_runtime: codex",
+            "source_context: runtime_install_state",
+            "license_status: \"unknown-review-required\"",
+            "sensitivity: \"unknown-review-required\"",
+            "review_required: true",
+            "activation_performed: false",
+            "runtime_write_performed: false",
+            "routing_recommendation: practice_candidate",
+            "routing_recommendation: asset_candidate",
+            "Script or executable surface present: `yes`",
+        ]:
+            if expected not in combined:
+                errors.append(f"apply: staged record missing {expected!r}")
+        if "print('not executed by import staging')" not in combined:
+            errors.append("apply: helper source snapshot missing from staged evidence")
+        if digest_tree(runtime) != source_before:
+            errors.append("apply: runtime source tree changed")
+        if digest_tree(vault / "practices") | digest_tree(vault / "assets") != vault_canonical_before:
+            errors.append("apply: canonical Vault practices/assets changed")
+        if digest_tree(generated) != adapter_before:
+            errors.append("apply: generated adapter output changed")
+
+        core_source = run(
+            [
+                str(IMPORT),
+                "--source",
+                str(ROOT / "workflows" / "import-external-skills.md"),
+                "--source-runtime",
+                "codex",
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(vault),
+                "--adapter-root",
+                str(generated),
+                "--quiet-context",
+            ],
+            ROOT,
+        )
+        errors.extend(expect_contains("core-source-dry-run", core_source, "source context foundry_core_maintenance"))
+        core_apply = run(
+            [
+                str(IMPORT),
+                "--source",
+                str(ROOT / "workflows" / "import-external-skills.md"),
+                "--source-runtime",
+                "codex",
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(vault),
+                "--adapter-root",
+                str(generated),
+                "--apply",
+                "--quiet-context",
+            ],
+            ROOT,
+        )
+        errors.extend(expect_contains("core-source-apply", core_apply, "status: rejected"))
+
+        missing = run(
+            [
+                str(IMPORT),
+                "--source",
+                str(base / "missing.md"),
+                "--source-runtime",
+                "codex",
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(vault),
+                "--adapter-root",
+                str(generated),
+                "--quiet-context",
+            ],
+            ROOT,
+        )
+        errors.extend(expect_contains("missing-source", missing, "source file does not exist or is not a file"))
+
+    if errors:
+        print("Runtime import fixture failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("Runtime import fixture passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_operation_context.py
+++ b/scripts/test_operation_context.py
@@ -144,6 +144,7 @@ def main() -> int:
 
         for name, operation, cwd, expected in [
             ("product-harvest", "harvest", product, "product_project_evidence"),
+            ("runtime-import", "import", runtime, "runtime_install_state"),
             ("core-status", "status", ROOT, "foundry_core_maintenance"),
             ("vault-maintenance", "vault-maintenance", vault, "foundry_vault_operation"),
             ("generated-publish", "publish", generated, "generated_adapter_output"),

--- a/workflows/import-external-skills.md
+++ b/workflows/import-external-skills.md
@@ -23,6 +23,16 @@ Record:
 
 If a staged import file is needed, place it under `imports/inbox/` with a concise provenance header.
 
+For existing runtime or local source material, prefer the Core staging helper with explicit paths:
+
+```text
+python3 scripts/import_runtime_assets.py --source <explicit-path> --source-runtime <codex|claude-code|hermes|chatgpt|prompts|helper-files|other> --vault-root <vault-root>
+```
+
+Default behavior is dry-run. Use `--apply` only after confirming the operation context and target Vault/import inbox. Directories are explicit inputs; recursive directory reads require `--recursive`. Do not scan broad private runtime trees by default.
+
+The staging helper writes review evidence only under `imports/inbox/`. It must preserve source runtime files, avoid adapter writes, avoid canonical practice/asset activation, and never execute imported helper scripts.
+
 ## 2. License and Security Review
 
 Check:


### PR DESCRIPTION
## Summary

Refs #80.

- Add `scripts/import_runtime_assets.py` to stage explicit runtime/source paths as review evidence under `<vault>/imports/inbox`.
- Add `import` operation-context routing that distinguishes runtime/source evidence from Core, selected Vault, generated adapter output, and runtime install state before reads/writes.
- Update the external skill import workflow with the runtime staging helper and add regression coverage proving dry-run behavior, source preservation, no activation, no adapter writes, and no canonical Vault mutation.

## Verification

- `python3 scripts/test_import_runtime_assets.py`
- `python3 scripts/check_consistency.py`
- `python3 -m py_compile scripts/import_runtime_assets.py scripts/test_import_runtime_assets.py scripts/operation_context.py scripts/test_operation_context.py scripts/check_consistency.py`
- `git diff --check`

## Residual Risks / Reviewer Focus

- Routing recommendations are intentionally conservative heuristics; reviewer should check whether the route labels fit Architect expectations.
- Directory handling is explicit and bounded, with recursive reads opt-in via `--recursive`; reviewer should check whether the default file allowlist is appropriately narrow.
- Staging records include source snapshots for UTF-8 text/helper files but never execute them; reviewer should focus on evidence metadata sufficiency and privacy posture.