### PR TITLE
[codex] Add AF5 validation report

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -785,6 +785,80 @@ Execution order:
 7. Keep runtime import and product-project import behind the same staging/review rules so imported material does not bypass harvest discipline.
 8. Close AF-5 only with an end-to-end validation issue that runs the user journey, not merely individual script tests.
 
+#### AF-5 End-to-End Validation Report (#82)
+
+Status: Reviewer validation completed on 2026-06-12 against `af5/integration`.
+
+Findings first:
+
+- No blocking AF-5 onboarding readiness findings remain for Architect acceptance.
+- AF-5 is ready for Architect acceptance and a human AF-5 close / final `af5/integration` to `main` decision.
+- Final AF-5 close, final integration to `main`, issue closure, and any real selected Vault or runtime apply remain human-gated.
+- Current validation did not mutate the real selected User Vault, real runtime files, local config, private remotes, or ChatGPT project state.
+
+Evidence map:
+
+| Journey / boundary | Evidence | Reviewer conclusion |
+| --- | --- | --- |
+| Fresh install / blank Vault / bootstrap deployment / first usable command | #76, #77, #78, #89; `scripts/install_foundry.py --fresh-install`; `scripts/test_bootstrap_pack_deployment.py`; `scripts/sync_status.py` setup/status report | Temp blank Vault can initialize, deploy `pack.bootstrap.minimal`, publish generated output, report runtime dry-run/receipt status, keep ChatGPT manual, and name `python3 scripts/sync_status.py` as first usable command. |
+| Optional capability pack path | #75 and #79; `fixtures/capability-packs/optional-multi-agent`; `scripts/check_capability_pack_fixtures.py` | Optional pack fixture validates as a candidate/stage-only snapshot with provenance, inert helper payload metadata, no direct runtime install, and no third source of truth. |
+| Runtime asset import path | #80; `scripts/import_runtime_assets.py`; `scripts/test_import_runtime_assets.py` | Explicit runtime/source path import stages review evidence under the selected Vault inbox only after operation-context checks. It does not activate records, overwrite adapters, execute scripts, or scan broad private runtime trees by default. |
+| Product-project capability candidate | #79 / Tiny IPA evidence; operation-context harvest evidence | Tiny IPA remains product-project evidence only. Reusable role-generic helper surfaces are represented as optional pack candidates; project-local defaults, Project ids, cache paths, branch state, and mutating apply behavior are excluded or marked overlay/rejected. |
+| Cross-machine restore and rollback/disable | #81; `workflows/install-adapters.md`; `scripts/test_deployment_helpers.py`; `scripts/test_bootstrap_pack_deployment.py`; `scripts/test_adapter_install_receipt.py` | Restore is documented and tested as recreation from public Core plus selected Vault/generated output, not copying another machine's runtime/local state. Temp rollback/disable regression preserves unrelated Vault records and removes only managed runtime copies/blocks. |
+| Core / Vault / Generated / Runtime / Local Private boundaries | #89 plus `scripts/operation_context.py`, selected-output receipt status, `scripts/sync_status.py`, `scripts/test_operation_context.py`, `scripts/test_foundry_roots.py`, selected-output adapter quality check | Operation context identifies work context, selected Core/Vault roots, generated output route, allowed reads/writes, forbidden writes, manual targets, and receipt state before publish/install/status flows. Selected-output receipt is authoritative in split mode; Core adapters are secondary diagnostics. |
+
+Verification run for #82:
+
+- `python3 scripts/check_consistency.py` passed.
+- `python3 scripts/check_capability_pack_fixtures.py` passed.
+- `python3 scripts/test_bootstrap_pack_deployment.py` passed.
+- `python3 scripts/test_import_runtime_assets.py` passed.
+- `python3 scripts/test_adapter_install_receipt.py` passed.
+- `python3 scripts/test_operation_context.py` passed.
+- `python3 scripts/test_deployment_helpers.py` passed.
+- `python3 scripts/test_foundry_roots.py` passed.
+- `python3 scripts/check_activation.py` passed.
+- `python3 scripts/check_adapter_quality.py --surface selected-output --generated-root '/Users/jinghuliu/.agent-foundry/generated/agent-foundry-adapters'` passed.
+- `python3 scripts/sync_status.py` completed read-only. It reported selected-output receipt in sync for Codex, Claude Code, and Hermes; ChatGPT remains manual. It also reported `deployed_pack: none detected` for the current maintainer Vault, which is expected because the fresh-install bootstrap deployment acceptance is temp/blank-Vault scoped and was not applied to the real selected Vault.
+
+Residual gaps and explicit deferrals:
+
+- Physical second-machine execution remains deferred; #81 covered local temp restore/rollback simulation and documents the physical-machine gap.
+- ChatGPT manual import and cleanup remain manual by design; no live ChatGPT project update was attempted.
+- Optional pack deployment beyond the MVP candidate fixture remains later work; #79 validates the candidate boundary, not real optional-pack rollout.
+- Real capability-owned helper install remains deferred until a reviewed helper install path is selected; helper payloads stay declared/inert in pack fixtures.
+- Advanced capability discovery, marketplace behavior, broad pack registry, automatic update management, and M9-style discovery remain future work.
+- Memory-system implementation remains out of scope for AF-5 and should not be introduced by AF-5 close.
+- Current maintainer Vault bootstrap deployment state is not evidence of new-user onboarding success; temp blank-Vault fixtures are the acceptance evidence for that journey.
+
+Human Decision Contract draft:
+
+Decision needed:
+Authorize whether AF-5 may close and whether `af5/integration` may proceed to final human-gated integration toward `main`.
+
+Why human input is required:
+AF-5 close changes roadmap maturity state, and final `af5/integration` to `main` integration is explicitly human-gated by the AF5 branch contract. Agents may validate and route the issue, but must not close #82/#73 or merge to `main` without explicit authorization.
+
+Agent conclusion:
+Reviewer validation finds AF-5 onboarding MVP ready for Architect acceptance and human close/main-integration decision. Required AF-5 journeys have evidence, checks pass, layer boundaries remain intact, and known gaps are labeled as explicit deferrals rather than hidden blockers.
+
+Options:
+
+1. Approve Architect acceptance and human AF-5 close / final integration planning.
+2. Request additional validation before AF-5 close, such as physical second-machine execution or a live ChatGPT manual import check.
+3. Defer AF-5 close and keep #82/#73 open with the residual gaps named above.
+
+Consequences:
+
+- If approved: Architect may accept #82, prepare the final human-gated `af5/integration` to `main` path, and route AF-5 close decisions without merging or closing until explicitly authorized.
+- If additional validation is requested: keep #82 open or create targeted follow-up issues for the requested evidence.
+- If deferred: AF-6 and later memory-system readiness work should not start from a claimed AF-5 baseline.
+
+Explicit authorization phrases:
+
+- `批准 AF5 close`
+- `批准 af5/integration 合入 main`
+
 ### M6: Existing Foundry Lifecycle Completion
 
 Goal: finish the practice/asset/adapter loop before adding memory record types.


