### PR TITLE
[codex] Review cross-machine restore and rollback onboarding

### DIFF
--- a/scripts/test_bootstrap_pack_deployment.py
+++ b/scripts/test_bootstrap_pack_deployment.py
@@ -3,12 +3,15 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
 
+import rollback_runtime
+import runtime_manifest
 
 ROOT = Path(__file__).resolve().parents[1]
 CHECK = ROOT / "scripts" / "check_foundry_roots.py"
@@ -60,6 +63,118 @@ def deploy_bootstrap(vault_root: Path) -> subprocess.CompletedProcess[str]:
             "--apply",
         ]
     )
+
+
+def tree_digest(root: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        digest.update(str(path.relative_to(root)).encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def exercise_restore_rollback_boundaries(base: Path, vault: Path) -> list[str]:
+    errors: list[str] = []
+    user_record = vault / "practices" / "user" / "USER-001-local-user-record.md"
+    user_record.parent.mkdir(parents=True, exist_ok=True)
+    user_record.write_text(
+        "\n".join(
+            [
+                "---",
+                'id: "USER-001"',
+                'title: "Local user record fixture"',
+                'status: "active"',
+                "---",
+                "",
+                "This fixture must survive runtime disable and rollback simulation.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    before_vault = tree_digest(vault)
+
+    original_manifest = runtime_manifest.LOCAL_MANIFEST
+    temp_manifest = base / "runtime-local" / "runtime_manifest.yaml"
+    runtime_manifest.LOCAL_MANIFEST = temp_manifest
+    try:
+        runtime_manifest.ensure_local_manifest()
+        runtime_manifest.set_target_status("codex", "enabled")
+        runtime_manifest.set_target_path("codex", str(base / "runtime" / "codex-skills"))
+        runtime_manifest.set_target_status("codex", "disabled")
+        targets = runtime_manifest.parse_targets(runtime_manifest.read_manifest())
+        if targets.get("codex", {}).get("status") != "disabled":
+            errors.append("runtime-disable: temp manifest did not disable codex")
+        if not temp_manifest.exists():
+            errors.append("runtime-disable: temp manifest missing")
+    finally:
+        runtime_manifest.LOCAL_MANIFEST = original_manifest
+
+    fake_claude = base / "runtime" / "claude" / "CLAUDE.md"
+    fake_claude.parent.mkdir(parents=True, exist_ok=True)
+    fake_claude.write_text(
+        "\n".join(
+            [
+                "User-owned Claude notes.",
+                rollback_runtime.CLAUDE_INCLUDE_START,
+                "# Agent Foundry managed instructions",
+                "@managed/CLAUDE.md",
+                rollback_runtime.CLAUDE_INCLUDE_END,
+                "User-owned footer.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    codex_root = base / "runtime" / "codex-skills"
+    managed_skill = codex_root / "pack-sourced-skill"
+    unmanaged_skill = codex_root / "user-owned-skill"
+    (managed_skill / ".agent-foundry-managed").parent.mkdir(parents=True, exist_ok=True)
+    (managed_skill / ".agent-foundry-managed").write_text("managed-by: agent-foundry\n", encoding="utf-8")
+    (managed_skill / "SKILL.md").write_text("managed runtime copy\n", encoding="utf-8")
+    unmanaged_skill.mkdir(parents=True, exist_ok=True)
+    (unmanaged_skill / "SKILL.md").write_text("user runtime copy\n", encoding="utf-8")
+
+    original_claude = rollback_runtime.CLAUDE_MD
+    original_roots = rollback_runtime.SKILL_ROOTS
+    rollback_runtime.CLAUDE_MD = fake_claude
+    rollback_runtime.SKILL_ROOTS = {"codex": codex_root, "hermes": base / "runtime" / "hermes-skills"}
+    try:
+        rollback_runtime.remove_skill("codex", "pack-sourced-skill", dry_run=True, force=False)
+        if not managed_skill.exists():
+            errors.append("rollback-dry-run: managed skill was removed during dry-run")
+        rollback_runtime.remove_skill("codex", "pack-sourced-skill", dry_run=False, force=False)
+        if managed_skill.exists():
+            errors.append("rollback-managed-skill: managed skill still exists after removal")
+        try:
+            rollback_runtime.remove_skill("codex", "user-owned-skill", dry_run=False, force=False)
+            errors.append("rollback-unmanaged-skill: unmanaged skill removal was not refused")
+        except SystemExit as exc:
+            if "Refusing to remove unmanaged directory" not in str(exc):
+                errors.append(f"rollback-unmanaged-skill: unexpected refusal text {exc}")
+        if not unmanaged_skill.exists():
+            errors.append("rollback-unmanaged-skill: unmanaged skill was removed")
+
+        rollback_runtime.remove_managed_block(dry_run=True)
+        if rollback_runtime.CLAUDE_INCLUDE_START not in fake_claude.read_text(encoding="utf-8"):
+            errors.append("rollback-block-dry-run: managed block was removed during dry-run")
+        rollback_runtime.remove_managed_block(dry_run=False)
+        claude_text = fake_claude.read_text(encoding="utf-8")
+        if rollback_runtime.CLAUDE_INCLUDE_START in claude_text:
+            errors.append("rollback-block: managed block remains after removal")
+        for expected in ["User-owned Claude notes.", "User-owned footer."]:
+            if expected not in claude_text:
+                errors.append(f"rollback-block: user text missing after removal: {expected}")
+    finally:
+        rollback_runtime.CLAUDE_MD = original_claude
+        rollback_runtime.SKILL_ROOTS = original_roots
+
+    after_vault = tree_digest(vault)
+    if before_vault != after_vault:
+        errors.append("restore-rollback-boundary: runtime disable/rollback changed Vault records")
+    return errors
 
 
 def main() -> int:
@@ -184,6 +299,8 @@ def main() -> int:
         rerun = deploy_bootstrap(vault)
         errors.extend(expect("deploy-bootstrap-rerun-skip", rerun, True, "skipped: 24"))
         errors.extend(expect("deploy-bootstrap-rerun-no-add", rerun, True, "added: 0"))
+
+        errors.extend(exercise_restore_rollback_boundaries(base, vault))
 
         record = vault / "practices" / "meta" / "BOOT-001-bootstrap-orientation.md"
         record.write_text(record.read_text(encoding="utf-8") + "\nLocal edit fixture.\n", encoding="utf-8")

--- a/workflows/install-adapters.md
+++ b/workflows/install-adapters.md
@@ -79,6 +79,64 @@ runtime/local/runtime_manifest.yaml
 
 10. For ChatGPT, manually upload `adapters/chatgpt/knowledge/` and copy `custom-instructions.md`.
 
+## Cross-Machine Restore
+
+Use this path when a deployment must recreate runtime state from public Core plus a selected Vault, not from another machine's runtime copy.
+
+1. Clone or update Core on the target machine.
+2. Clone, pull, or initialize the selected Vault on the target machine.
+3. Validate the pair before publishing or installing:
+
+   ```bash
+   python3 scripts/check_foundry_roots.py --core-root <core-root> --vault-root <vault-root>
+   ```
+
+4. Publish generated adapters from that selected Vault into a machine-local output directory:
+
+   ```bash
+   python3 scripts/publish_adapters.py --core-root <core-root> --vault-root <vault-root> --output-root <generated-root> --apply
+   ```
+
+5. Initialize and review the local runtime manifest on that machine:
+
+   ```bash
+   python3 scripts/runtime_manifest.py init
+   python3 scripts/runtime_manifest.py detect
+   python3 scripts/runtime_manifest.py plan
+   ```
+
+6. Dry-run install from the selected output and read the status report before applying:
+
+   ```bash
+   python3 scripts/install_foundry.py --core-root <core-root> --vault-root <vault-root> --adapter-root <generated-root>
+   python3 scripts/sync_status.py --core-root <core-root> --vault-root <vault-root> --adapter-root <generated-root>
+   ```
+
+7. Apply only after the report names the expected Core root, Vault root, generated output, enabled runtimes, manual targets, and receipt status.
+
+Do not copy `runtime/local/runtime_manifest.yaml`, `runtime/local/adapter-install-receipt.yaml`, `~/.agent-foundry/config.yaml`, managed runtime directories, or ChatGPT project imports from another machine as canonical truth. Recreate them locally from the selected Vault and generated output.
+
+## Disable And Rollback
+
+Disabling a target changes only the machine-local runtime manifest:
+
+```bash
+python3 scripts/runtime_manifest.py disable <target>
+python3 scripts/runtime_manifest.py plan
+python3 scripts/sync_status.py
+```
+
+Rollback helpers operate on managed runtime copies and Claude managed blocks. They do not delete or rewrite canonical Vault records:
+
+```bash
+python3 scripts/rollback_runtime.py status
+python3 scripts/rollback_runtime.py remove-skill <skill-name> --target codex --dry-run
+python3 scripts/rollback_runtime.py remove-block --target claude-code --dry-run
+python3 scripts/rollback_runtime.py restore-claude --dry-run
+```
+
+Remove only directories that contain `.agent-foundry-managed`, unless the user explicitly approves `--force` after inspecting the path. If `sync_status.py` reports selected-output drift, stale runtime files, or missing receipts, treat that as cleanup work on the current machine; do not repair it by editing unrelated Vault records. ChatGPT remains manual import and manual cleanup.
+
 ## Safety
 
 - Never install proposed/candidate content directly.


### PR DESCRIPTION
## Findings

- Restore path already validates Core/Vault roots through `check_foundry_roots.py`, and fresh-install/bootstrap fixtures exercise temp Vault creation, bootstrap deployment, selected-Vault publish, machine-local locator output, missing receipt visibility, and ChatGPT manual import reporting.
- Runtime manifest, local locator, and selected-output install receipts are machine-local surfaces: `runtime/local/` is gitignored, `~/.agent-foundry/config.yaml` is local, and receipts record local absolute install destinations and hashes.
- Gap found: rollback/disable safety was documented in broad roadmap language but did not have an explicit temp regression proving runtime disable/rollback leaves unrelated user-created Vault records untouched.
- Gap found: the install workflow did not provide a concise cross-machine restore path that tells agents not to copy another machine's local manifest, receipt, locator, runtime directories, or ChatGPT imports as canonical truth.

## Changes

- Added a temp-only restore/rollback boundary check to `scripts/test_bootstrap_pack_deployment.py`:
  - monkeypatches `runtime_manifest.LOCAL_MANIFEST` to a temp manifest and verifies target disable is local;
  - monkeypatches `rollback_runtime` paths to temp Codex/Claude runtime fixtures;
  - verifies dry-run behavior, managed skill removal, unmanaged skill refusal, managed Claude block removal, and preservation of user-owned Claude text;
  - hashes the temp Vault before/after to ensure unrelated user-created Vault records are unchanged.
- Expanded `workflows/install-adapters.md` with cross-machine restore and disable/rollback guidance, including selected-root validation, selected-Vault publish, local runtime manifest review, sync status/receipt checks, and explicit ChatGPT manual cleanup boundaries.

## Verification

- `python3 scripts/check_consistency.py`
- `python3 scripts/test_bootstrap_pack_deployment.py`
- `python3 scripts/test_adapter_install_receipt.py`
- `python3 scripts/test_operation_context.py`
- `python3 scripts/test_deployment_helpers.py`
- `python3 scripts/sync_status.py --core-root "$PWD" --vault-root "$PWD" --adapter-root "$PWD/adapters" --receipt-path /tmp/agent-foundry-issue-81-nonexistent-receipt.yaml`
- `git diff --check`

## Residual Gaps

- True cross-machine execution was not possible in this environment because no other physical deployment is accessible.
- ChatGPT import/cleanup remains manual by design; this PR verifies that the manual target is reported, not that an external ChatGPT project was updated.
- The read-only `sync_status.py` run used this checkout as both Core and Vault and correctly reported missing Vault markers, missing selected-output receipt, manual ChatGPT import, and runtime drift. That output was used as visibility evidence, not as a failure of the temp restore/rollback simulation.

Closes #81 after Architect acceptance.