### PR DESCRIPTION
## Findings

No blocking AF5 onboarding readiness findings remain from the Reviewer pass. AF5 is ready for Architect acceptance and a human AF5 close / final `af5/integration` -> `main` decision.

This PR does not mutate the real selected Vault, runtime files, local config, private remotes, or ChatGPT project state. Final AF5 close, issue closure, and final `main` integration remain human-gated.

## What changed

- Added an AF-5 end-to-end validation report to `docs/roadmap.md` under M5.
- Mapped required onboarding journeys to issue/test evidence:
  - fresh install / blank Vault / bootstrap / first usable command
  - optional capability pack path
  - runtime asset import path
  - product-project capability candidate
  - cross-machine restore and rollback/disable
  - Core / Vault / Generated / Runtime / Local Private boundaries
- Captured explicit deferrals and a Human Decision Contract draft for AF5 close / final `main` integration.

## Verification

- `python3 scripts/check_consistency.py`
- `python3 scripts/check_capability_pack_fixtures.py`
- `python3 scripts/test_bootstrap_pack_deployment.py`
- `python3 scripts/test_import_runtime_assets.py`
- `python3 scripts/test_adapter_install_receipt.py`
- `python3 scripts/test_operation_context.py`
- `python3 scripts/test_deployment_helpers.py`
- `python3 scripts/test_foundry_roots.py`
- `python3 scripts/check_activation.py`
- `python3 scripts/check_adapter_quality.py --surface selected-output --generated-root '/Users/jinghuliu/.agent-foundry/generated/agent-foundry-adapters'`
- `python3 scripts/sync_status.py` read-only
- `git diff --check`

## Residual gaps / deferrals

- Physical second-machine execution remains deferred; #81 covered local temp simulation.
- ChatGPT import/cleanup remains manual by design.
- Optional pack deployment beyond MVP candidate fixture remains later work.
- Real capability-owned helper install remains deferred.
- Advanced capability discovery / marketplace / broad registry / M9-style discovery remains future work.
- Memory-system implementation remains out of AF5 scope.

Handoff: routes #82 to Architect for acceptance; final AF5 close and final `af5/integration` -> `main` remain human-gated.