### PR TITLE
Integrate AF5 onboarding readiness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ This repository is Agent Foundry Core, the public source of truth for reusable w
 - After the user approves a new or changed practice, apply the approved item and publish relevant adapters automatically.
 - Record ordinary asset usage evidence automatically when an active asset is invoked and the note can be kept concise and non-sensitive.
 - Treat memories, session summaries, and activity logs as evidence only. Memory can suggest; Agent Foundry decides.
-- For GitHub issue, branch, and PR work, follow `COLLAB-001`: verified task commits, task-branch pushes, and PR creation are normal workflow steps; direct commits to `main`, merges, issue closure, destructive Git operations, deletion, data migration, and privacy/security boundary changes still require explicit authorization.
+- For GitHub issue, branch, and PR work, follow `COLLAB-001`: verified task commits, task-branch pushes, PR creation, and validated child PR merges into non-`main` Epic integration branches are normal workflow steps when the issue or Epic contract authorizes them. Direct commits to `main`, final merges into `main`, issue closure without delegated Epic readiness authority, destructive Git operations, deletion, data migration, and privacy/security boundary changes still require explicit authorization.
 
 ## Default Workflow
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -12,6 +12,7 @@ Use these short commands in day-to-day agent work.
 | `discover assets` | `发现可打包资产` | Find repeated workflows that should become skills, subagents, automations, or extensions. |
 | `import skill <source>` | `导入这个 skill <source>` | Evaluate an external skill, repo, prompt pack, article, or local folder. |
 | `publish practices` | `发布 practices` | Publish adapters from current active practices. Usually not needed manually. |
+| `check operation context` | `检查操作上下文` | Show the current Agent Foundry Core/Vault/evidence/runtime context before writes. |
 | `review practices` | `review practices` / `检查 skill rot` | Review the practice repo for duplicates, stale entries, weak or missed activation, and adapter drift. |
 | `review assets` | `review assets` / `检查 asset rot` | Review reusable assets for usage, overlap, stale triggers, and adapter coverage. |
 | `refresh practices and assets` | `刷新practices和assets` | Pull remote updates, conditionally publish adapters, and install to local runtimes. |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -731,6 +731,7 @@ AF-5 MVP deliverables:
 - A bootstrap pack built from public, reviewed canonical data.
 - A first optional multi-agent collaboration pack candidate, validated against Tiny IPA helper evidence after the helper executable boundary is designed.
 - CLI or workflow support for blank Vault creation, pack staging/deployment, selected-root refresh, and status reporting.
+- An operation-context preflight that lets AF operations invoked from product projects, Core, Vault, generated output, or runtime directories prove their Core/Vault roots, allowed writes, and publish/install route before mutation.
 - Validation fixtures for blank Vault, bootstrap-only Vault, optional-pack Vault, imported-runtime candidate, and product-project evidence source.
 - Runtime install behavior that preserves managed markers, receipts, manual ChatGPT boundaries, and no direct execution from canonical stores.
 
@@ -744,6 +745,7 @@ Acceptance criteria:
 - Cross-machine restore proves runtime state can be regenerated from public Core plus selected Vault rather than copied from another machine.
 - Disable or rollback behavior can remove or supersede runtime outputs without erasing unrelated user-created Vault records.
 - The onboarding flow preserves product project, Foundry Core, Foundry Vault, Generated, Runtime, and Local Private context separation.
+- AF operations invoked from nested contexts display and verify their work context, evidence root, selected Core/Vault roots, allowed writes, forbidden writes, and selected-output publish/install receipt path.
 
 Stop conditions:
 
@@ -764,11 +766,12 @@ Planned GitHub issue sequence:
 | 4 | #75 Minimal capability pack manifest and fixtures | Task batch | Implementer with Architect review | Medium | #53 and #74 define fields, lifecycle states, and conflict behavior | Batch checkpoint |
 | 5 | #76 Blank Vault plus bootstrap deployment path | Task batch | Implementer | Medium | #75 fixtures exist; blank Vault initializer validates selected roots | Batch checkpoint |
 | 6 | #77 Bootstrap capability pack content | Harvester / Architect | Medium | #76 can import pack snapshot into Vault records | Human review of included canonical records before activation |
-| 7 | #78 Fresh install command and status report | Task batch | Implementer | Medium | #77 can deploy into blank Vault | Batch checkpoint with runtime dry-run evidence |
-| 8 | #79 Optional multi-agent capability pack candidate | Evidence / Task | Architect + Harvester | Medium | #76 works; #53 defines executable helper payload boundary | Review before packaging Tiny IPA helper evidence |
-| 9 | #80 Runtime asset import path | Task batch | Implementer with Harvester review | Medium | #74 import staging and artifact routing model defined | Batch checkpoint |
-| 10 | #81 Cross-machine restore and rollback onboarding | Review / Task | Reviewer + Architect | High | #78 selected-Vault refresh and receipts work locally | Structured review handoff |
-| 11 | #82 AF5 end-to-end onboarding validation | Review | Reviewer | High | #53 and #73-#81 complete or explicitly deferred with rationale | User acceptance before AF-5 close |
+| 7 | #89 Operation context preflight and nested-context guard | Task | Architect then Implementer | Medium | #77 can deploy bootstrap content; nested-context confusion has concrete evidence | Reviewer handoff before #78 starts |
+| 8 | #78 Fresh install command and status report | Task batch | Implementer | Medium | #77 can deploy into blank Vault and #89 can prove operation context before mutation | Batch checkpoint with runtime dry-run evidence |
+| 9 | #79 Optional multi-agent capability pack candidate | Evidence / Task | Architect + Harvester | Medium | #76 works; #53 defines executable helper payload boundary | Review before packaging Tiny IPA helper evidence |
+| 10 | #80 Runtime asset import path | Task batch | Implementer with Harvester review | Medium | #74 import staging and artifact routing model defined | Batch checkpoint |
+| 11 | #81 Cross-machine restore and rollback onboarding | Review / Task | Reviewer + Architect | High | #78 selected-Vault refresh and receipts work locally | Structured review handoff |
+| 12 | #82 AF5 end-to-end onboarding validation | Review | Reviewer | High | #53 and #73-#81 plus #89 complete or explicitly deferred with rationale | User acceptance before AF-5 close |
 
 Execution order:
 
@@ -776,9 +779,10 @@ Execution order:
 2. Resolve #53 before packaging Tiny IPA-style helper scripts as reusable capability payloads.
 3. Build pack manifest fixtures before bootstrap content so bootstrap can be validated as one instance of the general deployment mechanism.
 4. Build the mandatory bootstrap path before optional packs.
-5. Treat the multi-agent pack as the first optional validation case, not as a blocker for fresh install.
-6. Keep runtime import and product-project import behind the same staging/review rules so imported material does not bypass harvest discipline.
-7. Close AF-5 only with an end-to-end validation issue that runs the user journey, not merely individual script tests.
+5. Add operation-context preflight before fresh install polish so first-run commands and nested product-project harvests prove which layer owns each read, write, publish, install, and receipt.
+6. Treat the multi-agent pack as the first optional validation case, not as a blocker for fresh install.
+7. Keep runtime import and product-project import behind the same staging/review rules so imported material does not bypass harvest discipline.
+8. Close AF-5 only with an end-to-end validation issue that runs the user journey, not merely individual script tests.
 
 ### M6: Existing Foundry Lifecycle Completion
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -785,6 +785,80 @@ Execution order:
 7. Keep runtime import and product-project import behind the same staging/review rules so imported material does not bypass harvest discipline.
 8. Close AF-5 only with an end-to-end validation issue that runs the user journey, not merely individual script tests.
 
+#### AF-5 End-to-End Validation Report (#82)
+
+Status: Reviewer validation completed on 2026-06-12 against `af5/integration`.
+
+Findings first:
+
+- No blocking AF-5 onboarding readiness findings remain for Architect acceptance.
+- AF-5 is ready for Architect acceptance and a human AF-5 close / final `af5/integration` to `main` decision.
+- Final AF-5 close, final integration to `main`, issue closure, and any real selected Vault or runtime apply remain human-gated.
+- Current validation did not mutate the real selected User Vault, real runtime files, local config, private remotes, or ChatGPT project state.
+
+Evidence map:
+
+| Journey / boundary | Evidence | Reviewer conclusion |
+| --- | --- | --- |
+| Fresh install / blank Vault / bootstrap deployment / first usable command | #76, #77, #78, #89; `scripts/install_foundry.py --fresh-install`; `scripts/test_bootstrap_pack_deployment.py`; `scripts/sync_status.py` setup/status report | Temp blank Vault can initialize, deploy `pack.bootstrap.minimal`, publish generated output, report runtime dry-run/receipt status, keep ChatGPT manual, and name `python3 scripts/sync_status.py` as first usable command. |
+| Optional capability pack path | #75 and #79; `fixtures/capability-packs/optional-multi-agent`; `scripts/check_capability_pack_fixtures.py` | Optional pack fixture validates as a candidate/stage-only snapshot with provenance, inert helper payload metadata, no direct runtime install, and no third source of truth. |
+| Runtime asset import path | #80; `scripts/import_runtime_assets.py`; `scripts/test_import_runtime_assets.py` | Explicit runtime/source path import stages review evidence under the selected Vault inbox only after operation-context checks. It does not activate records, overwrite adapters, execute scripts, or scan broad private runtime trees by default. |
+| Product-project capability candidate | #79 / Tiny IPA evidence; operation-context harvest evidence | Tiny IPA remains product-project evidence only. Reusable role-generic helper surfaces are represented as optional pack candidates; project-local defaults, Project ids, cache paths, branch state, and mutating apply behavior are excluded or marked overlay/rejected. |
+| Cross-machine restore and rollback/disable | #81; `workflows/install-adapters.md`; `scripts/test_deployment_helpers.py`; `scripts/test_bootstrap_pack_deployment.py`; `scripts/test_adapter_install_receipt.py` | Restore is documented and tested as recreation from public Core plus selected Vault/generated output, not copying another machine's runtime/local state. Temp rollback/disable regression preserves unrelated Vault records and removes only managed runtime copies/blocks. |
+| Core / Vault / Generated / Runtime / Local Private boundaries | #89 plus `scripts/operation_context.py`, selected-output receipt status, `scripts/sync_status.py`, `scripts/test_operation_context.py`, `scripts/test_foundry_roots.py`, selected-output adapter quality check | Operation context identifies work context, selected Core/Vault roots, generated output route, allowed reads/writes, forbidden writes, manual targets, and receipt state before publish/install/status flows. Selected-output receipt is authoritative in split mode; Core adapters are secondary diagnostics. |
+
+Verification run for #82:
+
+- `python3 scripts/check_consistency.py` passed.
+- `python3 scripts/check_capability_pack_fixtures.py` passed.
+- `python3 scripts/test_bootstrap_pack_deployment.py` passed.
+- `python3 scripts/test_import_runtime_assets.py` passed.
+- `python3 scripts/test_adapter_install_receipt.py` passed.
+- `python3 scripts/test_operation_context.py` passed.
+- `python3 scripts/test_deployment_helpers.py` passed.
+- `python3 scripts/test_foundry_roots.py` passed.
+- `python3 scripts/check_activation.py` passed.
+- `python3 scripts/check_adapter_quality.py --surface selected-output --generated-root '/Users/jinghuliu/.agent-foundry/generated/agent-foundry-adapters'` passed.
+- `python3 scripts/sync_status.py` completed read-only. It reported selected-output receipt in sync for Codex, Claude Code, and Hermes; ChatGPT remains manual. It also reported `deployed_pack: none detected` for the current maintainer Vault, which is expected because the fresh-install bootstrap deployment acceptance is temp/blank-Vault scoped and was not applied to the real selected Vault.
+
+Residual gaps and explicit deferrals:
+
+- Physical second-machine execution remains deferred; #81 covered local temp restore/rollback simulation and documents the physical-machine gap.
+- ChatGPT manual import and cleanup remain manual by design; no live ChatGPT project update was attempted.
+- Optional pack deployment beyond the MVP candidate fixture remains later work; #79 validates the candidate boundary, not real optional-pack rollout.
+- Real capability-owned helper install remains deferred until a reviewed helper install path is selected; helper payloads stay declared/inert in pack fixtures.
+- Advanced capability discovery, marketplace behavior, broad pack registry, automatic update management, and M9-style discovery remain future work.
+- Memory-system implementation remains out of scope for AF-5 and should not be introduced by AF-5 close.
+- Current maintainer Vault bootstrap deployment state is not evidence of new-user onboarding success; temp blank-Vault fixtures are the acceptance evidence for that journey.
+
+Human Decision Contract draft:
+
+Decision needed:
+Authorize whether AF-5 may close and whether `af5/integration` may proceed to final human-gated integration toward `main`.
+
+Why human input is required:
+AF-5 close changes roadmap maturity state, and final `af5/integration` to `main` integration is explicitly human-gated by the AF5 branch contract. Agents may validate and route the issue, but must not close #82/#73 or merge to `main` without explicit authorization.
+
+Agent conclusion:
+Reviewer validation finds AF-5 onboarding MVP ready for Architect acceptance and human close/main-integration decision. Required AF-5 journeys have evidence, checks pass, layer boundaries remain intact, and known gaps are labeled as explicit deferrals rather than hidden blockers.
+
+Options:
+
+1. Approve Architect acceptance and human AF-5 close / final integration planning.
+2. Request additional validation before AF-5 close, such as physical second-machine execution or a live ChatGPT manual import check.
+3. Defer AF-5 close and keep #82/#73 open with the residual gaps named above.
+
+Consequences:
+
+- If approved: Architect may accept #82, prepare the final human-gated `af5/integration` to `main` path, and route AF-5 close decisions without merging or closing until explicitly authorized.
+- If additional validation is requested: keep #82 open or create targeted follow-up issues for the requested evidence.
+- If deferred: AF-6 and later memory-system readiness work should not start from a claimed AF-5 baseline.
+
+Explicit authorization phrases:
+
+- `批准 AF5 close`
+- `批准 af5/integration 合入 main`
+
 ### M6: Existing Foundry Lifecycle Completion
 
 Goal: finish the practice/asset/adapter loop before adding memory record types.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -609,6 +609,7 @@ Layer rule:
 - After deployment, the selected User Vault owns the canonical practices, assets, indexes, and accepted payloads.
 - `refresh` reads the current selected Vault plus Core adapter profiles, not live pack definitions.
 - Runtime copies are installed from generated output or accepted Vault payloads through managed runtime/tool locations with receipts.
+- Pack updates are reviewed releases governed by each pack's own contract. Do not regenerate a pack merely because an included canonical record changed unless Pack Relevance Review decides the change belongs inside that pack's promised use case.
 
 Predefined packs and discovered packs are compatible with freeform Vault maintenance:
 

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -798,7 +798,7 @@ Locator semantics:
 - `vault_markers`: markers that validate a Vault before canonical writes. Required examples include `indexes/practice_index.yaml`, `indexes/asset_index.yaml`, and `usage/usage-aggregate.yaml`.
 - `canonical_markers`: deprecated compatibility field from the single-root staging state. It may be read for old local configs, but new configs should use `core_markers` and `vault_markers`.
 
-Current capability: `scripts/foundry_config.py` writes `core_root`, `vault_root`, and `repo_root` to the same path for compatibility, but emits separate Core and Vault marker lists. This is still a single-repo staging mode until later AF-3 work teaches all commands to operate on distinct roots.
+Current capability: `scripts/foundry_config.py` records separate `core_root`, `vault_root`, and compatibility `repo_root` values, and emits separate Core and Vault marker lists. Split mode is valid when both roots validate. Same-root operation remains a compatibility path, not proof that Core and Vault are the same authority.
 
 Locator precedence:
 
@@ -813,6 +813,8 @@ Do not treat a single root found through `AGENT_FOUNDRY_HOME` or current directo
 
 Do not use a product project checkout as a Vault merely because the user is working there. Do not use a Vault as Core merely because it contains practices. Do not use Core as a Vault merely because it has templates or examples.
 
+`scripts/operation_context.py` is the current preflight guard for this boundary. It reports invocation cwd, operation type, work context, evidence root, selected Core/Vault roots, generated adapter output route, manual targets, allowed reads, allowed writes, forbidden writes, root validation, and warnings. Harvest, publish, install, refresh, and status workflows should display this context before writes or installs.
+
 Operation-to-config mapping:
 
 | Operation | Required context | Reads | Writes |
@@ -821,6 +823,7 @@ Operation-to-config mapping:
 | `harvest practices` | Product project evidence plus Foundry Core and active Vault | Evidence source, Core workflow/schema, Vault index | Vault canonical records after review |
 | `refresh practices and assets` | Core plus active Vault plus local runtime manifest | Core tooling, Vault records, runtime local manifest | runtime copies and optional sanitized aggregate |
 | `publish adapters` | Core plus active Vault | Core adapter profiles, Vault practices/assets | generated adapter outputs and runtime copies after approval |
+| Operation context preflight | current cwd plus selected Core/Vault | Core/Vault markers, runtime manifest, install receipt when relevant | no writes |
 | Foundry Core maintenance | Core | Core docs/workflows/scripts/schemas | Core repo |
 | Vault maintenance | active Vault | Vault practices/assets/indexes/usage | Vault repo |
 

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -632,6 +632,17 @@ Capability packs are exported or deployable snapshots, not independent runtime t
 
 Pack deployment is not ownership transfer to a pack controller. A deployed record may belong to no pack, one pack, or multiple packs. Pack membership explains provenance and update comparison; it does not prevent ordinary reviewed edits, deprecation, retirement, or archive decisions. If a user edits a pack-sourced record, later pack updates must treat that local edit as canonical user state and produce a reviewable merge proposal rather than overwriting it.
 
+Pack updates are reviewed releases, not automatic mirrors of all canonical record changes. Each pack should carry enough contract metadata to answer what user journey or capability it promises. A changed canonical record triggers a pack update only after a Pack Relevance Review decides the change belongs inside that pack's promised boundary.
+
+Pack Relevance Review asks:
+
+- Did pack membership change?
+- Did the pack's promised use case, first-run behavior, activation/default behavior, compatibility range, or schema expectations change?
+- Does the canonical change fix a bug, privacy issue, security issue, or misleading instruction that is material to this pack's promised use case?
+- Would users receiving the older pack snapshot be materially unsafe, blocked, or misled for this pack's journey?
+
+If yes, propose a new pack version, included-record diff, manifest update, and checksum refresh. If no, record that no pack update is needed. Do not regenerate a pack merely because an included canonical record changed outside the pack's selected contract.
+
 Minimal manifest responsibilities for #75:
 
 - stable pack id, title, description, lifecycle status, version, exported date, source provenance, and maintainer/source contact when available;
@@ -640,7 +651,8 @@ Minimal manifest responsibilities for #75:
 - per-item id, path, kind, lifecycle status, source version, content hash, and intended destination layer;
 - provenance, license, sensitivity, security, permission, dependency, and runtime-impact metadata;
 - conflict policy, rollback notes, and whether the pack is mandatory bootstrap, optional user-selected capability, or product-project candidate;
-- checksums for snapshot integrity and enough metadata to compare a later pack version with the user's current Vault records.
+- checksums for snapshot integrity and enough metadata to compare a later pack version with the user's current Vault records;
+- selection scope, pack contract, or included-rationale metadata that supports later Pack Relevance Review.
 
 Conflict and update behavior:
 

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -736,6 +736,31 @@ Migration path:
 
 The Tiny IPA role-generic GitHub helpers are a validation case for this model. Tiny IPA remains the evidence source. The reusable multi-agent helper subset can become a candidate optional capability pack only after AF-5 defines pack snapshot, provenance, project-local overlay, executable payload, and runtime install boundaries.
 
+#### Optional Multi-Agent Pack Candidate Evidence
+
+Issue #79 uses the Tiny IPA `tools/agents/` helpers and companion design docs as product-project evidence for the first optional capability pack candidate. The evidence is useful because it has already exercised role-generic routing, fast label inboxes, dry-run pickup and handoff, contract parsing, and read-only audit checks in a real multi-agent project. It is not canonical Agent Foundry content by itself, and Tiny IPA must not become a hidden runtime dependency after packaging.
+
+Reusable candidate nucleus:
+
+| Candidate area | Candidate contents | Packaging stance |
+| --- | --- | --- |
+| Practices | role-generic `needs:<role>` routing, durable handoff comments, explicit Execution Contract fields, dependency-gated ready queues, dry-run before mutation, read-only audit first | Candidate or proposed Vault records after review; not active by default merely because the pack is deployed. |
+| Asset | role-generic GitHub scheduler helper set for inbox, ready queue, pickup, handoff, audit, label routing, and context summary | Candidate asset that declares permissions, dependencies, supported roles, dry-run behavior, and install boundary. |
+| Docs/templates | role routing configuration guide, Execution Contract template, pickup/handoff comment templates, reviewer/architect handoff examples | Pack docs or templates copied into the Vault/import surface as examples, not Core defaults. |
+| Scripts | `agent-inbox`, `agent-ready-queue`, `agent-pickup`, `agent-handoff`, `agent-audit`, `agent-issue-context`, `agent-pr-context`, `agent-label`, `agent-role-config`, `gh-retry`, shared role config library, and tests | Executable payload candidates only. They remain inert in the pack snapshot and require managed runtime/tool install before use. |
+| Optional overlay | Project v2 status sync, roadmap status mapping, project ids, status option ids, issue type labels, and cache paths | Project-local overlay, not reusable defaults. Omitted unless a target project explicitly configures them. |
+
+Rejected-as-pack for this candidate:
+
+- Tiny IPA's default `GH_REPO`, GitHub Project id, status field ids, status option ids, `.agent-cache` files, issue numbers, branch names, and current project-specific label/status conventions.
+- Mutating `--apply` behavior before the helper install and permission boundary is implemented.
+- Treating Project v2 as the scheduler source of truth.
+- Copying helper scripts into Core `scripts/` as platform tooling.
+- Executing helpers from Tiny IPA, pack staging, or canonical Vault payload paths after import.
+- Packaging Tiny IPA design notes as active Agent Foundry practices without a separate harvest review.
+
+The candidate pack should therefore be evaluated as a reviewed snapshot: evidence from Tiny IPA, optional public pack fixture, stage-only included records, inert executable payload declarations, no runtime install, and no private path leakage. If later implementation imports the pack, the selected User Vault owns the resulting records and payload metadata; the pack remains provenance and update-comparison evidence, not a live authority.
+
 ## Operating Context Separation
 
 Agent Foundry must remain safe when it is used inside another software project. Users and agents regularly operate in nested contexts:

--- a/fixtures/capability-packs/bootstrap-minimal/manifest.yaml
+++ b/fixtures/capability-packs/bootstrap-minimal/manifest.yaml
@@ -1,12 +1,12 @@
 manifest_schema_version: 1
 pack_id: pack.bootstrap.minimal
 title: Minimal Agent Foundry Bootstrap Pack
-description: Minimal public bootstrap snapshot for AF-5 fixture validation.
+description: Minimal public bootstrap snapshot for first-run harvest, review, refresh, publish, root, and runtime-boundary workflows.
 lifecycle_status: reviewed
-version: 0.1.0
-exported_at: 2026-06-11
+version: 0.2.0
+exported_at: 2026-06-12
 distribution_type: mandatory_bootstrap
-source_provenance: "Agent Foundry public Core fixture for issue #75"
+source_provenance: "Agent Foundry public Core fixture for issue #77"
 maintainer_contact: "https://github.com/farmerhunter/agent-foundry"
 license: "repository license"
 sensitivity: public
@@ -17,6 +17,23 @@ compatibility:
   core_schema_version_max: 1
   vault_layout_versions: [1]
   requires_bootstrap_pack: false
+
+selection_review:
+  rationale: "Provide the smallest usable blank-Vault baseline: bootstrap orientation plus the public Practice Harvester asset and its canonical meta, governance, and runtime practices."
+  included_groups:
+    - bootstrap orientation and status records
+    - Practice Harvester skill asset
+    - meta practices required for harvest, asset discovery, import review, dedupe, and adapter publishing
+    - governance practices required for source-of-truth and maintainability decisions
+    - runtime practices required for root, adapter, sync, and privacy boundaries
+  excluded_groups:
+    - optional multi-agent collaboration records
+    - architecture and provider-integration records
+    - product-project-specific records
+    - raw maintainer usage evidence
+    - private paths, runtime manifests, and local deployment receipts
+  adapter_impact: "After deployment and refresh, generated runtime outputs expose ASSET-META-001, ASSET-BOOT-001, and the included active practices only."
+  runtime_impact: "No runtime files are changed by deploying the pack; runtime installation remains a separate refresh/install step."
 
 included_records:
   - id: BOOT-001
@@ -29,12 +46,232 @@ included_records:
     membership_role: bootstrap_required
     activation_default: active
     import_action: create_or_review_update
+  - id: GOV-001
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/GOV-001-protect-canonical-source-of-truth.md
+    source_version: 1
+    content_sha256: "183be3ddd0347051fb9c07cd89d9741f6cd9a6c09eecbbbc039f2554e3f15e40"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: GOV-002
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/GOV-002-prefer-smallest-maintainable-mechanism.md
+    source_version: 2
+    content_sha256: "78dd9283183f02611808087c15ccc0e1f5d70e6c90da82b5bf9b18cee73305e4"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: GOV-003
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/GOV-003-treat-transient-context-as-evidence.md
+    source_version: 1
+    content_sha256: "d3d50f436c3a0bb5e255302d1900d46607bca3a64fbafc8f644253b8796f72e0"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: GOV-004
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/GOV-004-preserve-runtime-capability.md
+    source_version: 1
+    content_sha256: "4e092ed3616f522d24021dd3e88f51167f4f794bc592417fddb34f44ed9ea0de"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-001
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-001-canonical-practices-source-of-truth.md
+    source_version: 1
+    content_sha256: "bc411c01cbda78f8002bfa3cb51aa8a523f2b7635ae0c1db428befc033a46ae6"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-002
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-002-harvest-before-publishing.md
+    source_version: 1
+    content_sha256: "2b84e5ae40c3430894004ef90315d13a470aa805691ac773b132925aad77014e"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-003
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-003-borrow-external-skills-through-review.md
+    source_version: 1
+    content_sha256: "ee3c7c051f185bc3b7d3747a5dac140effb8284933f30ecb151dd25f1db2f7b7"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-004
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-004-choose-smallest-suitable-asset.md
+    source_version: 1
+    content_sha256: "47fef94b99fb9952239ab681c78c097e7d68d82555139641611cc16ac6e272e2"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-005
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-005-define-asset-boundaries-before-creation.md
+    source_version: 1
+    content_sha256: "187746bd40906ce15a46dc2a8c88db982730935fd5f00e9c9ade5b70c25bf82a"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-006
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-006-memory-is-evidence-not-source-of-truth.md
+    source_version: 1
+    content_sha256: "e7429a6b0904c9268f3f867e83bbf5151d4916075ee9e0bbd88ba48fbf4322fa"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-007
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-007-native-agent-learning-is-candidate-input.md
+    source_version: 1
+    content_sha256: "bd6952ad01cf6b926bb12e71c73b3eeea09359a62e4f7b502b0cc5c2f84d247e"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-008
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-008-route-through-assets-constrain-with-practices.md
+    source_version: 1
+    content_sha256: "b81bca421697152e9ce088bdf082b6e74d3b00d728586c8a760b99e9ded5c992"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-009
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-009-make-adapter-fidelity-executable.md
+    source_version: 2
+    content_sha256: "6f66caf3d0574c9c241b0088009c62c7bd40ff5946d2a2aaffa84fdb9397e4e4"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-010
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-010-review-assets-with-lifecycle-evidence.md
+    source_version: 1
+    content_sha256: "d31a102a8c6b658330f3e7099987126dc232503c2d65b0e64d3022b5df227dc4"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-011
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-011-route-artifacts-before-abstracting-practices.md
+    source_version: 1
+    content_sha256: "a144755298e994ac9be820cd59e588cb73271666416d3bfc514f96f591593344"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-012
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-012-treat-user-corrections-as-process-evidence-before-content-evidence.md
+    source_version: 3
+    content_sha256: "2ec58adada8a3c72dd00629905e2dea3fb4f44c3e11266588b2852b194b467e5"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: META-013
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/META-013-apply-generalization-gate-before-promoting-insights-into-practices.md
+    source_version: 1
+    content_sha256: "6c4341cb08f1fac6302223ccabac565f1ec181759d1a9b8ab15a306d772ee81f"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: RUNTIME-001
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/RUNTIME-001-treat-agent-runtimes-as-shared-environments.md
+    source_version: 2
+    content_sha256: "381ea45b1bd33f9d175d4ca948fa1df951ee6334451efdbe132402fbd1be2a67"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: RUNTIME-002
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/RUNTIME-002-separate-portable-adapter-intent-from-machine-local-state.md
+    source_version: 2
+    content_sha256: "1698103aafbcf8a7f71d37981bd24833bda3e50bee666a35b10c3b27493e7727"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: RUNTIME-003
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/RUNTIME-003-sync-operations-must-expose-unambiguous-state.md
+    source_version: 1
+    content_sha256: "e554ca573c6f95dc84b69a1111c90db07ffce9847eec273c8c958fe4ed6fea4b"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: RUNTIME-004
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/RUNTIME-004-sync-aggregates-not-raw-evidence.md
+    source_version: 2
+    content_sha256: "0be462345da8b6820243c360e0d3cda96a038991be5ebf4c2f1c6f44a76d73b9"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
   - id: ASSET-BOOT-001
     kind: asset
     lifecycle_status: active
     path: records/assets/ASSET-BOOT-001-bootstrap-status.asset.yaml
     source_version: 1
     content_sha256: "61cc197353a2564806b5a1f4827b8d732c5c68f0272ce1e04acf2e040d63ad4f"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
+  - id: ASSET-META-001
+    kind: asset
+    lifecycle_status: active
+    path: records/assets/ASSET-META-001-practice-harvester.asset.yaml
+    source_version: 3
+    content_sha256: "c69cc0ec3a45a81dfd7d4dd30d0c55448345b736d7c72f978a0b216fd4509427"
     destination_layer: canonical_vault_record
     membership_role: bootstrap_required
     activation_default: active

--- a/fixtures/capability-packs/bootstrap-minimal/records/assets/ASSET-META-001-practice-harvester.asset.yaml
+++ b/fixtures/capability-packs/bootstrap-minimal/records/assets/ASSET-META-001-practice-harvester.asset.yaml
@@ -1,0 +1,88 @@
+id: ASSET-META-001
+title: Practice Harvester
+asset_type: skill
+status: active
+version: 3
+created: 2026-05-26
+updated: 2026-06-09
+purpose: Maintain reusable practices and assets by harvesting lessons, discovering reusable skills/assets, importing external skills, publishing adapters, and reviewing skill rot.
+responsibility: Maintain the Agent Foundry lifecycle of practices, assets, indexes, adapters, usage evidence, and related review reports.
+non_responsibility: Does not perform domain-specific engineering work except to harvest or package reusable lessons from it.
+inputs:
+  - current session context
+  - linked issue, PR, commit, or roadmap history when the user asks to review a whole session or phase
+  - external skill source
+  - existing practice and asset indexes
+  - recent work history when discovering assets
+process:
+  - locate and validate the current Agent Foundry Core and Vault
+  - reconstruct the relevant session or correction
+  - when harvesting skills or assets from a long session, set an explicit evidence window that includes earlier phases, linked issues, PRs, and commits rather than only the latest discussion topic
+  - route artifacts before drafting candidates
+  - apply the generalization gate
+  - classify candidate practices or assets
+  - for asset discovery, choose create, extend, skip, or defer using the smallest suitable asset rule
+  - deduplicate against indexes
+  - present a concise review list before canonical mutation
+  - apply approved items
+  - publish relevant adapters only after approved canonical changes are applied
+outputs:
+  - harvest report or review list
+  - asset discovery review list
+  - proposed or active practice entries
+  - active asset records
+  - updated indexes
+  - updated adapters
+  - review report
+canonical_practices:
+  - META-001
+  - META-002
+  - META-003
+  - META-004
+  - META-005
+  - META-006
+  - META-007
+  - META-008
+  - META-009
+  - META-010
+  - META-011
+  - META-012
+  - META-013
+  - GOV-001
+  - GOV-002
+  - GOV-003
+  - GOV-004
+  - RUNTIME-001
+  - RUNTIME-002
+  - RUNTIME-003
+  - RUNTIME-004
+published_to:
+  - codex
+  - claude-code
+  - hermes
+  - chatgpt
+usage_triggers:
+  - harvest practices
+  - 做一次 harvest practice
+  - harvest skills
+  - harvest assets
+  - import skill
+  - 导入这个 skill
+  - discover assets
+  - 发现可打包资产
+  - publish practices
+  - review practices
+  - 检查 skill rot
+success_criteria:
+  - artifact routing, generalization, rejected-as-practice, canonical impact, adapter impact, and runtime impact are visible before approval
+  - candidates are deduplicated against existing practices and assets
+  - skill or asset harvests review the requested evidence window, not just the most recent subtopic
+  - existing assets are extended when coverage is partial, instead of creating near-duplicate skills
+  - human approval is requested per meaningful new or changed item
+  - broad approval language is not interpreted as permission to skip unshown workflow steps
+  - self-referential workflow changes stop at a review list before canonical mutation
+  - approved items are activated and published to relevant adapters
+  - changed files and deferred items are reported clearly
+review_cadence: monthly
+review_after_days: 90
+evidence_summary: Created as the first core asset for this repository.

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/GOV-001-protect-canonical-source-of-truth.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/GOV-001-protect-canonical-source-of-truth.md
@@ -1,0 +1,62 @@
+---
+id: GOV-001
+title: Protect canonical source of truth
+domain: governance
+type: principle
+status: active
+version: 1
+created: 2026-05-28
+updated: 2026-05-28
+tags: [governance, source-of-truth, derived-data, maintainability]
+aliases:
+  - GOV-001
+  - do not create a second source of truth
+  - derived views must stay derived
+related: [META-001, META-006, ARCH-007]
+applies_when:
+  - creating indexes, summaries, generated files, views, caches, docs, or exports from existing data
+  - adding a second representation of data that already has a canonical owner
+  - deciding whether a document, schema, config, or generated artifact should be edited by hand
+  - improving tool compatibility without changing the underlying product or system behavior
+review_required: false
+provenance: "Extracted from the Obsidian rollback lesson on 2026-05-28."
+---
+
+## Principle
+
+Protect the canonical source of truth. In any project, derived views, generated artifacts, agent notes, summaries, caches, and compatibility files must not become a second hand-maintained truth source.
+
+## Rationale
+
+Duplicate truth sources create silent drift. They look helpful at first because they make a tool or workflow easier to use, but every future change must update multiple locations. Once agents or humans forget one of them, the project loses trust in its own records.
+
+## Guidance
+
+Before adding a new file, view, index, export, or generated artifact, identify:
+
+- the canonical owner;
+- whether the new artifact is canonical or derived;
+- how derived artifacts are regenerated;
+- whether consistency is checked automatically;
+- who is allowed to edit the artifact by hand.
+
+If the artifact is derived, make it generated, checked, or clearly non-authoritative. Prefer improving schema, validation, or generation paths over adding another manually maintained representation.
+
+## Watch Out For
+
+Do not justify duplicate truth sources by saying they improve readability in one tool. Tool-specific views are allowed only when they are generated from the canonical source or have a clear non-authoritative role.
+
+Do not let agent session conclusions replace project-owned durable records such as schemas, ADRs, migrations, API contracts, design docs, or canonical indexes.
+
+## Activation
+
+- Tier: always_preflight
+- Phases: planning, before_edit, before_new_file, review
+- Signals: creating derived views; adding a second representation; generating indexes, summaries, caches, exports, or compatibility files; deciding whether a file is canonical or derived
+- Evidence: final report identifies the canonical owner and whether any new artifact is canonical, derived, generated, or non-authoritative
+
+## Related Practices
+
+- [[META-001]]
+- [[META-006]]
+- [[ARCH-007]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/GOV-002-prefer-smallest-maintainable-mechanism.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/GOV-002-prefer-smallest-maintainable-mechanism.md
@@ -1,0 +1,73 @@
+---
+id: GOV-002
+title: Prefer the smallest maintainable mechanism
+domain: governance
+type: principle
+status: active
+version: 2
+created: 2026-05-28
+updated: 2026-06-02
+tags: [governance, maintainability, complexity, scope]
+aliases:
+  - GOV-002
+  - smallest maintainable mechanism
+  - do not add machinery before boundaries are clear
+related: [META-004, META-005, ARCH-001, ARCH-009]
+applies_when:
+  - choosing how much implementation, automation, abstraction, documentation, or tooling to add
+  - responding to an open-ended request such as "make the necessary changes"
+  - adding a new layer, workflow, script, framework, generated artifact, or integration
+  - deciding whether to create, extend, skip, or defer reusable capability
+review_required: false
+provenance: "Extracted from the Obsidian rollback lesson and capability-governance review on 2026-05-28."
+---
+
+## Principle
+
+Prefer the smallest maintainable mechanism that solves the real problem. More complete-looking solutions are worse when they add synchronization burden, unclear ownership, or long-term maintenance cost.
+
+## Rationale
+
+Agents tend to overbuild when the user gives an open-ended implementation request. Extra scripts, files, generated views, abstractions, or workflows can make the first result look polished while making the project harder to operate later.
+
+## Guidance
+
+Before adding machinery, ask:
+
+- What is the smallest change that preserves the intended capability?
+- What new state must be maintained?
+- What future workflow must remember this change?
+- Can the same value be achieved by tightening schema, checks, docs, or an existing workflow?
+- What fails if no one remembers this change later?
+
+Prefer bounded changes that integrate into existing workflows and checks. If a mechanism needs ongoing maintenance, define its owner, trigger, validation path, and failure mode.
+
+For frontend and interaction complexity, escalate by the shape of the problem:
+
+- one or two local toggles: use local state;
+- mutually exclusive views: use a discriminated union;
+- action availability depends on several domain or workflow states: introduce a small interaction ViewModel;
+- shared state has complex write paths: consider a reducer or lightweight store;
+- async flows require cancellation, retry, rollback, or concurrent transition control: consider a state machine;
+- URL, deep-link, history, or multi-page navigation are real requirements: consider a router;
+- visual consistency, accessibility, and component reuse dominate the problem: consider a component framework.
+
+Do not treat a busy JSX file as automatic evidence for a larger framework. First identify whether the missing mechanism is a state boundary, interaction contract, shared write model, transition model, navigation model, or visual system.
+
+## Watch Out For
+
+Do not treat "more complete" as "more correct." A hub note, generated index, helper script, adapter, automation, or abstraction is only justified if it improves long-term operation without creating hidden sync work.
+
+## Activation
+
+- Tier: always_preflight
+- Phases: planning, before_edit, before_new_layer, review
+- Signals: open-ended implementation request; adding scripts, workflows, adapters, generated files, abstractions, automations, or integrations; solution seems complete but adds maintenance state
+- Evidence: final report explains the smaller mechanism chosen or the maintenance path for added machinery
+
+## Related Practices
+
+- [[META-004]]
+- [[META-005]]
+- [[ARCH-001]]
+- [[ARCH-009]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/GOV-003-treat-transient-context-as-evidence.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/GOV-003-treat-transient-context-as-evidence.md
@@ -1,0 +1,60 @@
+---
+id: GOV-003
+title: Treat transient context as evidence
+domain: governance
+type: principle
+status: active
+version: 1
+created: 2026-05-28
+updated: 2026-05-28
+tags: [governance, memory, evidence, durable-records]
+aliases:
+  - GOV-003
+  - session context is evidence
+  - memory is not project truth
+related: [META-006, META-007, ARCH-007]
+applies_when:
+  - using chat history, memory, rollout summaries, notes, logs, or temporary analysis
+  - turning a session conclusion into project behavior
+  - deciding whether an insight belongs in code, schema, design docs, tests, practices, or memory
+  - resuming work after compaction, interruption, or handoff
+review_required: false
+provenance: "Extracted from the memory and rollback discussions on 2026-05-28."
+---
+
+## Principle
+
+Treat transient context as evidence, not project truth. Chat history, agent memory, session summaries, temporary notes, and activity logs can suggest decisions, but durable project behavior must live in the project's canonical records.
+
+## Rationale
+
+Transient context is useful but incomplete. It can be stale, compressed, unavailable to another agent, or detached from the files that actually govern the project. If agents rely on it as truth, future work becomes inconsistent and hard to audit.
+
+## Guidance
+
+When a session produces a durable decision, place it in the right canonical home:
+
+- code or tests for executable behavior;
+- schema or config for machine-readable contracts;
+- design docs or ADRs for architectural decisions;
+- practices or assets for reusable agent behavior;
+- local logs or aggregates for usage evidence.
+
+Use memory and summaries to rediscover context, then verify against project-owned records before acting.
+
+## Watch Out For
+
+Do not write long-term behavior only into memory or a chat transcript. Do not assume another agent, machine, or future compacted session will recover the same context.
+
+## Activation
+
+- Tier: always_preflight
+- Phases: planning, resume, handoff, before_edit
+- Signals: relying on chat history, memory, rollout summary, temporary note, or compacted context as fact; turning a session conclusion into durable behavior
+- Evidence: final report names the project-owned record checked or updated instead of relying only on transient context
+
+## Related Practices
+
+- [[META-006]]
+- [[META-007]]
+- [[ARCH-007]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/GOV-004-preserve-runtime-capability.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/GOV-004-preserve-runtime-capability.md
@@ -1,0 +1,62 @@
+---
+id: GOV-004
+title: Preserve maintainability and runtime capability
+domain: governance
+type: principle
+status: active
+version: 1
+created: 2026-05-28
+updated: 2026-05-28
+tags: [governance, maintainability, runtime, degradation, safety]
+aliases:
+  - GOV-004
+  - do not degrade native agent capability
+  - preserve long-term runtime capability
+related: [GOV-002, RUNTIME-001, META-007, META-009]
+applies_when:
+  - adding capability-management mechanisms, adapters, runtime files, scripts, or automations
+  - deploying Agent Foundry content into Codex, Claude Code, Hermes, ChatGPT, or another agent runtime
+  - changing rules that affect native memory, skills, project instructions, commands, or self-improvement
+  - designing a system enhancement that must keep working across agents and machines
+review_required: false
+provenance: "Added from the user's explicit guardrail on 2026-05-28: Agent Foundry must preserve minimal maintainability and avoid degrading long-running agent runtimes."
+---
+
+## Principle
+
+Preserve maintainability and runtime capability. A capability system must enhance agent runtimes without weakening their native skills, memory, instructions, self-improvement, or user-owned configuration.
+
+## Rationale
+
+Governance systems can become harmful when they add too much structure, overwrite runtime behavior, or force every agent into one uniform model. Long-term value depends on staying lightweight, reversible, and compatible with each runtime's native strengths.
+
+## Guidance
+
+Before adding or changing a capability mechanism, verify:
+
+- it does not overwrite unmanaged runtime content;
+- it does not disable native memory, skill creation, project instructions, or self-improvement;
+- it has a clear maintenance path and validation check;
+- it can fail safely or be rolled back;
+- it avoids manual synchronization burden;
+- it improves future agent behavior enough to justify its complexity.
+
+Prefer managed blocks, namespaced files, dry-runs, adapter quality checks, and explicit local deployment manifests over direct runtime takeover.
+
+## Watch Out For
+
+Do not optimize one agent's adapter in a way that degrades another agent's native mode of operation. Do not make a rule global unless it can survive compaction, handoff, and multi-machine use without requiring hidden memory.
+
+## Activation
+
+- Tier: always_preflight
+- Phases: planning, before_runtime_write, before_adapter_publish, review
+- Signals: writing runtime files; changing agent skills, memory, project instructions, commands, hooks, or self-improvement behavior; introducing capability-management machinery
+- Evidence: final report states how native runtime capability, rollback, and maintainability were preserved
+
+## Related Practices
+
+- [[GOV-002]]
+- [[RUNTIME-001]]
+- [[META-007]]
+- [[META-009]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-001-canonical-practices-source-of-truth.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-001-canonical-practices-source-of-truth.md
@@ -1,0 +1,50 @@
+---
+id: META-001
+title: Canonical practices are the source of truth for adapters
+domain: meta
+type: principle
+status: active
+version: 1
+created: 2026-05-26
+updated: 2026-05-26
+tags: [canonical, source-of-truth, adapters]
+aliases:
+  - META-001
+  - skills are downstream
+  - adapters are not source of truth
+related: [GOV-001, META-002, META-003]
+applies_when:
+  - maintaining reusable agent practices
+  - updating agent skills or prompts
+  - porting practices across agent environments
+review_required: false
+provenance: "Initial Agent Foundry system design."
+---
+
+## Principle
+
+Within Agent Foundry, canonical practice entries are the source of truth for agent adapters. Agent-specific skills, prompts, instructions, and commands are downstream outputs.
+
+## Rationale
+
+Different agent environments use different packaging formats. If practices are edited directly inside each adapter, the system will drift and become hard to deduplicate, review, and merge.
+
+## Guidance
+
+When adding or changing a reusable practice, update the canonical entry under `practices/` first. Update Codex skills, Claude Code instructions, ChatGPT custom instructions, DeepSeek prompt packs, or Hermes prompt packs only after the canonical entry is settled.
+
+For the cross-project source-of-truth rule, apply [[GOV-001]]. This practice is the Agent Foundry-specific application of that broader governance principle.
+
+## Watch Out For
+
+Do not treat a polished `SKILL.md` as the canonical source. It is optimized for context loading and trigger behavior, not long-term knowledge governance.
+
+## Example
+
+An architecture principle should live under `practices/architecture/ARCH-*.md`. The Codex `architecture-design` skill should contain only the compact version needed during work.
+
+## Related Practices
+
+- [[GOV-001]]
+- [[META-002]]
+- [[META-003]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-002-harvest-before-publishing.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-002-harvest-before-publishing.md
@@ -1,0 +1,47 @@
+---
+id: META-002
+title: Harvest before publishing
+domain: meta
+type: principle
+status: active
+version: 1
+created: 2026-05-26
+updated: 2026-05-26
+tags: [harvesting, review, skill-rot]
+aliases:
+  - META-002
+  - do not add raw notes to skills
+  - review gate
+related: [META-001, META-003]
+applies_when:
+  - extracting lessons from a project session
+  - updating practices after coding work
+  - preventing skill rot
+review_required: false
+provenance: "Initial Agent Foundry system design."
+---
+
+## Principle
+
+Reusable lessons must be harvested, classified, deduplicated, and reviewed before being published into agent adapters.
+
+## Rationale
+
+Raw session notes often contain project-specific facts, duplicate ideas, and immature conclusions. Publishing them directly into skills bloats context and weakens future agent behavior.
+
+## Guidance
+
+Follow `workflows/harvest-practices.md`. Each candidate must receive a decision: discard, merge, create, supersede, or defer. New entries start as `candidate` or `proposed` unless the user explicitly approves activation.
+
+## Watch Out For
+
+Avoid creating a new practice for every interesting observation. Prefer strengthening existing rules with examples or sharper guidance.
+
+## Example
+
+If a session shows that UI should consume a domain summary, first search for existing frontend/domain separation practices. If one exists, merge the new case as an example rather than creating a near-duplicate.
+
+## Related Practices
+
+- [[META-001]]
+- [[META-003]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-003-borrow-external-skills-through-review.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-003-borrow-external-skills-through-review.md
@@ -1,0 +1,47 @@
+---
+id: META-003
+title: Borrow external skills through review
+domain: meta
+type: playbook
+status: active
+version: 1
+created: 2026-05-26
+updated: 2026-05-26
+tags: [external-skills, imports, security, provenance]
+aliases:
+  - META-003
+  - external skill import path
+  - borrow skills safely
+related: [META-001, META-002]
+applies_when:
+  - evaluating public skill repositories
+  - importing a community skill
+  - adapting internet prompt packs
+review_required: false
+provenance: "Initial Agent Foundry system design."
+---
+
+## Principle
+
+External skills are inputs for review, not trusted source-of-truth content.
+
+## Rationale
+
+Public skills may be useful, but they can also be generic, stale, overbroad, insecure, license-incompatible, or misaligned with personal practices. Direct import increases skill rot and supply-chain risk.
+
+## Guidance
+
+Use `workflows/import-external-skills.md`. Capture provenance, check license and scripts, extract candidate practices, deduplicate against `indexes/practice_index.yaml`, then ask for human approval before activation. After approval, publish relevant adapters automatically.
+
+## Watch Out For
+
+Never execute external scripts, install dependencies, or copy large prompt packs into active adapters without explicit approval.
+
+## Example
+
+A public Codex skill may have a good trigger description and workflow. Borrow the structure by creating a canonical candidate, not by copying its entire `SKILL.md` into your active skill directory.
+
+## Related Practices
+
+- [[META-001]]
+- [[META-002]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-004-choose-smallest-suitable-asset.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-004-choose-smallest-suitable-asset.md
@@ -1,0 +1,57 @@
+---
+id: META-004
+title: Choose the smallest suitable asset
+domain: meta
+type: principle
+status: active
+version: 1
+created: 2026-05-26
+updated: 2026-05-26
+tags: [assets, discovery, skill-rot, scope]
+aliases:
+  - META-004
+  - skill is not the default
+  - smallest suitable reusable asset
+related: [GOV-002, META-001, META-002, META-003, META-005]
+applies_when:
+  - discovering repeated workflows
+  - deciding whether to create a skill
+  - choosing between skill, subagent, automation, extend, skip, or defer
+review_required: false
+provenance: "Extracted from Agent Foundry asset lifecycle design."
+---
+
+## Principle
+
+Within Agent Foundry, package repeated work into the smallest suitable reusable asset. A skill is one possible form, not the default.
+
+## Rationale
+
+Creating a new skill for every useful observation causes overlap and skill rot. Some repeated work is better handled as an automation, a bounded subagent, an extension of an existing asset, or a skipped/deferred candidate.
+
+## Guidance
+
+For each discovered workflow, compare:
+
+- `skill`: reusable workflow or operating guide used by the current agent.
+- `subagent`: bounded delegable role or investigation/review task.
+- `automation`: scheduled or event-driven check, report, reminder, or monitor.
+- `extend_existing`: existing asset mostly covers the need.
+- `skip`: one-off, vague, sensitive, or already sufficiently covered.
+- `defer`: promising but lacks enough evidence.
+
+Prefer the smallest form that produces the intended value with clear triggers and success criteria.
+
+For the cross-project complexity-control rule, apply [[GOV-002]]. This practice only decides the smallest suitable Agent Foundry asset form.
+
+## Watch Out For
+
+Do not create a skill when a checklist in an existing skill, a recurring automation, or a specialized subagent would be narrower and easier to maintain.
+
+## Related Practices
+
+- [[GOV-002]]
+- [[META-001]]
+- [[META-002]]
+- [[META-003]]
+- [[META-005]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-005-define-asset-boundaries-before-creation.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-005-define-asset-boundaries-before-creation.md
@@ -1,0 +1,57 @@
+---
+id: META-005
+title: Define asset boundaries before creation
+domain: meta
+type: principle
+status: active
+version: 1
+created: 2026-05-26
+updated: 2026-05-26
+tags: [assets, scope, boundaries, discovery]
+aliases:
+  - META-005
+  - define skill scope before creating it
+  - asset boundaries before asset creation
+related: [GOV-002, META-001, META-002, META-004]
+applies_when:
+  - creating or extending a reusable asset
+  - deciding skill scope
+  - preventing overlap between assets
+review_required: false
+provenance: "Extracted from Agent Foundry asset lifecycle design."
+---
+
+## Principle
+
+Before creating a reusable Agent Foundry asset, define its trigger, responsibility, non-responsibility, inputs, process, outputs, and success criteria.
+
+## Rationale
+
+Assets without explicit boundaries become broad prompt piles. Boundary definitions make assets easier to trigger, publish, review, merge, or retire.
+
+## Guidance
+
+Every asset should answer:
+
+- Trigger: when should it be used?
+- Responsibility: what does it do?
+- Non-responsibility: what does it explicitly not do?
+- Inputs: what information does it need?
+- Process: what steps or checks does it follow?
+- Outputs: what should it produce?
+- Success criteria: how do we know it helped?
+
+If these cannot be answered, defer the asset instead of creating it.
+
+For broader project mechanisms, layers, tools, or abstractions, apply [[GOV-002]] and [[ARCH-001]] before creating new machinery.
+
+## Watch Out For
+
+Avoid assets with vague triggers such as "help with engineering" or "improve code". Narrow the asset or extend an existing one.
+
+## Related Practices
+
+- [[GOV-002]]
+- [[META-001]]
+- [[META-002]]
+- [[META-004]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-006-memory-is-evidence-not-source-of-truth.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-006-memory-is-evidence-not-source-of-truth.md
@@ -1,0 +1,61 @@
+---
+id: META-006
+title: Memory is evidence, not source of truth
+domain: meta
+type: principle
+status: active
+version: 1
+created: 2026-05-26
+updated: 2026-05-26
+tags: [memory, evidence, source-of-truth, governance]
+aliases:
+  - META-006
+  - memory can suggest but foundry decides
+  - memory is not canonical
+related: [GOV-003, META-001, META-002, META-004]
+applies_when:
+  - using agent memory for discovery
+  - converting session history into practices or assets
+  - deciding what belongs in canonical records
+review_required: false
+provenance: "Extracted from Agent Foundry naming and memory boundary discussion."
+---
+
+## Principle
+
+For Agent Foundry governance, memory can suggest; canonical records decide. Agent memories, session summaries, activity logs, and rollout summaries are evidence sources, not canonical source of truth for practices, assets, adapters, or lifecycle state.
+
+## Rationale
+
+Memory is useful for discovering repeated patterns, user preferences, and usage evidence. It may also be incomplete, stale, noisy, or unreviewed. Durable practices and reusable assets require explicit governance, indexing, review, and publication.
+
+## Guidance
+
+Use memory as:
+
+- discovery evidence for repeated workflows;
+- preference evidence for candidate rules;
+- usage evidence candidates for assets.
+
+Do not use memory as the only authoritative home for:
+
+- canonical practices;
+- asset records;
+- adapter mappings;
+- approval policy;
+- lifecycle state.
+
+If a memory contains a durable rule, harvest it into `practices/`. If it indicates repeated work, process it through `discover assets`. If it records useful asset or practice use, record concise evidence through `scripts/record_asset_usage.py` so raw evidence stays local and shared review uses sanitized aggregates.
+
+For the cross-project rule that transient session context is evidence rather than durable project truth, apply [[GOV-003]].
+
+## Watch Out For
+
+Do not let automatically written memory silently override approved practices or active assets.
+
+## Related Practices
+
+- [[GOV-003]]
+- [[META-001]]
+- [[META-002]]
+- [[META-004]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-007-native-agent-learning-is-candidate-input.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-007-native-agent-learning-is-candidate-input.md
@@ -1,0 +1,62 @@
+---
+id: META-007
+title: Native agent learning is candidate input
+domain: meta
+type: principle
+status: active
+version: 1
+created: 2026-05-26
+updated: 2026-05-26
+tags: [native-learning, memory, skills, hermes, governance]
+aliases:
+  - META-007
+  - native skills can suggest but foundry canonizes
+  - do not disable native self-growth
+related: [META-001, META-003, META-006]
+applies_when:
+  - using Hermes native memory or self-improvement
+  - importing agent-native generated skills
+  - reconciling native agent learning with Agent Foundry
+review_required: false
+provenance: "Extracted from Hermes self-growth and Agent Foundry boundary discussion."
+---
+
+## Principle
+
+Native agent learning should remain enabled and useful. Agent-native memories, auto-generated skills, self-improvement artifacts, and project-local instructions are candidate inputs for Agent Foundry, not replacements for it.
+
+## Rationale
+
+Systems such as Hermes may improve themselves through memory, skill creation, and local skill refinement. Disabling those capabilities would reduce the agent's local effectiveness. The risk is not native learning itself; the risk is letting native outputs silently become durable cross-agent truth without review, dedupe, provenance, and publication control.
+
+## Guidance
+
+Allow native agent systems to:
+
+- remember local context;
+- create or refine local skills;
+- search session history;
+- suggest repeated workflows;
+- produce candidate procedures or prompts.
+
+Route durable or cross-agent outputs through Agent Foundry:
+
+- native memory finding -> `discover assets` or `harvest practices`;
+- native generated skill -> `import skill <path>`;
+- native usage insight -> `record_asset_usage.py`;
+- native workflow improvement -> proposed canonical practice or asset update.
+
+Do not deploy Agent Foundry in a way that disables Hermes memory, autonomous skill creation, or local self-improvement unless the user explicitly asks for a locked-down environment.
+
+## Watch Out For
+
+Avoid two failure modes:
+
+- bypass: native generated skills become cross-agent assets without review;
+- suppression: Agent Foundry instructions prevent a capable agent from using its native memory and self-improvement tools.
+
+## Related Practices
+
+- [[META-001]]
+- [[META-003]]
+- [[META-006]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-008-route-through-assets-constrain-with-practices.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-008-route-through-assets-constrain-with-practices.md
@@ -1,0 +1,76 @@
+---
+id: META-008
+title: Route through assets, constrain with practices
+domain: meta
+type: principle
+status: active
+version: 1
+created: 2026-05-26
+updated: 2026-05-26
+tags: [assets, practices, routing, dispatch, meta]
+aliases:
+  - META-008
+  - assets perform work, practices govern rules
+  - skill vs practice boundary
+  - invoke asset, apply practice
+related: [META-001, META-004, META-005, META-006]
+applies_when:
+  - interpreting user intent at session start
+  - deciding whether to invoke a skill or apply a rule
+  - writing or updating agent adapters
+  - discovering or creating new reusable capabilities
+review_required: false
+provenance: "Harvested from the practice vs asset boundary review on 2026-05-26."
+---
+
+## Principle
+
+Route user requests through assets; constrain execution with practices. Assets are user-facing reusable workflows. Practices are canonical behavioral rules. Do not conflate them.
+
+## Rationale
+
+When an agent treats a practice as a callable workflow, it invents unnecessary skills. When it treats an asset as a behavioral rule, it misses the structured process and success criteria the asset provides. A clear boundary prevents bloat, drift, and ambiguous responsibility.
+
+## Guidance
+
+Before acting on a request, classify it:
+
+1. **Is the user asking you to execute a repeatable workflow?**
+   - Match the request to an asset `usage_trigger`.
+   - Invoke the asset: load its inputs, process, and outputs.
+   - During execution, reference the canonical practices listed in the asset's `canonical_practices`.
+2. **Is the user asking you to behave differently or apply a constraint?**
+   - Match the request to a canonical practice in the relevant domain.
+   - Apply the practice's Principle and Guidance to your current behavior.
+   - Do not invent a new asset for a one-off behavioral correction.
+3. **Is the user asking you to update, canonize, or govern agent knowledge?**
+   - This is meta-work. Invoke the Practice Harvester asset, which itself references META practices.
+
+## Use This When
+
+- The user gives a command that could match both a short command and a general domain rule.
+- You are deciding whether to create a new skill or write a new practice.
+- You are updating an adapter and need to decide whether the content belongs in a skill body or in a rules section.
+
+## Watch Out For
+
+- Do not route a request to a practice when an active asset covers it. Practices constrain behavior; they do not own end-to-end workflows.
+- Do not invoke an asset when the user only asked for a behavioral correction. For example, "stop closing issues without comments" is a practice application (COLLAB-002), not a skill invocation.
+- Do not duplicate an asset's process into a practice entry. Assets own the workflow; practices own the rules.
+
+## Example
+
+User: `"harvest practices from this session"`
+- Classification: execute repeatable workflow → invoke asset `ASSET-META-001`
+- Asset process runs; during execution it references `META-001` (canonical practices are source of truth), `META-002` (harvest before publishing), etc.
+
+User: `"I noticed you keep choosing tools before defining boundaries. Stop doing that."`
+- Classification: behavioral correction → apply practice `ARCH-001`
+- No asset is invoked. The agent adjusts its behavior according to the principle.
+
+## Related Practices
+
+- [[META-001]]
+- [[META-004]]
+- [[META-005]]
+- [[META-006]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-009-make-adapter-fidelity-executable.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-009-make-adapter-fidelity-executable.md
@@ -1,0 +1,66 @@
+---
+id: META-009
+title: Make adapter fidelity executable
+domain: meta
+type: principle
+status: active
+version: 2
+created: 2026-05-27
+updated: 2026-05-28
+tags: [adapters, fidelity, verification, testing, publishing]
+aliases:
+  - META-009
+  - test adapter meaning, not only adapter existence
+  - executable adapter quality
+  - adapter fidelity check
+related: [META-001, META-002, META-008, RUNTIME-003]
+applies_when:
+  - publishing canonical practices into agent-specific adapters
+  - reviewing whether adapters preserve canonical intent
+  - adding support for a new agent runtime
+  - changing adapter generation or adapter quality checks
+review_required: false
+provenance: "Harvested from the adapter quality work on 2026-05-27, where file-existence checks were insufficient to prove that Codex, Claude Code, Hermes, and ChatGPT adapters preserved canonical practice semantics."
+---
+
+## Principle
+
+Adapter fidelity must be executable. Do not treat an adapter as correct just because the target file exists or was regenerated. The publish path must include checks that the adapter still carries the canonical semantics needed by that agent.
+
+## Rationale
+
+Agent adapters are lossy by default: each runtime has different instruction surfaces, length tolerance, trigger behavior, and deployment mechanics. A concise adapter can accidentally drop important constraints, while a full-fidelity adapter can become too long for the target agent to follow well. If quality remains a manual impression, drift appears only when a later agent fails to apply the intended rule.
+
+Executable checks turn adapter quality into a repeatable gate. They do not replace human review, but they catch obvious loss of meaning, missing triggers, missing asset IDs, and target-specific requirements before runtime publishing.
+
+## Guidance
+
+When publishing or reviewing adapters:
+
+1. Maintain an adapter quality checklist for each supported target.
+2. Check more than file existence:
+   - user-facing trigger phrases are present
+   - active canonical practice IDs required by the adapter profile are represented
+   - published asset IDs are represented
+   - target-specific conventions are followed
+   - high-fidelity targets retain enough detail to act correctly
+3. Run the executable adapter quality check before claiming adapters are publishable.
+4. Treat failed quality checks as adapter drift, not as cosmetic formatting issues.
+5. Update the check when adding a new adapter target or changing a target's expected instruction surface.
+
+Checks must verify the exact contract surface they claim to protect. If the requirement is "practice appears in Compact Preflight", the check must inspect the Compact Preflight section, not the entire adapter file. If the requirement is "runtime managed block is intact", the check must inspect the managed block, not only the target file's existence.
+
+## Watch Out For
+
+Do not let the check become a brittle text snapshot. It should verify durable meaning signals such as IDs, trigger vocabulary, ownership markers, and required target conventions. Exact wording may vary across adapters.
+
+Do not assume all agents need identical output. Fidelity means preserving the canonical behavior in the form the target agent can actually use.
+
+Do not accept a loose proxy when the contract surface is narrower. Broad text search can hide missing behavior when the same ID appears in references, examples, or unrelated sections.
+
+## Related Practices
+
+- [[META-001]]
+- [[META-002]]
+- [[META-008]]
+- [[RUNTIME-003]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-010-review-assets-with-lifecycle-evidence.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-010-review-assets-with-lifecycle-evidence.md
@@ -1,0 +1,65 @@
+---
+id: META-010
+title: Review assets with lifecycle evidence
+domain: meta
+type: principle
+status: active
+version: 1
+created: 2026-05-27
+updated: 2026-05-27
+tags: [assets, lifecycle, evidence, review, skill-rot]
+aliases:
+  - META-010
+  - asset lifecycle review needs evidence
+  - review assets before skill rot
+  - usage evidence drives asset lifecycle
+related: [META-004, META-005, META-008, META-009]
+applies_when:
+  - reviewing existing skills, subagents, automations, or other reusable assets
+  - deciding whether to keep, revise, deprecate, archive, split, or merge an asset
+  - detecting skill rot or stale reusable workflows
+  - adding lifecycle metadata to assets
+review_required: false
+provenance: "Harvested from the asset lifecycle work on 2026-05-27, where review needed usage evidence, overlap detection, and lifecycle states instead of informal judgment."
+---
+
+## Principle
+
+Review reusable assets with lifecycle evidence. Asset status should be based on usage, overlap, coverage, stale triggers, and verification evidence, not only on whether the asset still looks useful.
+
+## Rationale
+
+Skills, subagents, and automations rot when their triggers drift, their scope overlaps with newer assets, or their instructions stop matching the current canonical practices. Without lifecycle evidence, stale assets remain active because nobody remembers why they were created, and useful assets get rewritten because their value is not visible.
+
+Lifecycle review makes asset maintenance explicit. It gives agents a narrow way to recommend keep, revise, deprecate, archive, split, merge, or create follow-up evidence without turning every review into a broad rewrite.
+
+## Guidance
+
+When reviewing assets:
+
+1. Read the asset index and each relevant asset record.
+2. Check lifecycle state, review cadence, last usage, usage count, published targets, and canonical practice coverage.
+3. Compare assets for overlapping triggers, responsibilities, or canonical practice coverage.
+4. Recommend one lifecycle decision per asset:
+   - keep active
+   - revise
+   - deprecate
+   - archive
+   - split
+   - merge
+   - gather more evidence
+5. Prefer extending an existing asset when the new workflow shares the same trigger, responsibility, and success criteria.
+6. Prefer creating a new asset when the workflow has a distinct trigger, responsibility, user-facing output, or verification loop.
+
+## Watch Out For
+
+Do not require the user to approve routine evidence logging. Evidence should be concise, non-sensitive, and automatic when an active asset is invoked.
+
+Do not promote or remove an asset only because it has low usage. Low usage is a review signal, not an automatic lifecycle decision.
+
+## Related Practices
+
+- [[META-004]]
+- [[META-005]]
+- [[META-008]]
+- [[META-009]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-011-route-artifacts-before-abstracting-practices.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-011-route-artifacts-before-abstracting-practices.md
@@ -1,0 +1,80 @@
+---
+id: META-011
+title: Route artifacts before abstracting practices
+domain: meta
+type: heuristic
+status: active
+version: 1
+created: 2026-06-08
+updated: 2026-06-08
+tags: [harvesting, artifact-routing, practice-governance, review]
+aliases:
+  - META-011
+  - route artifacts before practices
+  - do not convert every insight into a practice
+related: [META-002, META-006, META-008, META-013]
+applies_when:
+  - running a harvest practices workflow
+  - extracting lessons from session notes or handoff dumps
+  - deciding whether a session insight belongs in practices
+review_required: false
+provenance: "Corrected harvest outcome from ChatGPT memory-system design and harvest discipline discussion; source context: docs/memory-system-handoff-dump.md."
+---
+
+## Principle
+
+In any `harvest practices` task, perform artifact routing before drafting practice candidates. Do not convert every important session insight into a practice.
+
+## Rationale
+
+The failed harvest converted important memory-system design content directly into practices without first deciding whether each item was research output, design evidence, future architecture, a project-local decision, or a generalized practice.
+
+## Guidance
+
+Before abstracting a lesson, route the source artifact into one of these classes:
+
+- evidence only;
+- design note;
+- research/reference material;
+- project-local decision;
+- workflow update;
+- practice candidate;
+- skill/asset candidate;
+- adapter update;
+- discard.
+
+Only items routed to `practice candidate` should continue through practice drafting. Items routed elsewhere may still be important, but they need a different canonical destination, review path, or no write at all.
+
+## Use This When
+
+- The user says `harvest practices`, `extract lessons`, `turn this session into foundry entries`, or equivalent.
+- A session contains a mix of research, design, user corrections, future architecture, workflow feedback, and reusable agent rules.
+
+## Watch Out For
+
+- Do not treat importance as evidence that something is a practice.
+- Do not create practice entries for research notes, domain design details, project-local decisions, or future-system concepts.
+- Do not invent destination directories or schemas during routing.
+
+## Example
+
+A memory-system design session may contain a useful taxonomy for research memos. If the current repository has no implemented research-memo substrate, route that taxonomy as design or research evidence, not as a general Agent Foundry practice.
+
+## Activation
+
+- Tier: workflow_embedded
+- Phases: harvest, import, review, before_candidate_drafting
+- Signals: harvesting mixed session content; important insights include research, design, local decisions, future architecture, or workflow feedback
+- Evidence: harvest output shows artifact routing before practice candidates are drafted
+
+## Review Notes
+
+- Human approval: approved on 2026-06-08.
+- Failure prevented: practice vault pollution by research notes, domain design details, project-local decisions, and future-system concepts.
+
+## Related Practices
+
+- [[META-002]]
+- [[META-006]]
+- [[META-008]]
+- [[META-013]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-012-treat-user-corrections-as-process-evidence-before-content-evidence.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-012-treat-user-corrections-as-process-evidence-before-content-evidence.md
@@ -1,0 +1,85 @@
+---
+id: META-012
+title: Treat user corrections as process evidence before content evidence
+domain: meta
+type: heuristic
+status: active
+version: 3
+created: 2026-06-08
+updated: 2026-06-10
+tags: [feedback-learning, corrections, harvesting, process-evidence]
+aliases:
+  - META-012
+  - user corrections are process evidence first
+  - corrections reveal workflow failures
+related: [META-002, META-006, META-011, COLLAB-005]
+applies_when:
+  - harvesting lessons from a session with user corrections
+  - reviewing an agent failure or workflow drift
+  - deciding whether correction content belongs in a domain record or process rule
+review_required: false
+provenance: "Corrected harvest outcome from ChatGPT memory-system design and harvest discipline discussion; source context: docs/memory-system-handoff-dump.md."
+---
+
+## Principle
+
+When the user corrects the agent's method, first treat the correction as evidence about the process, not merely as content inside the current domain.
+
+## Rationale
+
+The session contained user corrections about drift, loss of complexity, over-emphasis on action planning, weak generalization, and confusion between proposed and current systems. These are process failures, not merely memory-system content.
+
+## Guidance
+
+Analyze corrections for:
+
+- agent failure mode;
+- workflow weakness;
+- prompting gap;
+- review checklist gap;
+- handoff risk;
+- harvest risk;
+- approval-scope confusion;
+- generalizable practice evidence.
+
+After that process analysis, decide whether the correction also contains domain content worth routing elsewhere.
+
+When a correction points out that the agent generalized a system-specific mechanism too far, preserve the system-specific boundary before extracting any generic rule. For Agent Foundry, lifecycle mechanisms such as Core/Vault split, selected-output receipts, adapter publishing, harvest routing, and runtime install semantics belong in `meta` or `runtime` only when the practice is about Agent Foundry itself. Do not recast those mechanisms as generic architecture categories. If a broader lesson exists, restate it without Agent Foundry vocabulary, pass it through [[META-013]], and route it to `governance`, `architecture`, or another non-meta domain only after the generic trigger is clear.
+
+When the correction says the agent skipped or compressed the required workflow, do not treat a later `continue`, `approved`, or `do the whole chain` response as retroactive permission to skip the missing step. First name the process failure and restore the missing review checkpoint. Once the user approves the listed items and post-approval chain, continue through canonical mutation, checks, PR/traceability, merge/apply, and adapter/runtime publish automatically unless the implementation departs from the approved list, checks fail, risk increases, or a new unlisted runtime/global target appears.
+
+## Use This When
+
+- The user says the agent drifted, oversimplified, overbuilt, lost nuance, or confused current and proposed systems.
+- A correction changes how the agent should harvest, review, plan, or hand off work.
+- The same correction could be read as both domain content and workflow feedback.
+- The user points out that the agent over-interpreted approval, skipped harvest, published before review, or explained a missed step after the fact.
+
+## Watch Out For
+
+- Do not bury method corrections inside the domain being discussed.
+- Do not treat every correction as a new practice; route it first, then apply the generalization gate.
+- Do not confuse Agent Foundry-specific `meta` rules with generic governance or architecture rules merely because the wording sounds abstract.
+- Do not convert the user's approval of a direction into approval to bypass unshown workflow steps.
+- Do not publish adapters or runtime instructions first and then use an explanation as a substitute for the missing harvest report.
+- Do not turn the restored review checkpoint into unnecessary repeated approval when the user has already approved a complete listed chain and no escalation condition appears.
+- Do not record missed activation evidence unless a specific existing practice should have triggered.
+
+## Activation
+
+- Tier: workflow_embedded
+- Phases: harvest, review, handoff, failure_analysis
+- Signals: user correction about agent method, drift, oversimplification, overbuilding, lost nuance, or capability confusion
+- Evidence: harvest or review output names the process failure before routing any domain content
+
+## Review Notes
+
+- Human approval: approved on 2026-06-08.
+- Failure prevented: missing opportunities to improve Agent Foundry workflows because user corrections were buried as domain-specific discussion.
+
+## Related Practices
+
+- [[META-002]]
+- [[META-006]]
+- [[META-011]]
+- [[COLLAB-005]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-013-apply-generalization-gate-before-promoting-insights-into-practices.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-013-apply-generalization-gate-before-promoting-insights-into-practices.md
@@ -1,0 +1,75 @@
+---
+id: META-013
+title: Apply a generalization gate before promoting insights into practices
+domain: meta
+type: checklist
+status: active
+version: 1
+created: 2026-06-08
+updated: 2026-06-08
+tags: [harvesting, generalization, practice-governance, dedupe]
+aliases:
+  - META-013
+  - generalization gate
+  - practice candidates must generalize
+related: [META-002, META-011, META-012, GOV-003]
+applies_when:
+  - converting a session insight into a practice candidate
+  - reviewing harvest output for over-specific entries
+  - deciding whether to create, merge, defer, or reject a candidate
+review_required: false
+provenance: "Corrected harvest outcome from ChatGPT memory-system design and harvest discipline discussion; source context: docs/memory-system-handoff-dump.md."
+---
+
+## Principle
+
+A session insight must pass a generalization gate before becoming a practice candidate.
+
+## Rationale
+
+The earlier harvest generated too many memory-system-specific design points as practices. Agent Foundry practices should be reusable, reviewable, and deployable across work contexts.
+
+## Guidance
+
+Before drafting or promoting a practice candidate, ask:
+
+- Would this help in unrelated future work?
+- Would it help more than one agent or runtime?
+- Does it describe a repeatable judgment or process?
+- Can it be triggered operationally?
+- Is it independent of the current domain's vocabulary?
+- Is it more than a local design decision?
+- Can it be reviewed and maintained as a durable rule?
+
+If the answer is weak, route the item to a better artifact class, merge it into an existing entry, defer it, or list it as rejected-as-practice.
+
+## Use This When
+
+- A harvest contains many interesting but domain-specific insights.
+- A candidate depends on a future architecture that is not implemented.
+- A proposed rule sounds useful only inside the session's immediate domain vocabulary.
+
+## Watch Out For
+
+- Do not confuse "important" with "generalizable."
+- Do not create durable rules that are hard to activate or maintain.
+- Do not skip duplicate search after a candidate passes the gate.
+
+## Activation
+
+- Tier: workflow_embedded
+- Phases: harvest, import, review, candidate_drafting
+- Signals: session contains many interesting insights; a candidate depends on domain vocabulary, local decisions, or future architecture
+- Evidence: harvest output records gate results or rejected-as-practice reasons before canonical drafting
+
+## Review Notes
+
+- Human approval: approved on 2026-06-08.
+- Failure prevented: practice vault expansion with local design rules that are hard to activate or maintain.
+
+## Related Practices
+
+- [[META-002]]
+- [[META-011]]
+- [[META-012]]
+- [[GOV-003]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/RUNTIME-001-treat-agent-runtimes-as-shared-environments.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/RUNTIME-001-treat-agent-runtimes-as-shared-environments.md
@@ -1,0 +1,75 @@
+---
+id: RUNTIME-001
+title: Treat agent runtimes as shared, user-owned environments
+domain: runtime
+type: principle
+status: active
+version: 2
+created: 2026-05-26
+updated: 2026-06-11
+tags: [runtime, adapters, deployment, ownership, safety]
+aliases:
+  - RUNTIME-001
+  - do not overwrite unmanaged runtime files
+  - runtime directories are shared environments
+  - publish through managed blocks and markers
+  - do not execute canonical payloads directly
+related: [META-001, META-002, META-006, GOV-007, RUNTIME-002]
+applies_when:
+  - publishing Agent Foundry adapters into local agent runtimes
+  - installing generated skills or commands
+  - installing executable payloads from canonical assets or capability packs
+  - updating shared instruction files
+  - syncing cross-agent practices into Codex, Claude Code, Hermes, or ChatGPT
+review_required: false
+provenance: "Harvested from the runtime sync conflict review on 2026-05-26, where direct writes to ~/.claude/CLAUDE.md and unmarked Codex/Hermes skill directories exposed ownership ambiguity."
+---
+
+## Principle
+
+Treat agent runtime directories and shared configuration files as user-owned, tool-shared environments. Publish Agent Foundry content through managed blocks, namespaced files, ownership markers, backups, dry-runs, and human-approved adoption; never overwrite unmanaged runtime files by default.
+
+## Rationale
+
+Agent runtimes are not private output directories. Files such as `~/.claude/CLAUDE.md` may be edited by the user, the native agent, Agent Foundry, and other automation. Skill directories under `~/.codex/skills` or `~/.hermes/skills` look isolated, but a same-name directory can still belong to another system. Without explicit ownership boundaries, a publish step can silently erase or corrupt existing agent behavior.
+
+## Guidance
+
+Keep canonical practice entries and generated adapters inside the Agent Foundry repository. When installing into a real runtime:
+
+- Use managed include blocks or imports for central shared files.
+- Store generated runtime content in namespaced files or directories.
+- Install executable canonical payloads, such as helper scripts, into managed runtime or tool directories before execution instead of running them directly from the canonical store.
+- Mark generated skill directories with `.agent-foundry-managed`.
+- Refuse to overwrite unmarked files or directories by default.
+- Run dry-runs before writes and show destination paths.
+- Back up shared files before modifying a managed block.
+- Write or update install receipts that identify source root, selected Vault, source hash or version, destination path, and install time when executable payloads are installed.
+- Require explicit human approval before adopting an existing unmanaged runtime path.
+
+## Watch Out For
+
+Do not treat "adapter output exists" as permission to overwrite runtime state. Adapter generation describes the desired package shape; the sync layer still owns merge safety, collision detection, backup, and adoption rules.
+
+Do not treat "canonical payload exists" as permission to execute from the canonical store. Canonical records and payloads are reviewable source material; runtime install is the boundary where permissions, dependencies, executable bits, wrappers, receipts, and rollback behavior become concrete.
+
+## Example
+
+For Claude Code, write generated instructions to `~/.claude/agent-foundry/CLAUDE.md` and update only a bounded Agent Foundry import block in `~/.claude/CLAUDE.md`. For Codex or Hermes, update a skill directory only when it contains `.agent-foundry-managed`, unless the user explicitly approves adopting that directory.
+
+For a future capability pack that contains helper scripts, keep the accepted asset payload in the selected User Vault, then install a managed runtime copy under an Agent Foundry-owned tools location with a receipt. Generated runtime skills should point to the managed copy, not to an arbitrary source project or unverified pack staging directory.
+
+## Activation
+
+- Tier: always_preflight
+- Phases: before_runtime_write, before_adapter_publish, verification
+- Signals: writing into `~/.codex`, `~/.claude`, `~/.hermes`, ChatGPT project instructions, or any shared agent/runtime config; adopting an existing runtime path; executable asset or pack payload is being installed or referenced
+- Evidence: final report lists managed markers, backups, dry-run/apply behavior, install receipts, or explicit adoption for touched runtime paths
+
+## Related Practices
+
+- [[META-001]]
+- [[META-002]]
+- [[META-006]]
+- [[GOV-007]]
+- [[RUNTIME-002]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/RUNTIME-002-separate-portable-adapter-intent-from-machine-local-state.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/RUNTIME-002-separate-portable-adapter-intent-from-machine-local-state.md
@@ -1,0 +1,70 @@
+---
+id: RUNTIME-002
+title: Separate portable adapter intent from machine-local deployment state
+domain: runtime
+type: principle
+status: active
+version: 2
+created: 2026-05-26
+updated: 2026-06-11
+tags: [runtime, deployment, manifest, offline-sync, portability]
+aliases:
+  - RUNTIME-002
+  - runtime manifest is machine-local
+  - keep local deployment state out of git
+  - portable snapshots exclude local runtime state
+  - runtime tools are machine-local installs
+related: [RUNTIME-001, META-001, GOV-007]
+applies_when:
+  - designing runtime manifests
+  - syncing Agent Foundry across machines
+  - exporting portable snapshots
+  - installing adapters on a new machine
+  - installing generated runtime tools from canonical asset payloads
+review_required: false
+provenance: "Harvested from the runtime manifest redesign on 2026-05-26, where a tracked manifest risked syncing one machine's enabled targets and paths to other machines."
+---
+
+## Principle
+
+Separate portable adapter intent from machine-local deployment state. Track adapter profiles and runtime templates in the repository, but keep enabled targets, detected paths, and adoption decisions in gitignored local manifests; portable snapshots must exclude machine-local runtime state by default.
+
+## Rationale
+
+Adapter profiles answer "how should this type of agent be supported?" Runtime manifests answer "where should this machine install Agent Foundry now?" These are different facts. If a local manifest is tracked or included in portable snapshots, one machine's installed agents, paths, and adoption decisions can leak into another machine and cause wrong or unsafe deployments.
+
+## Guidance
+
+Use repository-tracked files for portable intent:
+
+- adapter profiles;
+- runtime manifest templates;
+- schemas, workflows, and install scripts.
+
+Use gitignored local files for machine-specific state:
+
+- enabled or disabled targets;
+- detected runtime paths;
+- local adoption decisions;
+- machine-specific install notes.
+- installed runtime tool copies and receipts derived from canonical asset payloads.
+
+Portable snapshots should include runtime templates but exclude local runtime manifests. New machines should initialize a local manifest from the template, detect available runtimes, and require review before enabling targets.
+
+When canonical assets contain executable payloads, keep the portable source and policy in the selected Vault, but put executable copies, wrappers, chmod state, dependency probes, and install receipts in machine-local runtime/tool state. Another machine should recreate those runtime copies through refresh/install from its selected Vault rather than inheriting paths or execution state from the original machine.
+
+## Watch Out For
+
+Do not confuse a conservative template with a detected local state. Templates should be safe defaults. Local manifests may enable targets, but that choice belongs to the current machine only.
+
+## Example
+
+Track `runtime/templates/runtime_manifest.template.yaml` in git with local targets disabled by default. Keep `runtime/local/runtime_manifest.yaml` ignored by git, and exclude it from portable snapshots. On a new machine, run `runtime_manifest.py init`, then detect, enable, configure, review, and install.
+
+For a helper-script asset, the Vault may store the accepted source payload, while `~/.agent-foundry/runtime/tools/...` stores the executable installed copy and receipt for the current machine.
+
+## Related Practices
+
+- [[RUNTIME-001]]
+- [[META-001]]
+- [[GOV-007]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/RUNTIME-003-sync-operations-must-expose-unambiguous-state.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/RUNTIME-003-sync-operations-must-expose-unambiguous-state.md
@@ -1,0 +1,95 @@
+---
+id: RUNTIME-003
+title: Sync operations must expose unambiguous state
+domain: runtime
+type: principle
+status: active
+version: 1
+created: 2026-05-27
+updated: 2026-05-27
+tags: [runtime, sync, state, git, safety, visibility]
+aliases:
+  - RUNTIME-003
+  - report exact state after every sync
+  - sync without ambiguity
+  - unambiguous final report
+  - status commands are read-only
+related: [RUNTIME-001, RUNTIME-002, COLLAB-004]
+applies_when:
+  - syncing Agent Foundry with remote repositories
+  - refreshing local runtimes after canonical changes
+  - pushing or pulling across machines
+  - reporting completion after multi-step sync workflows
+  - implementing sync status, review, compare, or report commands
+review_required: false
+provenance: "Harvested from the refresh workflow redesign on 2026-05-27, where git push failures and ambiguous local-vs-remote state led to uncertainty about whether adapters and runtimes were actually in sync."
+---
+
+## Principle
+
+Sync operations must expose unambiguous state. After every sync, report the exact commit hash, unpushed commits, runtime updates applied, and next actions required. Never leave the user guessing whether canonical files, generated adapters, and local runtimes are aligned.
+
+## Rationale
+
+Safety barriers like managed blocks and dry-runs prevent accidents, but they do not tell users whether their systems are in sync. A successful git pull does not mean adapters were regenerated. A successful adapter generation does not mean runtimes were updated. A successful runtime update does not mean changes were pushed to remote. Without explicit state reporting, users must manually infer alignment from scattered tool output, which leads to skipped steps, duplicate work, and silent drift.
+
+## Guidance
+
+After any sync or refresh workflow, produce an unambiguous Final Report that answers these questions explicitly:
+
+1. **What is the canonical state?** Report the exact commit hash after any commit.
+2. **What is the remote state?** Report whether local commits were pushed successfully, or if unpushed commits remain.
+3. **What adapters changed?** List which adapters were regenerated and why.
+4. **What runtime updates occurred?** List which runtime files were created, updated, or skipped.
+5. **What should happen next?** State the exact next action the user must take, if any.
+
+Use a structured, human-readable format. Do not rely on the user reading verbose command output. Do not report "done" when there are pending pushes or unreviewed changes.
+
+When network issues prevent push, report the failure explicitly and preserve the knowledge that unpushed commits exist. Do not silently defer or hide the issue.
+
+Status, report, check, review, and compare commands are read-only by default. If local state is missing, report that it has not been initialized and suggest the explicit initialization command. Do not create or mutate local state just to display status.
+
+## Watch Out For
+
+Do not assume that because a command succeeded, the overall sync is complete. A refresh workflow may involve git pull, conditional adapter regeneration, installation to runtimes, and git commit+push. Each step can succeed independently while the overall system remains out of sync. The Final Report is the only source of truth for the aggregate state.
+
+Do not omit the commit hash. Relative terms like "latest" or "just now" lose meaning across interruptions, compaction, or multi-machine work.
+
+Do not let a supposedly read-only status operation write machine-local manifests, sync state, usage logs, or adoption records. Read-only reporting must be safe to run repeatedly before install, after install, and on an unfamiliar machine.
+
+## Example
+
+After a refresh workflow, report:
+
+```
+Final Report
+- Commit: abc1234
+- Push: 1 commit pushed to origin/main
+- Adapters regenerated: claude-code, codex, hermes (canonical practices changed)
+- Runtime updates: claude-code managed block updated; codex skills copied; hermes skills copied
+- Next action: none
+```
+
+If push failed:
+
+```
+Final Report
+- Commit: abc1234
+- Push: FAILED (network timeout). 1 commit remains unpushed.
+- Adapters regenerated: claude-code, codex, hermes
+- Runtime updates: claude-code managed block updated; codex skills copied; hermes skills copied
+- Next action: retry push with `./sync.sh push` when network recovers
+```
+
+## Activation
+
+- Tier: always_preflight
+- Phases: after_sync, after_publish, after_install, final_report
+- Signals: git pull, git push, snapshot export/import, adapter publish, runtime install, sync status, refresh command, multi-machine handoff
+- Evidence: final report includes repo commit, unpushed commits, adapter changes, runtime updates, drift status, and exact next action
+
+## Related Practices
+
+- [[RUNTIME-001]]
+- [[RUNTIME-002]]
+- [[COLLAB-004]]

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/RUNTIME-004-sync-aggregates-not-raw-evidence.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/RUNTIME-004-sync-aggregates-not-raw-evidence.md
@@ -1,0 +1,70 @@
+---
+id: RUNTIME-004
+title: Sync aggregates, not raw evidence
+domain: runtime
+type: principle
+status: active
+version: 2
+created: 2026-05-27
+updated: 2026-05-28
+tags: [runtime, sync, evidence, privacy, review]
+aliases:
+  - RUNTIME-004
+  - keep raw usage local
+  - sync usage aggregates
+  - aggregate evidence across machines
+related: [RUNTIME-002, RUNTIME-003, META-006, META-010]
+applies_when:
+  - recording asset or practice usage evidence
+  - reviewing assets or practices across multiple machines
+  - exporting portable snapshots
+  - deciding what operational metadata is safe to sync
+review_required: false
+provenance: "Harvested from the multi-machine usage review design on 2026-05-27, where raw local evidence needed to stay private while review statistics needed cross-agent aggregation."
+---
+
+## Principle
+
+Sync aggregate usage statistics, not raw evidence. Raw usage logs are local audit evidence. Shared review should consume sanitized aggregate rows that can be merged across machines and agents.
+
+## Rationale
+
+Asset and practice review needs usage statistics from every machine where agents run. If usage evidence stays only local, reviews undercount active practices and assets. If raw evidence is synced directly, project names, prompts, notes, and session context can leak into remote repositories or portable snapshots.
+
+A two-layer model preserves both needs. Raw logs stay local for audit and reconstruction. Aggregates provide enough cross-machine signal for lifecycle review without copying sensitive session context.
+
+## Guidance
+
+Use two evidence layers:
+
+1. Raw local evidence:
+   - stored under gitignored local paths such as `usage/local/`;
+   - may include project, trigger, short note, agent, outcome, and date;
+   - excluded from snapshots and default remote sync.
+2. Shared aggregate evidence:
+   - stored in tracked files such as `usage/usage-aggregate.yaml`;
+   - includes subject type, subject ID, month, agent, hashed machine ID, outcome counts, and last-used date;
+   - excludes raw prompt text, project names, transcripts, and detailed notes.
+
+Review scripts should use aggregates as their primary input. Raw logs are evidence sources for local audit, migration, or aggregate rebuilds.
+
+When recording usage, update local raw evidence first, then update or rebuild the aggregate. When exporting portable snapshots, include aggregates and exclude raw local evidence.
+
+Only material applied usage belongs in shared usage aggregates. Review signals such as missed activation, suspected overbuild, noisy preflight, or "should have applied" evidence should stay in local raw evidence or a separate review channel unless explicitly summarized through an approved aggregate format. Do not let review signals inflate usage counts.
+
+## Watch Out For
+
+Do not treat aggregate counts as final truth about quality. They are review signals. Low usage means investigate, not automatically deprecate.
+
+Do not store unhashed machine names or raw session notes in shared aggregate files.
+
+Do not remove legacy logs until their useful information has been migrated or summarized.
+
+Do not rebuild aggregates from local logs without respecting evidence type. A rebuild must preserve the boundary between successful/material usage and review-only signals.
+
+## Related Practices
+
+- [[RUNTIME-002]]
+- [[RUNTIME-003]]
+- [[META-006]]
+- [[META-010]]

--- a/fixtures/capability-packs/optional-multi-agent/manifest.yaml
+++ b/fixtures/capability-packs/optional-multi-agent/manifest.yaml
@@ -1,16 +1,67 @@
 manifest_schema_version: 1
 pack_id: pack.multi-agent.optional
 title: Optional Multi-Agent Collaboration Pack
-description: Minimal optional capability snapshot with inert helper payload metadata.
+description: Candidate optional capability snapshot for role-generic GitHub multi-agent coordination helpers.
 lifecycle_status: candidate
-version: 0.1.0
-exported_at: 2026-06-11
+version: 0.2.0
+exported_at: 2026-06-12
 distribution_type: optional_capability
-source_provenance: "Agent Foundry public Core fixture for issue #75"
+source_provenance: "Agent Foundry public Core fixture for issue #79; Tiny IPA helper work used as evidence only."
 maintainer_contact: "https://github.com/farmerhunter/agent-foundry"
 license: "repository license"
 sensitivity: public
 review_state: unreviewed
+
+pack_contract:
+  promised_use_case: "Help a project operate GitHub issues, PRs, labels, comments, and optional Project status as a lightweight multi-agent scheduler."
+  deployment_role: "optional user-selected capability after bootstrap"
+  source_authority_after_deployment: "selected User Vault records and managed runtime/tool install receipts"
+  not_runtime_authority: "pack staging, product project evidence, and Core fixture paths"
+
+evidence_sources:
+  - "Tiny IPA tools/agents helper suite"
+  - "Tiny IPA role-generic agent helper design notes"
+  - "Agent Foundry #53 executable helper boundary"
+
+candidate_contents:
+  practices:
+    - "role-generic needs:<role> routing"
+    - "durable pickup and handoff comments"
+    - "explicit Execution Contract role fields"
+    - "dependency-gated ready queues"
+    - "read-only audit before write automation"
+  assets:
+    - "role-generic GitHub scheduler helper set"
+  docs_templates:
+    - "role routing config example"
+    - "Execution Contract template"
+    - "pickup and handoff comment templates"
+  executable_payload_candidates:
+    - "agent-inbox"
+    - "agent-ready-queue"
+    - "agent-pickup"
+    - "agent-handoff"
+    - "agent-audit"
+    - "agent-issue-context"
+    - "agent-pr-context"
+    - "agent-label"
+    - "agent-role-config"
+    - "gh-retry"
+    - "role routing library and config"
+
+project_local_overlays:
+  - "GH_REPO default repository"
+  - "GitHub Project ids, field ids, and status option ids"
+  - "Roadmap Status mapping"
+  - "issue type labels and project-specific label policy"
+  - "Project cache paths"
+
+rejected_as_pack:
+  - "Tiny IPA issue numbers, branch names, Project ids, and local cache files"
+  - "Project v2 as the scheduler source of truth"
+  - "mutating apply behavior before managed helper install exists"
+  - "execution from product project paths, pack staging, or canonical Vault payload paths"
+  - "active Agent Foundry practices without separate harvest review"
 
 compatibility:
   core_schema_version_min: 1
@@ -23,8 +74,8 @@ included_records:
     kind: practice
     lifecycle_status: candidate
     path: records/practices/COLLAB-PACK-001-review-handoff.md
-    source_version: 1
-    content_sha256: "cff47b12ef1fdda1cc975433226cd4c8d10124b87d71c7feb2659f7d4aaceed9"
+    source_version: 2
+    content_sha256: "3d68186c067db71927fd4861842c8c7f446e435c1dc0f17176cfdc18222a2116"
     destination_layer: canonical_vault_record
     membership_role: optional_member
     activation_default: manual_review
@@ -33,8 +84,8 @@ included_records:
     kind: asset
     lifecycle_status: candidate
     path: records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
-    source_version: 1
-    content_sha256: "aa875a255de4818d07e8f6af38490782a990a403150e83570d006f2e622d5e51"
+    source_version: 2
+    content_sha256: "e43c1f9205a51ccf796eba87ec16dc15f9a70255ad83e31322ffdd92f9495eb4"
     destination_layer: canonical_vault_record
     membership_role: optional_member
     activation_default: manual_review
@@ -42,7 +93,7 @@ included_records:
 
 executable_payloads:
   - id: helper.review-handoff-summary
-    title: Review Handoff Summary Helper
+    title: Review Handoff Summary Helper Fixture
     lifecycle_status: candidate
     path: payloads/helpers/review_handoff_summary.py
     source_sha256: "61ebb3b134a4ce82bba92103b8033a4474688057bfbf5be68e908d8322a1b334"
@@ -51,7 +102,7 @@ executable_payloads:
     install_boundary: managed_runtime_copy_required
     permissions: [filesystem-read]
     dependencies: []
-    runtime_impact: "May read reviewed issue or PR handoff text only after managed install."
+    runtime_impact: "Fixture payload stands in for the broader helper set and may read reviewed issue or PR handoff text only after managed install."
 
 conflict_policy:
   id_collision: fail_closed

--- a/fixtures/capability-packs/optional-multi-agent/records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
+++ b/fixtures/capability-packs/optional-multi-agent/records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
@@ -1,27 +1,41 @@
 id: ASSET-COLLAB-PACK-001
-title: Review Handoff Summary Helper
+title: Role-Generic GitHub Scheduler Helper Set
 asset_type: skill
 status: candidate
-version: 1
+version: 2
 created: 2026-06-11
-updated: 2026-06-11
-purpose: Draft a concise issue and PR completion handoff from reviewed local evidence.
-responsibility: Summarize scope, verification, residual risks, and reviewer target.
-non_responsibility: Does not post comments, mutate GitHub labels, install helpers, or execute from pack staging.
+updated: 2026-06-12
+purpose: Provide reviewed helper surfaces for role-generic GitHub issue and PR coordination.
+responsibility: Support inbox, ready-queue, pickup, handoff, audit, label routing, issue context, PR context, and retry wrappers after managed install.
+non_responsibility: Does not decide product scope, override issue contracts, make Project v2 the scheduler authority, install helpers, or execute from pack staging.
 inputs:
   - issue number
   - PR number
-  - verification results
+  - role name
+  - Execution Contract text
+  - GitHub label and comment state
+  - optional project-local routing config
 process:
-  - Read provided handoff evidence.
-  - Build a concise completion summary.
-  - Leave posting and label changes to Core or GitHub workflow tooling.
+  - Read durable GitHub issue, PR, label, and comment state.
+  - Resolve role labels and completion handoff from explicit configuration and contracts.
+  - Print dry-run plans before any mutating helper behavior is allowed.
+  - Keep Project status updates optional and project-configured.
+  - Leave installation and runtime exposure to managed Agent Foundry tooling.
 outputs:
-  - Handoff summary draft
+  - role inbox report
+  - ready queue report
+  - pickup or handoff dry-run
+  - audit report
+  - issue or PR context summary
 canonical_practices:
   - COLLAB-PACK-001
 published_to: []
 usage_triggers:
-  - review handoff summary
+  - agent inbox
+  - role handoff
+  - GitHub issue scheduler
+  - multi-agent ready queue
 success_criteria:
-  - The helper can be reviewed as source without being executed from the pack snapshot.
+  - The helper set can be reviewed as source without being executed from the pack snapshot.
+  - Project-specific defaults are represented as overlays rather than reusable pack defaults.
+  - Mutating actions remain disabled until managed install, permissions, and receipts exist.

--- a/fixtures/capability-packs/optional-multi-agent/records/practices/COLLAB-PACK-001-review-handoff.md
+++ b/fixtures/capability-packs/optional-multi-agent/records/practices/COLLAB-PACK-001-review-handoff.md
@@ -1,27 +1,31 @@
 ---
 id: COLLAB-PACK-001
-title: Review Handoff Discipline
+title: Role-Generic GitHub Handoff Routing
 domain: agent-collaboration
 type: checklist
 status: candidate
-version: 1
+version: 2
 created: 2026-06-11
-updated: 2026-06-11
-tags: [multi-agent, review, handoff]
+updated: 2026-06-12
+tags: [multi-agent, review, handoff, scheduler]
 aliases: [COLLAB-PACK-001]
 review_required: true
 ---
 
 ## Principle
 
-When an Implementer hands work to a Reviewer, durable issue and PR comments must identify scope, verification, residual risks, and the expected review target.
+Multi-agent GitHub work should route through explicit role labels, durable comments, and Execution Contract fields rather than relying on transient chat history or Project board status.
 
 ## Rationale
 
-Multi-agent work loses continuity when completion evidence lives only in a chat thread.
+Multi-agent work loses continuity when completion evidence lives only in a chat thread. A project-local helper suite can make handoff faster, but the reusable rule is the role-generic coordination model: `needs:<role>` labels identify the next actor, comments preserve context, and Project status remains a visual mirror rather than the scheduler source of truth.
 
 ## Guidance
 
-- Put handoff evidence on both the issue and PR when a PR exists.
-- Include exact verification commands and outcomes.
-- Mark unresolved risks explicitly instead of implying independent review has already happened.
+- Use one primary `needs:<role>` next-action label unless the issue contract explicitly allows parallel actors.
+- Put pickup and handoff evidence on durable issue and PR surfaces when a PR exists.
+- Include scope, verification commands and outcomes, residual risks, and the expected next role.
+- Parse explicit Execution Contract fields for owner role, review role, acceptance role, dependency gates, branch strategy, and completion handoff.
+- Prefer read-only inbox, ready-queue, pickup, handoff, and audit dry-runs before write automation.
+- Keep Project status and roadmap status as mirrors or reports unless a project explicitly configures them as managed outputs.
+- Treat project-specific repository names, Project ids, branch names, issue numbers, and status mappings as overlays, not reusable pack defaults.

--- a/scripts/check_capability_pack_fixtures.py
+++ b/scripts/check_capability_pack_fixtures.py
@@ -65,9 +65,6 @@ REQUIRED_PAYLOAD_FIELDS = {
 
 FORBIDDEN_PACK_TEXT = {
     "/Users/",
-    "runtime/local",
-    "usage/local",
-    "sync/local",
     "gho_",
 }
 

--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -593,6 +593,26 @@ def check_capability_pack_fixtures_script() -> list[str]:
     return output.splitlines()
 
 
+def check_bootstrap_pack_deployment_script() -> list[str]:
+    script = ROOT / "scripts" / "test_bootstrap_pack_deployment.py"
+    if not script.exists():
+        return ["Missing scripts/test_bootstrap_pack_deployment.py"]
+    result = subprocess.run(
+        ["python3", str(script)],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode == 0:
+        return []
+    output = (result.stdout + result.stderr).strip()
+    if not output:
+        return ["Bootstrap pack deployment fixture failed without output"]
+    return output.splitlines()
+
+
 def main() -> int:
     errors: list[str] = []
     errors += check_index_paths(VAULT_ROOT / "indexes" / "practice_index.yaml", VAULT_ROOT, "Practice")
@@ -613,6 +633,7 @@ def main() -> int:
     errors += check_adapter_quality_script()
     errors += check_activation_script()
     errors += check_capability_pack_fixtures_script()
+    errors += check_bootstrap_pack_deployment_script()
 
     if errors:
         print("Consistency check failed:")

--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -613,6 +613,26 @@ def check_bootstrap_pack_deployment_script() -> list[str]:
     return output.splitlines()
 
 
+def check_runtime_import_script() -> list[str]:
+    script = ROOT / "scripts" / "test_import_runtime_assets.py"
+    if not script.exists():
+        return ["Missing scripts/test_import_runtime_assets.py"]
+    result = subprocess.run(
+        ["python3", str(script)],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode == 0:
+        return []
+    output = (result.stdout + result.stderr).strip()
+    if not output:
+        return ["Runtime import fixture failed without output"]
+    return output.splitlines()
+
+
 def main() -> int:
     errors: list[str] = []
     errors += check_index_paths(VAULT_ROOT / "indexes" / "practice_index.yaml", VAULT_ROOT, "Practice")
@@ -634,6 +654,7 @@ def main() -> int:
     errors += check_activation_script()
     errors += check_capability_pack_fixtures_script()
     errors += check_bootstrap_pack_deployment_script()
+    errors += check_runtime_import_script()
 
     if errors:
         print("Consistency check failed:")

--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -270,6 +270,26 @@ def check_foundry_roots_script() -> list[str]:
     return output.splitlines()
 
 
+def check_operation_context_script() -> list[str]:
+    script = ROOT / "scripts" / "test_operation_context.py"
+    if not script.exists():
+        return ["Missing scripts/test_operation_context.py"]
+    result = subprocess.run(
+        ["python3", str(script)],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode == 0:
+        return []
+    output = (result.stdout + result.stderr).strip()
+    if not output:
+        return ["Operation-context fixture failed without output"]
+    return output.splitlines()
+
+
 def parse_simple_targets(text: str) -> dict[str, dict[str, str]]:
     targets: dict[str, dict[str, str]] = {}
     current: str | None = None
@@ -584,6 +604,7 @@ def main() -> int:
     errors += check_no_deepseek_direct_adapter()
     errors += check_usage_aggregate()
     errors += check_foundry_roots_script()
+    errors += check_operation_context_script()
     errors += check_runtime_manifest()
     errors += check_claude_managed_block_integrity()
     errors += check_cross_references()

--- a/scripts/deploy_capability_pack.py
+++ b/scripts/deploy_capability_pack.py
@@ -1,0 +1,525 @@
+#!/usr/bin/env python3
+"""Deploy a reviewed mandatory bootstrap capability pack into a selected Vault."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+from check_foundry_roots import (
+    VAULT_LAYOUT_MARKER,
+    frontmatter,
+    parse_marker,
+    scan_yaml_field,
+    simple_yaml_entries,
+    validate,
+)
+from foundry_config import ROOT
+
+
+REQUIRED_MANIFEST_FIELDS = {
+    "manifest_schema_version",
+    "pack_id",
+    "title",
+    "lifecycle_status",
+    "version",
+    "distribution_type",
+    "sensitivity",
+    "review_state",
+}
+
+REQUIRED_RECORD_FIELDS = {
+    "id",
+    "kind",
+    "lifecycle_status",
+    "path",
+    "source_version",
+    "content_sha256",
+    "destination_layer",
+    "membership_role",
+    "activation_default",
+    "import_action",
+}
+
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True)
+class PackRecord:
+    item_id: str
+    kind: str
+    source_path: Path
+    destination_path: Path
+    index_entry: dict[str, str]
+    source_sha256: str
+    deployed_text: str
+    deployed_sha256: str
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def write(path: Path, text: str, apply: bool) -> None:
+    print(f"{'write' if apply else 'would write'}: {path}")
+    if apply:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+
+def unquote(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def top_level_scalars(text: str) -> dict[str, str]:
+    data: dict[str, str] = {}
+    for raw in text.splitlines():
+        if raw.startswith(" ") or ":" not in raw:
+            continue
+        key, value = raw.split(":", 1)
+        value = value.strip()
+        if value:
+            data[key.strip()] = unquote(value)
+    return data
+
+
+def section_scalars(text: str, section: str) -> dict[str, str]:
+    data: dict[str, str] = {}
+    in_section = False
+    for raw in text.splitlines():
+        if raw == f"{section}:":
+            in_section = True
+            continue
+        if in_section and raw and not raw.startswith(" "):
+            break
+        if in_section and raw.startswith("  ") and ":" in raw:
+            key, value = raw.strip().split(":", 1)
+            data[key] = unquote(value)
+    return data
+
+
+def list_entries(text: str, section: str) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    in_section = False
+    saw_inline_empty = False
+
+    for raw in text.splitlines():
+        if raw.startswith(f"{section}:"):
+            in_section = True
+            saw_inline_empty = raw.split(":", 1)[1].strip() == "[]"
+            continue
+        if in_section and raw and not raw.startswith(" "):
+            break
+        if not in_section or saw_inline_empty:
+            continue
+        stripped = raw.strip()
+        if raw.startswith("  - "):
+            if current:
+                entries.append(current)
+            current = {}
+            item = stripped[2:].strip()
+            if ":" in item:
+                key, value = item.split(":", 1)
+                current[key.strip()] = unquote(value)
+            continue
+        if current is not None and raw.startswith("    ") and not raw.startswith("      ") and ":" in stripped:
+            key, value = stripped.split(":", 1)
+            current[key.strip()] = unquote(value)
+
+    if current:
+        entries.append(current)
+    return entries
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def inline_list(value: str) -> list[str]:
+    value = value.strip()
+    if not (value.startswith("[") and value.endswith("]")):
+        return []
+    return [item.strip().strip('"').strip("'") for item in value[1:-1].split(",") if item.strip()]
+
+
+def yaml_string(value: str) -> str:
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def destination_for(vault_root: Path, kind: str, source_path: Path) -> tuple[Path, dict[str, str], list[str]]:
+    errors: list[str] = []
+    if kind == "practice":
+        metadata = frontmatter(source_path)
+        item_id = metadata.get("id", "")
+        domain = metadata.get("domain", "")
+        if not item_id:
+            errors.append(f"{source_path}: practice missing id")
+        if not domain:
+            errors.append(f"{source_path}: practice missing domain")
+            domain = "uncategorized"
+        return (
+            vault_root / "practices" / domain / source_path.name,
+            {
+                "id": item_id,
+                "title": metadata.get("title", item_id),
+                "domain": domain,
+                "status": metadata.get("status", ""),
+                "path": f"practices/{domain}/{source_path.name}",
+            },
+            errors,
+        )
+    if kind == "asset":
+        item_id = scan_yaml_field(source_path, "id") or ""
+        asset_type = scan_yaml_field(source_path, "asset_type") or ""
+        if not item_id:
+            errors.append(f"{source_path}: asset missing id")
+        if not asset_type:
+            errors.append(f"{source_path}: asset missing asset_type")
+            asset_type = "asset"
+        directory = {"skill": "skills", "subagent": "subagents", "automation": "automations"}.get(
+            asset_type, f"{asset_type}s"
+        )
+        return (
+            vault_root / "assets" / directory / source_path.name,
+            {
+                "id": item_id,
+                "title": scan_yaml_field(source_path, "title") or item_id,
+                "asset_type": asset_type,
+                "status": scan_yaml_field(source_path, "status") or "",
+                "path": f"assets/{directory}/{source_path.name}",
+            },
+            errors,
+        )
+    return vault_root / source_path.name, {}, [f"{source_path}: unsupported record kind {kind}"]
+
+
+def pack_provenance(manifest: dict[str, str]) -> str:
+    pack_id = manifest.get("pack_id", "")
+    version = manifest.get("version", "")
+    source = manifest.get("source_provenance", "")
+    return f"Deployed from capability pack {pack_id} version {version}; source: {source}"
+
+
+def add_markdown_deployment_metadata(text: str, manifest: dict[str, str]) -> str:
+    if not text.startswith("---\n"):
+        return text
+    marker = "\n---\n"
+    end = text.find(marker, len("---\n"))
+    if end == -1:
+        return text
+    metadata = "\n".join(
+        [
+            f"provenance: {yaml_string(pack_provenance(manifest))}",
+            f"pack_membership: [{manifest.get('pack_id', '')}]",
+            f"pack_source_version: {yaml_string(manifest.get('version', ''))}",
+        ]
+    )
+    return text[:end].rstrip() + "\n" + metadata + text[end:]
+
+
+def add_yaml_deployment_metadata(text: str, manifest: dict[str, str]) -> str:
+    metadata = "\n".join(
+        [
+            f"provenance: {yaml_string(pack_provenance(manifest))}",
+            "pack_membership:",
+            f"  - {manifest.get('pack_id', '')}",
+            f"pack_source_version: {yaml_string(manifest.get('version', ''))}",
+        ]
+    )
+    return text.rstrip() + "\n" + metadata + "\n"
+
+
+def deployed_record_text(kind: str, source_text: str, manifest: dict[str, str]) -> str:
+    if kind == "practice":
+        return add_markdown_deployment_metadata(source_text, manifest)
+    if kind == "asset":
+        return add_yaml_deployment_metadata(source_text, manifest)
+    return source_text
+
+
+def parse_pack_records(
+    pack_root: Path, vault_root: Path, manifest: dict[str, str], manifest_text: str
+) -> tuple[list[PackRecord], list[str]]:
+    records: list[PackRecord] = []
+    errors: list[str] = []
+    seen_ids: set[str] = set()
+    for entry in list_entries(manifest_text, "included_records"):
+        item_id = entry.get("id", "<unknown>")
+        missing = sorted(REQUIRED_RECORD_FIELDS - entry.keys())
+        for field in missing:
+            errors.append(f"included_record {item_id} missing {field}")
+        if item_id in seen_ids:
+            errors.append(f"duplicate included_record id {item_id}")
+        seen_ids.add(item_id)
+        if missing:
+            continue
+        if entry.get("destination_layer") != "canonical_vault_record":
+            errors.append(f"included_record {item_id} must target canonical_vault_record")
+        if entry.get("import_action") not in {"create_or_review_update", "skip_if_present"}:
+            errors.append(f"included_record {item_id} import_action is not supported by bootstrap deploy")
+        digest = entry.get("content_sha256", "")
+        if not SHA256_RE.match(digest):
+            errors.append(f"included_record {item_id} has invalid content_sha256")
+            continue
+        source_path = pack_root / entry.get("path", "")
+        if not source_path.exists():
+            errors.append(f"included_record {item_id} source path missing: {entry.get('path')}")
+            continue
+        if sha256(source_path) != digest:
+            errors.append(f"included_record {item_id} content_sha256 mismatch")
+            continue
+        source_text = read(source_path)
+        text = deployed_record_text(entry["kind"], source_text, manifest)
+        destination_path, index_entry, destination_errors = destination_for(vault_root, entry["kind"], source_path)
+        errors.extend(destination_errors)
+        if index_entry.get("id") and index_entry.get("id") != item_id:
+            errors.append(f"included_record {item_id} id does not match record metadata {index_entry.get('id')}")
+        if not destination_errors:
+            records.append(
+                PackRecord(
+                    item_id=item_id,
+                    kind=entry["kind"],
+                    source_path=source_path,
+                    destination_path=destination_path,
+                    index_entry=index_entry,
+                    source_sha256=digest,
+                    deployed_text=text,
+                    deployed_sha256=sha256_text(text),
+                )
+            )
+    if not records:
+        errors.append("included_records must not be empty")
+    return records, errors
+
+
+def validate_manifest(core_root: Path, vault_root: Path, pack_root: Path, manifest_path: Path) -> tuple[dict[str, str], list[PackRecord], list[str]]:
+    errors: list[str] = []
+    text = read(manifest_path)
+    manifest = top_level_scalars(text)
+    missing = sorted(REQUIRED_MANIFEST_FIELDS - manifest.keys())
+    for field in missing:
+        errors.append(f"manifest missing {field}")
+    if manifest.get("distribution_type") != "mandatory_bootstrap":
+        errors.append("only mandatory_bootstrap packs are supported by this deployment path")
+    if manifest.get("lifecycle_status") != "reviewed" or manifest.get("review_state") != "reviewed":
+        errors.append("mandatory bootstrap pack must be reviewed before deployment")
+    if manifest.get("sensitivity") != "public":
+        errors.append("mandatory bootstrap pack must be public")
+
+    compatibility = section_scalars(text, "compatibility")
+    if "vault_layout_versions" not in compatibility:
+        errors.append("compatibility missing vault_layout_versions")
+    else:
+        vault_marker, marker_errors = parse_marker(vault_root / VAULT_LAYOUT_MARKER)
+        errors.extend(f"vault marker {error}" for error in marker_errors)
+        vault_layout = str(vault_marker.get("layout_version", ""))
+        if vault_layout and vault_layout not in inline_list(compatibility["vault_layout_versions"]):
+            errors.append(f"pack does not support selected Vault layout version {vault_layout}")
+    if compatibility.get("requires_bootstrap_pack") != "false":
+        errors.append("mandatory bootstrap pack must not require a prior bootstrap pack")
+
+    if list_entries(text, "executable_payloads"):
+        errors.append("bootstrap deployment refuses executable payloads")
+
+    records, record_errors = parse_pack_records(pack_root, vault_root, manifest, text)
+    errors.extend(record_errors)
+    if not (core_root / "schemas" / "capability-pack-manifest.schema.yaml").exists():
+        errors.append("core capability pack manifest schema missing")
+    return manifest, records, errors
+
+
+def existing_entries(vault_root: Path, kind: str) -> tuple[list[dict[str, str]], list[str]]:
+    if kind == "practice":
+        return simple_yaml_entries(read(vault_root / "indexes" / "practice_index.yaml"), "practices")
+    return simple_yaml_entries(read(vault_root / "indexes" / "asset_index.yaml"), "assets")
+
+
+def detect_conflicts(vault_root: Path, records: list[PackRecord]) -> tuple[list[PackRecord], list[PackRecord], list[str]]:
+    added: list[PackRecord] = []
+    skipped: list[PackRecord] = []
+    conflicts: list[str] = []
+    practice_ids = {entry.get("id", "") for entry in existing_entries(vault_root, "practice")[0]}
+    asset_ids = {entry.get("id", "") for entry in existing_entries(vault_root, "asset")[0]}
+    by_kind = {
+        "practice": {entry.get("id", ""): entry for entry in existing_entries(vault_root, "practice")[0]},
+        "asset": {entry.get("id", ""): entry for entry in existing_entries(vault_root, "asset")[0]},
+    }
+
+    for record in records:
+        if record.kind == "practice" and record.item_id in asset_ids:
+            conflicts.append(f"{record.item_id}: id already exists as an asset")
+            continue
+        if record.kind == "asset" and record.item_id in practice_ids:
+            conflicts.append(f"{record.item_id}: id already exists as a practice")
+            continue
+        indexed = by_kind.get(record.kind, {}).get(record.item_id)
+        rel_destination = str(record.destination_path.relative_to(vault_root))
+        if indexed and indexed.get("path") != rel_destination:
+            conflicts.append(
+                f"{record.item_id}: index path {indexed.get('path')} conflicts with pack destination {rel_destination}"
+            )
+            continue
+        if record.destination_path.exists():
+            if not indexed:
+                conflicts.append(f"{record.item_id}: record file exists without a matching index entry")
+            elif sha256(record.destination_path) == record.deployed_sha256:
+                skipped.append(record)
+            else:
+                conflicts.append(f"{record.item_id}: local Vault record differs from pack content")
+            continue
+        if indexed:
+            conflicts.append(f"{record.item_id}: index entry exists but record file is missing")
+            continue
+        added.append(record)
+    return added, skipped, conflicts
+
+
+def update_grouping(text: str, group_key: str, item_key: str, item_id: str) -> str:
+    empty_line = f"{group_key}: {{}}"
+    if empty_line in text:
+        return text.replace(empty_line, f"{group_key}:\n  {item_key}: [{item_id}]", 1)
+
+    lines = text.splitlines()
+    start = next((index for index, line in enumerate(lines) if line == f"{group_key}:"), None)
+    if start is None:
+        return text.rstrip() + f"\n\n{group_key}:\n  {item_key}: [{item_id}]\n"
+
+    end = start + 1
+    while end < len(lines) and (not lines[end] or lines[end].startswith(" ")):
+        end += 1
+
+    for index in range(start + 1, end):
+        if lines[index].startswith(f"  {item_key}:"):
+            values = inline_list(lines[index].split(":", 1)[1].strip())
+            if item_id not in values:
+                values.append(item_id)
+                lines[index] = f"  {item_key}: [{', '.join(values)}]"
+            return "\n".join(lines).rstrip() + "\n"
+
+    lines.insert(end, f"  {item_key}: [{item_id}]")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def append_index_entry(text: str, list_key: str, entry: dict[str, str]) -> str:
+    if f"{list_key}: []" in text:
+        head = text.replace(f"{list_key}: []", f"{list_key}:", 1).rstrip()
+        return head + "\n" + index_entry_text(entry)
+    if f"  - id: {entry['id']}" in text:
+        return text
+    return text.rstrip() + "\n" + index_entry_text(entry)
+
+
+def index_entry_text(entry: dict[str, str]) -> str:
+    lines = [f"  - id: {entry['id']}"]
+    for key in ["title", "asset_type", "domain", "status", "path"]:
+        value = entry.get(key, "")
+        if value:
+            lines.append(f"    {key}: {value}")
+    return "\n".join(lines) + "\n"
+
+
+def update_index_text(text: str, kind: str, records: list[PackRecord]) -> str:
+    text = re.sub(r"^updated: .*$", f"updated: {date.today().isoformat()}", text, flags=re.MULTILINE)
+    for record in records:
+        if kind == "practice":
+            text = update_grouping(text, "domains", record.index_entry["domain"], record.item_id)
+            text = append_index_entry(text, "practices", record.index_entry)
+        else:
+            text = update_grouping(text, "asset_types", record.index_entry["asset_type"], record.item_id)
+            text = append_index_entry(text, "assets", record.index_entry)
+    return text
+
+
+def deploy(core_root: Path, vault_root: Path, pack_root: Path, apply: bool) -> int:
+    root_errors = validate(core_root, vault_root)
+    if root_errors:
+        print("Capability pack deployment failed root validation:")
+        for error in root_errors:
+            print(f"- {error}")
+        return 1
+
+    manifest_path = pack_root / "manifest.yaml"
+    if not manifest_path.exists():
+        print(f"Capability pack manifest missing: {manifest_path}")
+        return 1
+
+    manifest, records, manifest_errors = validate_manifest(core_root, vault_root, pack_root, manifest_path)
+    if manifest_errors:
+        print("Capability pack deployment failed manifest validation:")
+        for error in manifest_errors:
+            print(f"- {error}")
+        return 1
+
+    added, skipped, conflicts = detect_conflicts(vault_root, records)
+    if conflicts:
+        print("Capability pack deployment found conflicts:")
+        for conflict in conflicts:
+            print(f"- {conflict}")
+        print("Deployment summary:")
+        print("added: 0")
+        print("updated: 0")
+        print(f"skipped: {len(skipped)}")
+        print(f"conflicts: {len(conflicts)}")
+        return 1
+
+    print(f"Deploying pack: {manifest['pack_id']} {manifest['version']}")
+    for record in added:
+        write(record.destination_path, record.deployed_text, apply)
+
+    practice_adds = [record for record in added if record.kind == "practice"]
+    asset_adds = [record for record in added if record.kind == "asset"]
+    if practice_adds:
+        path = vault_root / "indexes" / "practice_index.yaml"
+        write(path, update_index_text(read(path), "practice", practice_adds), apply)
+    if asset_adds:
+        path = vault_root / "indexes" / "asset_index.yaml"
+        write(path, update_index_text(read(path), "asset", asset_adds), apply)
+
+    print("Deployment summary:")
+    print(f"added: {len(added)}")
+    print("updated: 0")
+    print(f"skipped: {len(skipped)}")
+    print("conflicts: 0")
+
+    if apply:
+        post_errors = validate(core_root, vault_root)
+        if post_errors:
+            print("Capability pack deployed but post-deploy validation failed:")
+            for error in post_errors:
+                print(f"- {error}")
+            return 1
+        print("Capability pack deployed and selected Vault validated.")
+    else:
+        print("Dry-run only. Re-run with --apply to deploy the bootstrap pack.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Deploy a reviewed mandatory bootstrap capability pack into a selected Vault.")
+    parser.add_argument("pack_root", help="Capability pack directory containing manifest.yaml.")
+    parser.add_argument("--core-root", default=str(ROOT), help="Agent Foundry Core root.")
+    parser.add_argument("--vault-root", required=True, help="Selected Agent Foundry Vault root.")
+    parser.add_argument("--apply", action="store_true", help="Write files. Default is dry-run.")
+    args = parser.parse_args()
+
+    core_root = Path(args.core_root).expanduser().resolve()
+    vault_root = Path(args.vault_root).expanduser().resolve()
+    pack_root = Path(args.pack_root).expanduser().resolve()
+    return deploy(core_root, vault_root, pack_root, args.apply)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/import_runtime_assets.py
+++ b/scripts/import_runtime_assets.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Stage explicit runtime/source files as reviewed import evidence."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from operation_context import (
+    CONTEXT_CORE,
+    CONTEXT_GENERATED,
+    CONTEXT_VAULT,
+    build_context,
+    classify_context,
+    configured_roots,
+    is_relative_to,
+    text_report,
+)
+
+
+RUNTIMES = {"codex", "claude-code", "hermes", "chatgpt", "prompts", "helper-files", "other"}
+ROUTES = {
+    "practice_candidate",
+    "asset_candidate",
+    "pack_candidate",
+    "project_local_decision",
+    "design_note",
+    "discard",
+    "future_work",
+}
+TEXT_EXTENSIONS = {
+    ".cfg",
+    ".cjs",
+    ".ini",
+    ".js",
+    ".json",
+    ".jsx",
+    ".md",
+    ".mjs",
+    ".prompt",
+    ".py",
+    ".sh",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+SCRIPT_EXTENSIONS = {".cjs", ".js", ".jsx", ".mjs", ".py", ".sh", ".ts", ".tsx"}
+DEFAULT_MAX_BYTES = 200_000
+
+
+@dataclass
+class SourceRecord:
+    path: Path
+    source_context: str
+    status: str
+    routing: str
+    reason: str
+    text: str
+    size_bytes: int
+    sha256: str
+    has_script_surface: bool
+
+
+def yaml_scalar(value: object) -> str:
+    text = str(value).replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{text}"'
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9]+", "-", value).strip("-").lower()
+    return slug[:80] or "runtime-import"
+
+
+def fence_for(text: str) -> str:
+    longest = 2
+    for match in re.finditer(r"`+", text):
+        longest = max(longest, len(match.group(0)))
+    return "`" * (longest + 1)
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def looks_like_script(path: Path, text: str) -> bool:
+    if path.suffix.lower() in SCRIPT_EXTENSIONS:
+        return True
+    first_line = text.splitlines()[0] if text.splitlines() else ""
+    return first_line.startswith("#!")
+
+
+def infer_routing(path: Path, runtime: str, has_script_surface: bool, rejected: bool) -> str:
+    if rejected:
+        return "discard"
+    name = path.name.lower()
+    suffix = path.suffix.lower()
+    if has_script_surface:
+        return "asset_candidate"
+    if name in {"skill.md", "agents.md", "claude.md"}:
+        return "practice_candidate"
+    if "prompt" in name or runtime in {"chatgpt", "prompts"}:
+        return "pack_candidate"
+    if suffix in {".json", ".yaml", ".yml", ".toml"}:
+        return "design_note"
+    return "asset_candidate"
+
+
+def collect_sources(paths: list[Path], recursive: bool) -> list[Path]:
+    sources: list[Path] = []
+    seen: set[Path] = set()
+    for source in paths:
+        source = source.expanduser().resolve()
+        if source.is_file():
+            candidates = [source]
+        elif source.is_dir():
+            iterator = source.rglob("*") if recursive else source.iterdir()
+            candidates = [path.resolve() for path in iterator if path.is_file() and not path.name.startswith(".")]
+        else:
+            candidates = [source]
+        for candidate in sorted(candidates):
+            if candidate not in seen:
+                seen.add(candidate)
+                sources.append(candidate)
+    return sources
+
+
+def read_source(
+    path: Path,
+    core_root: Path,
+    vault_root: Path,
+    adapter_root: Path,
+    max_bytes: int,
+    source_runtime: str,
+    routing_override: str,
+) -> SourceRecord:
+    source_context = classify_context(path.parent if path.is_file() else path, core_root, vault_root, adapter_root)
+    if source_context in {CONTEXT_CORE, CONTEXT_VAULT, CONTEXT_GENERATED}:
+        return SourceRecord(
+            path=path,
+            source_context=source_context,
+            status="rejected",
+            routing="discard",
+            reason=f"source context {source_context} is not a runtime or evidence input",
+            text="",
+            size_bytes=0,
+            sha256="",
+            has_script_surface=False,
+        )
+    if not path.exists() or not path.is_file():
+        return SourceRecord(
+            path=path,
+            source_context=source_context,
+            status="rejected",
+            routing="discard",
+            reason="source file does not exist or is not a file",
+            text="",
+            size_bytes=0,
+            sha256="",
+            has_script_surface=False,
+        )
+
+    data = path.read_bytes()
+    digest = sha256_bytes(data)
+    if len(data) > max_bytes:
+        return SourceRecord(
+            path=path,
+            source_context=source_context,
+            status="rejected",
+            routing="discard",
+            reason=f"source file exceeds max_bytes={max_bytes}",
+            text="",
+            size_bytes=len(data),
+            sha256=digest,
+            has_script_surface=path.suffix.lower() in SCRIPT_EXTENSIONS,
+        )
+    if path.suffix.lower() not in TEXT_EXTENSIONS:
+        return SourceRecord(
+            path=path,
+            source_context=source_context,
+            status="rejected",
+            routing="discard",
+            reason=f"unsupported text extension: {path.suffix or '<none>'}",
+            text="",
+            size_bytes=len(data),
+            sha256=digest,
+            has_script_surface=False,
+        )
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        return SourceRecord(
+            path=path,
+            source_context=source_context,
+            status="rejected",
+            routing="discard",
+            reason="source file is not valid UTF-8 text",
+            text="",
+            size_bytes=len(data),
+            sha256=digest,
+            has_script_surface=False,
+        )
+
+    has_script_surface = looks_like_script(path, text)
+    routing = routing_override or infer_routing(path, source_runtime, has_script_surface, rejected=False)
+    return SourceRecord(
+        path=path,
+        source_context=source_context,
+        status="candidate",
+        routing=routing,
+        reason="explicit source path staged for human review",
+        text=text,
+        size_bytes=len(data),
+        sha256=digest,
+        has_script_surface=has_script_surface,
+    )
+
+
+def render_record(
+    record: SourceRecord,
+    source_runtime: str,
+    sensitivity: str,
+    license_status: str,
+    retrieved_at: str,
+) -> str:
+    lines = [
+        "---",
+        "schema_version: 1",
+        "record_type: runtime_import_evidence",
+        f"status: {record.status}",
+        f"source_runtime: {source_runtime}",
+        f"source_context: {record.source_context}",
+        f"source_path: {yaml_scalar(record.path)}",
+        f"source_sha256: {yaml_scalar(record.sha256)}",
+        f"source_size_bytes: {record.size_bytes}",
+        f"retrieved_at: {retrieved_at}",
+        f"license_status: {yaml_scalar(license_status)}",
+        f"sensitivity: {yaml_scalar(sensitivity)}",
+        "review_required: true",
+        f"routing_recommendation: {record.routing}",
+        f"has_script_surface: {'true' if record.has_script_surface else 'false'}",
+        "runtime_source_preserved: true",
+        "activation_performed: false",
+        "runtime_write_performed: false",
+        "---",
+        "",
+        "# Runtime Import Evidence",
+        "",
+        "## Provenance",
+        "",
+        f"- Source runtime: `{source_runtime}`",
+        f"- Source path: `{record.path}`",
+        f"- Source context: `{record.source_context}`",
+        f"- Source SHA-256: `{record.sha256}`",
+        f"- Retrieved at: `{retrieved_at}`",
+        "",
+        "## Review Routing",
+        "",
+        f"- Status: `{record.status}`",
+        f"- Recommendation: `{record.routing}`",
+        f"- Reason: {record.reason}",
+        f"- Sensitivity: `{sensitivity}`",
+        f"- License: `{license_status}`",
+        f"- Script or executable surface present: `{'yes' if record.has_script_surface else 'no'}`",
+        "",
+        "## Safety Notes",
+        "",
+        "- Imported content is review evidence only.",
+        "- Do not execute bundled scripts or helper files during review.",
+        "- Do not activate, publish, or install this content without human approval.",
+        "- Preserve the native runtime/source file.",
+    ]
+    if record.text:
+        fence = fence_for(record.text)
+        lines.extend(["", "## Source Snapshot", "", fence, record.text.rstrip("\n"), fence])
+    else:
+        lines.extend(["", "## Source Snapshot", "", f"Content omitted: {record.reason}"])
+    return "\n".join(lines) + "\n"
+
+
+def plan_records(
+    args: argparse.Namespace,
+    core_root: Path,
+    vault_root: Path,
+    adapter_root: Path,
+) -> tuple[Path, list[tuple[SourceRecord, Path, str]]]:
+    staging_root = (vault_root / "imports" / "inbox").resolve()
+    if not is_relative_to(staging_root, vault_root / "imports" / "inbox"):
+        raise SystemExit(f"Refusing staging root outside Vault imports/inbox: {staging_root}")
+
+    explicit_paths = [Path(path) for path in args.source]
+    sources = collect_sources(explicit_paths, args.recursive)
+    if not sources:
+        raise SystemExit("No source files found from explicit source paths.")
+    if len(sources) > args.max_files:
+        raise SystemExit(f"Refusing to stage {len(sources)} files; pass a narrower path or raise --max-files.")
+
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    records: list[tuple[SourceRecord, Path, str]] = []
+    used_names: set[str] = set()
+    for source in sources:
+        record = read_source(
+            source,
+            core_root,
+            vault_root,
+            adapter_root,
+            args.max_bytes,
+            args.source_runtime,
+            args.routing or "",
+        )
+        slug = slugify(f"{args.source_runtime}-{source.stem}-{record.sha256[:10] or record.status}")
+        name = f"runtime-import-{now[:10]}-{slug}.md"
+        counter = 2
+        while name in used_names:
+            name = f"runtime-import-{now[:10]}-{slug}-{counter}.md"
+            counter += 1
+        used_names.add(name)
+        content = render_record(record, args.source_runtime, args.sensitivity, args.license, now)
+        records.append((record, staging_root / name, content))
+    return staging_root, records
+
+
+def parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Stage explicit runtime/source paths as import evidence.")
+    parser.add_argument("--source", action="append", required=True, help="Explicit runtime/source file or directory.")
+    parser.add_argument("--source-runtime", required=True, choices=sorted(RUNTIMES), help="Runtime or source family.")
+    parser.add_argument("--routing", choices=sorted(ROUTES), default="", help="Override routing recommendation.")
+    parser.add_argument("--sensitivity", default="unknown-review-required", help="Sensitivity review status.")
+    parser.add_argument("--license", default="unknown-review-required", help="License review status.")
+    parser.add_argument("--core-root", default="", help="Agent Foundry Core root.")
+    parser.add_argument("--vault-root", default="", help="Selected Vault root. Writes go to imports/inbox only.")
+    parser.add_argument("--adapter-root", default="", help="Generated adapter output root.")
+    parser.add_argument("--recursive", action="store_true", help="Read files recursively under explicit directories.")
+    parser.add_argument("--max-files", type=int, default=20, help="Maximum source files to stage.")
+    parser.add_argument("--max-bytes", type=int, default=DEFAULT_MAX_BYTES, help="Maximum bytes copied per source file.")
+    parser.add_argument("--apply", action="store_true", help="Write staged records. Default is dry-run.")
+    parser.add_argument("--quiet-context", action="store_true", help="Do not print operation context report.")
+    return parser
+
+
+def main() -> int:
+    args = parser().parse_args()
+    core_root, vault_root = configured_roots(args.core_root, args.vault_root)
+    adapter_root = Path(args.adapter_root).expanduser().resolve() if args.adapter_root else core_root / "adapters"
+    context = build_context("import", Path.cwd(), core_root, vault_root, adapter_root)
+    if not args.quiet_context:
+        print(text_report(context))
+    if context["root_validation"] != "passed":
+        print("Refusing import staging because Core/Vault root validation failed.", file=sys.stderr)
+        return 1
+
+    staging_root, records = plan_records(args, core_root, vault_root, adapter_root)
+    print(f"{'write' if args.apply else 'would write'} staging root: {staging_root}")
+    for record, output_path, content in records:
+        print(f"{'write' if args.apply else 'would write'}: {output_path}")
+        print(f"  source: {record.path}")
+        print(f"  status: {record.status}")
+        print(f"  routing: {record.routing}")
+        print(f"  reason: {record.reason}")
+        if args.apply:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(content, encoding="utf-8")
+    if not args.apply:
+        print("Dry-run only. Re-run with --apply to stage records.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install_foundry.py
+++ b/scripts/install_foundry.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from adapter_install_receipt import write_receipt
 from foundry_config import CONFIG_PATH, parse_config, write_config
+from operation_context import print_operation_context
 from runtime_manifest import parse_targets, read_manifest
 
 
@@ -54,6 +55,7 @@ def main() -> int:
     args = parser.parse_args()
     core_root, vault_root = configured_roots(args.core_root, args.vault_root)
     adapter_root = Path(args.adapter_root).expanduser().resolve() if args.adapter_root else core_root / "adapters"
+    print_operation_context("install", core_root=core_root, vault_root=vault_root, adapter_root=adapter_root)
 
     if not args.skip_check:
         code = run(["python3", "scripts/check_consistency.py"], execute=True)

--- a/scripts/install_foundry.py
+++ b/scripts/install_foundry.py
@@ -8,12 +8,18 @@ import subprocess
 from pathlib import Path
 
 from adapter_install_receipt import write_receipt
+from deploy_capability_pack import deploy as deploy_capability_pack, top_level_scalars
 from foundry_config import CONFIG_PATH, parse_config, write_config
+from init_vault import initialize
 from operation_context import print_operation_context
+from publish_adapters import publish as publish_adapters
 from runtime_manifest import parse_targets, read_manifest
+from sync_status import setup_report
 
 
 ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_BOOTSTRAP_PACK = ROOT / "fixtures" / "capability-packs" / "bootstrap-minimal"
+DEFAULT_GENERATED_ROOT = Path.home() / ".agent-foundry" / "generated" / "agent-foundry-adapters"
 
 
 def run(command: list[str], execute: bool) -> int:
@@ -44,20 +50,19 @@ def configured_roots(core_root_arg: str, vault_root_arg: str) -> tuple[Path, Pat
     return Path(core_text).expanduser().resolve(), Path(vault_text).expanduser().resolve()
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description="Install Agent Foundry adapters from runtime manifest.")
-    parser.add_argument("--apply", action="store_true", help="Write managed runtime files.")
-    parser.add_argument("--target", default="", help="Install only one target from the manifest.")
-    parser.add_argument("--skip-check", action="store_true", help="Skip consistency check.")
-    parser.add_argument("--core-root", default="", help="Core root to validate and record in the local locator.")
-    parser.add_argument("--vault-root", default="", help="Vault root to validate and record in the local locator.")
-    parser.add_argument("--adapter-root", default="", help="Adapter output root to install from. Defaults to <core-root>/adapters.")
-    args = parser.parse_args()
-    core_root, vault_root = configured_roots(args.core_root, args.vault_root)
-    adapter_root = Path(args.adapter_root).expanduser().resolve() if args.adapter_root else core_root / "adapters"
+def install(
+    *,
+    core_root: Path,
+    vault_root: Path,
+    adapter_root: Path,
+    apply: bool,
+    target: str = "",
+    skip_check: bool = False,
+    write_locator: bool = True,
+) -> int:
     print_operation_context("install", core_root=core_root, vault_root=vault_root, adapter_root=adapter_root)
 
-    if not args.skip_check:
+    if not skip_check:
         code = run(["python3", "scripts/check_consistency.py"], execute=True)
         if code != 0:
             return code
@@ -75,34 +80,141 @@ def main() -> int:
     if code != 0:
         return code
 
-    if args.apply:
+    if apply and write_locator:
         write_config(CONFIG_PATH, core_root, core_root, vault_root)
 
     targets = parse_targets(read_manifest())
-    selected = [args.target] if args.target else list(targets)
+    selected = [target] if target else list(targets)
     installed_targets: dict[str, Path] = {}
-    for target in selected:
-        if target not in targets:
-            raise SystemExit(f"Unknown target: {target}")
-        config = targets[target]
+    for selected_target in selected:
+        if selected_target not in targets:
+            raise SystemExit(f"Unknown target: {selected_target}")
+        config = targets[selected_target]
         status = config.get("status", "")
         if status == "manual":
-            print(f"\n## {target}: manual import required", flush=True)
+            print(f"\n## {selected_target}: manual import required", flush=True)
             print(f"Use adapter files under {adapter_root / 'chatgpt'} or the target's documented import path.")
             continue
         if status != "enabled":
-            print(f"\n## {target}: skipped status={status}", flush=True)
+            print(f"\n## {selected_target}: skipped status={status}", flush=True)
             continue
-        print(f"\n## {target}: {'apply' if args.apply else 'dry-run'}", flush=True)
-        code = run(sync_command(target, config.get("install_path", ""), adapter_root, args.apply), execute=True)
+        print(f"\n## {selected_target}: {'apply' if apply else 'dry-run'}", flush=True)
+        code = run(sync_command(selected_target, config.get("install_path", ""), adapter_root, apply), execute=True)
         if code != 0:
             return code
-        if args.apply:
-            installed_targets[target] = Path(config.get("install_path", "")).expanduser()
-    if args.apply and installed_targets:
+        if apply:
+            installed_targets[selected_target] = Path(config.get("install_path", "")).expanduser()
+    if apply and installed_targets:
         write_receipt(core_root=core_root, vault_root=vault_root, adapter_root=adapter_root, installed_targets=installed_targets)
         print(f"wrote adapter install receipt: {ROOT / 'runtime' / 'local' / 'adapter-install-receipt.yaml'}")
     return 0
+
+
+def has_vault_markers(vault_root: Path) -> bool:
+    return all(
+        (vault_root / marker).exists()
+        for marker in [
+            ".agent-foundry-vault.yaml",
+            "indexes/practice_index.yaml",
+            "indexes/asset_index.yaml",
+            "usage/usage-aggregate.yaml",
+        ]
+    )
+
+
+def pack_label(pack_root: Path) -> str:
+    manifest_path = pack_root / "manifest.yaml"
+    if not manifest_path.exists():
+        return str(pack_root)
+    manifest = top_level_scalars(manifest_path.read_text(encoding="utf-8"))
+    pack_id = manifest.get("pack_id", str(pack_root))
+    version = manifest.get("version", "")
+    return f"{pack_id} {version}".strip()
+
+
+def fresh_install(args: argparse.Namespace) -> int:
+    core_root = Path(args.core_root or ROOT).expanduser().resolve()
+    if not args.vault_root:
+        raise SystemExit("--vault-root is required with --fresh-install")
+    vault_root = Path(args.vault_root).expanduser().resolve()
+    adapter_root = Path(args.adapter_root).expanduser().resolve() if args.adapter_root else DEFAULT_GENERATED_ROOT
+    bootstrap_pack = Path(args.bootstrap_pack).expanduser().resolve()
+
+    print("Agent Foundry fresh install")
+    print(f"core_root: {core_root}")
+    print(f"vault_root: {vault_root}")
+    print(f"bootstrap_pack: {pack_label(bootstrap_pack)}")
+    print(f"generated_output: {adapter_root}")
+    print(f"runtime_install: {'apply' if args.runtime_apply else 'dry-run'}")
+
+    if not args.apply:
+        print("Dry-run only. Re-run with --apply to create/select the Vault, deploy bootstrap, and publish generated output.")
+        print(setup_report(core_root, vault_root, adapter_root, adapter_root / "adapter-install-receipt.yaml"))
+        return 0
+
+    if has_vault_markers(vault_root):
+        print("Selected Vault already has required markers; skipping blank Vault initialization.")
+    else:
+        initialize(vault_root, apply=True, force=args.force)
+
+    code = deploy_capability_pack(core_root, vault_root, bootstrap_pack, apply=True)
+    if code != 0:
+        return code
+
+    code = publish_adapters(core_root, vault_root, adapter_root, apply=True)
+    if code != 0:
+        return code
+
+    if not args.no_write_locator:
+        write_config(CONFIG_PATH, core_root, core_root, vault_root)
+
+    code = install(
+        core_root=core_root,
+        vault_root=vault_root,
+        adapter_root=adapter_root,
+        apply=args.runtime_apply,
+        target=args.target,
+        skip_check=args.skip_check,
+        write_locator=False,
+    )
+    if code != 0:
+        return code
+
+    receipt_path = ROOT / "runtime" / "local" / "adapter-install-receipt.yaml"
+    if not args.runtime_apply:
+        receipt_path = adapter_root / "adapter-install-receipt.yaml"
+    print(setup_report(core_root, vault_root, adapter_root, receipt_path))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Install Agent Foundry adapters from runtime manifest.")
+    parser.add_argument("--fresh-install", action="store_true", help="Run the Fresh Install setup workflow before runtime install.")
+    parser.add_argument("--apply", action="store_true", help="Write managed runtime files, or Fresh Install Vault/generated setup.")
+    parser.add_argument("--runtime-apply", action="store_true", help="With --fresh-install, write managed runtime files and receipt.")
+    parser.add_argument("--target", default="", help="Install only one target from the manifest.")
+    parser.add_argument("--skip-check", action="store_true", help="Skip consistency check.")
+    parser.add_argument("--core-root", default="", help="Core root to validate and record in the local locator.")
+    parser.add_argument("--vault-root", default="", help="Vault root to validate and record in the local locator.")
+    parser.add_argument("--adapter-root", default="", help="Adapter output root to install from. Defaults to <core-root>/adapters.")
+    parser.add_argument("--generated-root", dest="adapter_root", default="", help="Fresh Install generated adapter output root.")
+    parser.add_argument("--bootstrap-pack", default=str(DEFAULT_BOOTSTRAP_PACK), help="Mandatory bootstrap capability pack root.")
+    parser.add_argument("--force", action="store_true", help="Allow blank Vault initialization over existing marker files.")
+    parser.add_argument("--no-write-locator", action="store_true", help="With --fresh-install, do not write the machine-local locator.")
+    args = parser.parse_args()
+    if args.fresh_install:
+        return fresh_install(args)
+
+    core_root, vault_root = configured_roots(args.core_root, args.vault_root)
+    adapter_root = Path(args.adapter_root).expanduser().resolve() if args.adapter_root else core_root / "adapters"
+    return install(
+        core_root=core_root,
+        vault_root=vault_root,
+        adapter_root=adapter_root,
+        apply=args.apply,
+        target=args.target,
+        skip_check=args.skip_check,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/operation_context.py
+++ b/scripts/operation_context.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Report Agent Foundry operation context before writes or installs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from check_foundry_roots import validate
+from foundry_config import CONFIG_PATH, ROOT, parse_config
+from runtime_manifest import LOCAL_MANIFEST, parse_targets
+
+
+CONTEXT_PRODUCT = "product_project_evidence"
+CONTEXT_CORE = "foundry_core_maintenance"
+CONTEXT_VAULT = "foundry_vault_operation"
+CONTEXT_GENERATED = "generated_adapter_output"
+CONTEXT_RUNTIME = "runtime_install_state"
+CONTEXT_LOCAL = "local_private_state"
+
+
+def is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve().relative_to(parent.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def configured_roots(core_root_arg: str = "", vault_root_arg: str = "") -> tuple[Path, Path]:
+    data = parse_config(CONFIG_PATH)
+    core_text = core_root_arg or str(data.get("core_root", "") or ROOT)
+    vault_text = vault_root_arg or str(data.get("vault_root", "") or "")
+    core_root = Path(core_text).expanduser().resolve()
+    vault_root = Path(vault_text).expanduser().resolve() if vault_text else core_root
+    return core_root, vault_root
+
+
+def runtime_paths() -> list[Path]:
+    paths: list[Path] = []
+    targets = read_runtime_targets()
+    for config in targets.values():
+        install_path = config.get("install_path", "")
+        if install_path:
+            paths.append(Path(install_path).expanduser().resolve())
+    paths.extend(
+        [
+            Path.home() / ".codex",
+            Path.home() / ".claude",
+            Path.home() / ".hermes",
+        ]
+    )
+    unique: list[Path] = []
+    seen: set[str] = set()
+    for path in paths:
+        key = str(path)
+        if key not in seen:
+            seen.add(key)
+            unique.append(path)
+    return unique
+
+
+def nearest_generated_root(cwd: Path, adapter_root: Path | None) -> Path | None:
+    if adapter_root and adapter_root.exists() and is_relative_to(cwd, adapter_root):
+        return adapter_root.resolve()
+    for path in [cwd.resolve(), *cwd.resolve().parents]:
+        if (path / "adapter-publish-manifest.yaml").exists():
+            return path
+    return None
+
+
+def has_managed_runtime_marker(cwd: Path) -> bool:
+    for path in [cwd.resolve(), *cwd.resolve().parents]:
+        if (path / ".agent-foundry-managed").exists():
+            return True
+    return False
+
+
+def classify_context(cwd: Path, core_root: Path, vault_root: Path, adapter_root: Path | None) -> str:
+    cwd = cwd.resolve()
+    if nearest_generated_root(cwd, adapter_root):
+        return CONTEXT_GENERATED
+    if has_managed_runtime_marker(cwd):
+        return CONTEXT_RUNTIME
+    for runtime_path in runtime_paths():
+        if runtime_path.exists() and is_relative_to(cwd, runtime_path):
+            return CONTEXT_RUNTIME
+    if is_relative_to(cwd, vault_root):
+        return CONTEXT_VAULT
+    if is_relative_to(cwd, core_root):
+        return CONTEXT_CORE
+    local_root = Path.home() / ".agent-foundry"
+    if local_root.exists() and is_relative_to(cwd, local_root):
+        return CONTEXT_LOCAL
+    if ".agent-foundry" in cwd.parts:
+        return CONTEXT_LOCAL
+    return CONTEXT_PRODUCT
+
+
+def manual_targets() -> list[str]:
+    targets = read_runtime_targets()
+    return sorted(name for name, config in targets.items() if config.get("status") == "manual")
+
+
+def read_runtime_targets() -> dict[str, dict[str, str]]:
+    if not LOCAL_MANIFEST.exists():
+        return {}
+    return parse_targets(LOCAL_MANIFEST.read_text(encoding="utf-8").splitlines())
+
+
+def operation_routes(operation: str, context: str, cwd: Path, core_root: Path, vault_root: Path, adapter_root: Path) -> dict[str, list[str] | str]:
+    evidence_root = str(cwd.resolve()) if context == CONTEXT_PRODUCT else ""
+    if operation == "harvest":
+        return {
+            "evidence_root": evidence_root or "explicit evidence source required when not invoked from product project",
+            "allowed_reads": [
+                "evidence root",
+                str(core_root / "workflows"),
+                str(core_root / "schemas"),
+                str(vault_root / "indexes"),
+            ],
+            "allowed_writes": [
+                str(vault_root / "practices"),
+                str(vault_root / "assets"),
+                str(vault_root / "indexes"),
+                str(vault_root / "usage"),
+            ],
+            "forbidden_writes": [
+                "product project files unless explicitly requested",
+                "Core source files unless doing Core maintenance",
+                "generated adapter output before approval",
+                "runtime files before publish/install",
+            ],
+        }
+    if operation == "publish":
+        return {
+            "evidence_root": "",
+            "allowed_reads": [str(core_root / "adapters"), str(vault_root / "practices"), str(vault_root / "assets")],
+            "allowed_writes": [str(adapter_root)],
+            "forbidden_writes": [
+                str(core_root / "adapters"),
+                "runtime install paths",
+                "product project files",
+                "Vault canonical records",
+            ],
+        }
+    if operation in {"install", "refresh"}:
+        return {
+            "evidence_root": "",
+            "allowed_reads": [str(core_root), str(vault_root), str(adapter_root), str(core_root / "runtime/local/runtime_manifest.yaml")],
+            "allowed_writes": [
+                "managed runtime files only",
+                str(core_root / "runtime/local/adapter-install-receipt.yaml"),
+                str(CONFIG_PATH),
+            ],
+            "forbidden_writes": [
+                "unmanaged runtime files",
+                "product project files",
+                "Vault canonical records",
+                "Core source files other than machine-local runtime receipt",
+            ],
+        }
+    if operation == "status":
+        return {
+            "evidence_root": "",
+            "allowed_reads": [str(core_root), str(vault_root), "runtime manifest", "adapter install receipt"],
+            "allowed_writes": [],
+            "forbidden_writes": ["all project, Vault, Core, generated, and runtime files"],
+        }
+    if operation == "core-maintenance":
+        return {
+            "evidence_root": "",
+            "allowed_reads": [str(core_root), str(vault_root)],
+            "allowed_writes": [str(core_root)],
+            "forbidden_writes": ["Vault canonical records unless explicitly part of a harvest", "runtime files", "product project files"],
+        }
+    if operation == "vault-maintenance":
+        return {
+            "evidence_root": "",
+            "allowed_reads": [str(core_root), str(vault_root)],
+            "allowed_writes": [str(vault_root)],
+            "forbidden_writes": ["Core source files", "runtime files", "product project files"],
+        }
+    return {
+        "evidence_root": evidence_root,
+        "allowed_reads": [str(core_root), str(vault_root)],
+        "allowed_writes": [],
+        "forbidden_writes": ["unknown operation: writes require explicit contract"],
+    }
+
+
+def build_context(
+    operation: str,
+    cwd: Path | None = None,
+    core_root: Path | None = None,
+    vault_root: Path | None = None,
+    adapter_root: Path | None = None,
+) -> dict[str, Any]:
+    cwd = (cwd or Path.cwd()).expanduser().resolve()
+    core_root = (core_root or ROOT).expanduser().resolve()
+    vault_root = (vault_root or core_root).expanduser().resolve()
+    adapter_root = (adapter_root or (core_root / "adapters")).expanduser().resolve()
+    context = classify_context(cwd, core_root, vault_root, adapter_root)
+    root_errors = validate(core_root, vault_root)
+    routes = operation_routes(operation, context, cwd, core_root, vault_root, adapter_root)
+    warnings: list[str] = []
+    if context == CONTEXT_PRODUCT and operation not in {"harvest", "status"}:
+        warnings.append("invoked from product project context; writes must go only to the declared Agent Foundry targets")
+    if operation == "publish" and adapter_root == (core_root / "adapters").resolve():
+        warnings.append("publish output points at Core adapters; apply should refuse Core template overwrite")
+    if operation in {"install", "refresh"} and not (adapter_root / "adapter-publish-manifest.yaml").exists():
+        warnings.append("adapter_root has no adapter-publish-manifest.yaml; selected-output install receipt may be unavailable")
+    return {
+        "schema_version": 1,
+        "operation": operation,
+        "invocation_cwd": str(cwd),
+        "work_context": context,
+        "evidence_root": routes["evidence_root"],
+        "core_root": str(core_root),
+        "vault_root": str(vault_root),
+        "adapter_root": str(adapter_root),
+        "manual_targets": manual_targets(),
+        "allowed_reads": routes["allowed_reads"],
+        "allowed_writes": routes["allowed_writes"],
+        "forbidden_writes": routes["forbidden_writes"],
+        "root_validation": "passed" if not root_errors else "failed",
+        "root_validation_errors": root_errors,
+        "warnings": warnings,
+        "safe_to_write": not root_errors,
+    }
+
+
+def text_report(report: dict[str, Any]) -> str:
+    lines = [
+        "Agent Foundry operation context:",
+        f"operation: {report['operation']}",
+        f"work_context: {report['work_context']}",
+        f"invocation_cwd: {report['invocation_cwd']}",
+        f"evidence_root: {report['evidence_root']}",
+        f"core_root: {report['core_root']}",
+        f"vault_root: {report['vault_root']}",
+        f"adapter_root: {report['adapter_root']}",
+        f"root_validation: {report['root_validation']}",
+    ]
+    manual = report.get("manual_targets") or []
+    if manual:
+        lines.append("manual_targets: " + ", ".join(manual))
+    for key in ["allowed_reads", "allowed_writes", "forbidden_writes", "warnings", "root_validation_errors"]:
+        values = report.get(key) or []
+        lines.append(f"{key}:")
+        if not values:
+            lines.append("  - none")
+        else:
+            lines.extend(f"  - {value}" for value in values)
+    lines.append(f"safe_to_write: {'yes' if report['safe_to_write'] else 'no'}")
+    return "\n".join(lines)
+
+
+def print_operation_context(
+    operation: str,
+    cwd: Path | None = None,
+    core_root: Path | None = None,
+    vault_root: Path | None = None,
+    adapter_root: Path | None = None,
+) -> dict[str, Any]:
+    report = build_context(operation, cwd, core_root, vault_root, adapter_root)
+    print(text_report(report), flush=True)
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Report Agent Foundry operation context before writes or installs.")
+    parser.add_argument(
+        "operation",
+        choices=["harvest", "publish", "install", "refresh", "status", "core-maintenance", "vault-maintenance"],
+        help="Operation type to preflight.",
+    )
+    parser.add_argument("--cwd", default="", help="Invocation directory. Defaults to current directory.")
+    parser.add_argument("--core-root", default="", help="Agent Foundry Core root. Defaults to configured core_root.")
+    parser.add_argument("--vault-root", default="", help="Selected Agent Foundry Vault root. Defaults to configured vault_root.")
+    parser.add_argument("--adapter-root", default="", help="Generated adapter output root. Defaults to <core-root>/adapters.")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    args = parser.parse_args()
+
+    core_root, vault_root = configured_roots(args.core_root, args.vault_root)
+    adapter_root = Path(args.adapter_root).expanduser().resolve() if args.adapter_root else core_root / "adapters"
+    cwd = Path(args.cwd).expanduser().resolve() if args.cwd else Path.cwd()
+    report = build_context(args.operation, cwd, core_root, vault_root, adapter_root)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(text_report(report))
+    return 0 if report["root_validation"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/operation_context.py
+++ b/scripts/operation_context.py
@@ -146,6 +146,27 @@ def operation_routes(operation: str, context: str, cwd: Path, core_root: Path, v
                 "Vault canonical records",
             ],
         }
+    if operation == "import":
+        return {
+            "evidence_root": "explicit runtime/source paths only",
+            "allowed_reads": [
+                "explicit runtime/source paths",
+                str(core_root / "workflows" / "import-external-skills.md"),
+                str(core_root / "workflows" / "discover-assets.md"),
+                str(core_root / "schemas" / "asset-candidate.schema.yaml"),
+                str(vault_root / "indexes"),
+            ],
+            "allowed_writes": [str(vault_root / "imports" / "inbox")],
+            "forbidden_writes": [
+                "runtime source files",
+                "runtime adapter install paths",
+                str(core_root / "adapters"),
+                str(vault_root / "practices"),
+                str(vault_root / "assets"),
+                str(vault_root / "indexes"),
+                "generated adapter output",
+            ],
+        }
     if operation in {"install", "refresh"}:
         return {
             "evidence_root": "",
@@ -206,7 +227,7 @@ def build_context(
     root_errors = validate(core_root, vault_root)
     routes = operation_routes(operation, context, cwd, core_root, vault_root, adapter_root)
     warnings: list[str] = []
-    if context == CONTEXT_PRODUCT and operation not in {"harvest", "status"}:
+    if context == CONTEXT_PRODUCT and operation not in {"harvest", "import", "status"}:
         warnings.append("invoked from product project context; writes must go only to the declared Agent Foundry targets")
     if operation == "publish" and adapter_root == (core_root / "adapters").resolve():
         warnings.append("publish output points at Core adapters; apply should refuse Core template overwrite")
@@ -274,7 +295,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Report Agent Foundry operation context before writes or installs.")
     parser.add_argument(
         "operation",
-        choices=["harvest", "publish", "install", "refresh", "status", "core-maintenance", "vault-maintenance"],
+        choices=["harvest", "import", "publish", "install", "refresh", "status", "core-maintenance", "vault-maintenance"],
         help="Operation type to preflight.",
     )
     parser.add_argument("--cwd", default="", help="Invocation directory. Defaults to current directory.")

--- a/scripts/publish_adapters.py
+++ b/scripts/publish_adapters.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from check_foundry_roots import validate
 from foundry_config import ROOT
+from operation_context import configured_roots, print_operation_context
 
 
 ACTIVE_STATUSES = {"active", "revised"}
@@ -361,6 +362,7 @@ def write_generated_skill_outputs(
 
 
 def publish(core_root: Path, vault_root: Path, output_root: Path, apply: bool) -> int:
+    print_operation_context("publish", core_root=core_root, vault_root=vault_root, adapter_root=output_root)
     errors = validate(core_root, vault_root)
     if errors:
         print("Adapter publish failed root validation:")
@@ -394,14 +396,13 @@ def publish(core_root: Path, vault_root: Path, output_root: Path, apply: bool) -
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Publish adapters from a selected Agent Foundry Vault.")
-    parser.add_argument("--core-root", default=str(ROOT), help="Agent Foundry Core root.")
-    parser.add_argument("--vault-root", default=str(ROOT), help="Selected Agent Foundry Vault root.")
+    parser.add_argument("--core-root", default="", help="Agent Foundry Core root. Defaults to configured core_root.")
+    parser.add_argument("--vault-root", default="", help="Selected Agent Foundry Vault root. Defaults to configured vault_root.")
     parser.add_argument("--output-root", default="", help="Adapter output directory. Defaults to <core-root>/adapters.")
     parser.add_argument("--apply", action="store_true", help="Write files. Default is dry-run.")
     args = parser.parse_args()
 
-    core_root = Path(args.core_root).expanduser().resolve()
-    vault_root = Path(args.vault_root).expanduser().resolve()
+    core_root, vault_root = configured_roots(args.core_root, args.vault_root)
     output_root = Path(args.output_root).expanduser().resolve() if args.output_root else core_root / "adapters"
     return publish(core_root, vault_root, output_root, args.apply)
 

--- a/scripts/sync_status.py
+++ b/scripts/sync_status.py
@@ -10,6 +10,7 @@ import tarfile
 from pathlib import Path
 from adapter_install_receipt import RECEIPT_PATH, read_receipt, receipt_status, receipt_target_statuses
 from foundry_config import CONFIG_PATH, parse_config, validate as validate_config
+from operation_context import text_report, build_context
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -213,6 +214,7 @@ def runtime_drift_status() -> str:
 
 
 def main() -> int:
+    print(text_report(build_context("status", core_root=ROOT, vault_root=Path(str(parse_config(CONFIG_PATH).get("vault_root", "") or ROOT)).expanduser().resolve())))
     print(f"root: {ROOT}")
     print(f"git branch: {run_git(['branch', '--show-current'])}")
     print("git remotes:")

--- a/scripts/sync_status.py
+++ b/scripts/sync_status.py
@@ -148,7 +148,83 @@ def locator_mode() -> tuple[str, str]:
     )
 
 
-def runtime_drift_status() -> str:
+def deployed_packs(vault_root: Path) -> list[str]:
+    packs: set[str] = set()
+    for base in [vault_root / "practices", vault_root / "assets"]:
+        if not base.exists():
+            continue
+        for path in sorted(p for p in base.rglob("*") if p.is_file()):
+            text = path.read_text(encoding="utf-8")
+            if "pack.bootstrap.minimal" in text:
+                packs.add("pack.bootstrap.minimal")
+    return sorted(packs)
+
+
+def generated_output_status(adapter_root: Path) -> tuple[str, int]:
+    manifest = adapter_root / "adapter-publish-manifest.yaml"
+    if not adapter_root.exists():
+        return "missing", 0
+    files = [path for path in adapter_root.rglob("*") if path.is_file()]
+    if not manifest.exists():
+        return "missing-manifest", len(files)
+    return "ready", len(files)
+
+
+def receipt_summary(receipt_path: Path) -> list[str]:
+    receipt = read_receipt(receipt_path)
+    if receipt is None:
+        return [f"receipt: missing ({receipt_path})"]
+    state, problems = receipt_status(receipt)
+    installed = receipt.get("installed_targets", [])
+    installed_text = ", ".join(str(item) for item in installed) if isinstance(installed, list) else ""
+    lines = [
+        f"receipt: {state} ({receipt_path})",
+        f"receipt adapter_root: {receipt.get('adapter_root', '')}",
+        f"receipt installed_targets: {installed_text}",
+    ]
+    for target, (target_state, target_problems, checked) in sorted(receipt_target_statuses(receipt).items()):
+        lines.append(f"receipt target: {target} {target_state} checked={checked} problems={len(target_problems)}")
+    for problem in problems[:10]:
+        lines.append(f"receipt detail: {problem}")
+    if len(problems) > 10:
+        lines.append(f"receipt detail: ... {len(problems) - 10} more")
+    return lines
+
+
+def setup_report(core_root: Path, vault_root: Path, adapter_root: Path, receipt_path: Path = RECEIPT_PATH) -> str:
+    manifest_path = ROOT / "runtime" / "local" / "runtime_manifest.yaml"
+    targets = parse_runtime_manifest(manifest_path.read_text(encoding="utf-8")) if manifest_path.exists() else {}
+    output_state, output_count = generated_output_status(adapter_root)
+    packs = deployed_packs(vault_root)
+    lines = [
+        "Agent Foundry setup/status report",
+        text_report(build_context("status", core_root=core_root, vault_root=vault_root, adapter_root=adapter_root)),
+        "fresh install summary:",
+        f"core_root: {core_root}",
+        f"vault_root: {vault_root}",
+        f"deployed_pack: {', '.join(packs) if packs else 'none detected'}",
+        f"generated_output: {output_state} path={adapter_root} files={output_count}",
+        "runtime targets:",
+    ]
+    if not targets:
+        lines.append("- none")
+    for name, config in targets.items():
+        status = config.get("status", "")
+        path = config.get("install_path", "") or "<manual>"
+        mode = config.get("ownership_mode", "")
+        if status == "manual":
+            lines.append(f"- {name}: manual import required path={path} ownership={mode}")
+        elif status == "enabled":
+            lines.append(f"- {name}: enabled path={path} ownership={mode}")
+        else:
+            lines.append(f"- {name}: skipped status={status} path={path} ownership={mode}")
+    lines.extend(receipt_summary(receipt_path))
+    lines.append("first_usable_command: python3 scripts/sync_status.py")
+    lines.append("chatgpt_manual_import: explicit; import generated ChatGPT files manually when desired")
+    return "\n".join(lines)
+
+
+def runtime_drift_status(receipt_path: Path = RECEIPT_PATH) -> str:
     manifest_path = ROOT / "runtime" / "local" / "runtime_manifest.yaml"
     if not manifest_path.exists():
         return "no local runtime manifest"
@@ -158,7 +234,7 @@ def runtime_drift_status() -> str:
         f"mode: {mode}",
     ]
     if mode == "split":
-        receipt = read_receipt(RECEIPT_PATH)
+        receipt = read_receipt(receipt_path)
         if receipt is None:
             lines.append(f"comparison: {note}")
             lines.append("selected-output: selected-output-unknown reason=install receipt missing")
@@ -214,7 +290,22 @@ def runtime_drift_status() -> str:
 
 
 def main() -> int:
-    print(text_report(build_context("status", core_root=ROOT, vault_root=Path(str(parse_config(CONFIG_PATH).get("vault_root", "") or ROOT)).expanduser().resolve())))
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Print local Agent Foundry sync status for offline and remote workflows.")
+    parser.add_argument("--core-root", default="", help="Agent Foundry Core root. Defaults to configured core_root.")
+    parser.add_argument("--vault-root", default="", help="Selected Agent Foundry Vault root. Defaults to configured vault_root.")
+    parser.add_argument("--adapter-root", default="", help="Generated adapter output root. Defaults to <core-root>/adapters.")
+    parser.add_argument("--receipt-path", default="", help="Adapter install receipt path. Defaults to runtime/local receipt.")
+    args = parser.parse_args()
+
+    config = parse_config(CONFIG_PATH)
+    core_root = Path(args.core_root or str(config.get("core_root", "") or ROOT)).expanduser().resolve()
+    vault_root = Path(args.vault_root or str(config.get("vault_root", "") or core_root)).expanduser().resolve()
+    adapter_root = Path(args.adapter_root).expanduser().resolve() if args.adapter_root else core_root / "adapters"
+    receipt_path = Path(args.receipt_path).expanduser().resolve() if args.receipt_path else RECEIPT_PATH
+
+    print(setup_report(core_root, vault_root, adapter_root, receipt_path))
     print(f"root: {ROOT}")
     print(f"git branch: {run_git(['branch', '--show-current'])}")
     print("git remotes:")
@@ -228,7 +319,7 @@ def main() -> int:
     print("runtime manifest:")
     print(runtime_status())
     print("runtime adapter drift:")
-    print(runtime_drift_status())
+    print(runtime_drift_status(receipt_path))
     return 0
 
 

--- a/scripts/test_bootstrap_pack_deployment.py
+++ b/scripts/test_bootstrap_pack_deployment.py
@@ -88,21 +88,24 @@ def main() -> int:
         errors.extend(expect("optional-pack-refused", optional_result, False, "only mandatory_bootstrap packs are supported"))
 
         deploy_result = deploy_bootstrap(vault)
-        errors.extend(expect("deploy-bootstrap", deploy_result, True, "added: 2"))
+        errors.extend(expect("deploy-bootstrap", deploy_result, True, "added: 24"))
         errors.extend(expect("deploy-bootstrap-validates", deploy_result, True, "selected Vault validated"))
         for expected in [
             vault / "practices" / "meta" / "BOOT-001-bootstrap-orientation.md",
+            vault / "practices" / "meta" / "META-001-canonical-practices-source-of-truth.md",
+            vault / "practices" / "runtime" / "RUNTIME-001-treat-agent-runtimes-as-shared-environments.md",
             vault / "assets" / "skills" / "ASSET-BOOT-001-bootstrap-status.asset.yaml",
+            vault / "assets" / "skills" / "ASSET-META-001-practice-harvester.asset.yaml",
         ]:
             if not expected.exists():
                 errors.append(f"deploy-bootstrap: expected Vault record missing: {expected}")
             else:
                 text = expected.read_text(encoding="utf-8")
                 for marker in [
-                    "provenance: \"Deployed from capability pack pack.bootstrap.minimal version 0.1.0",
+                    "provenance: \"Deployed from capability pack pack.bootstrap.minimal version 0.2.0",
                     "pack_membership",
                     "pack.bootstrap.minimal",
-                    "pack_source_version: \"0.1.0\"",
+                    "pack_source_version: \"0.2.0\"",
                 ]:
                     if marker not in text:
                         errors.append(f"deploy-bootstrap: {expected} missing deployment metadata marker {marker}")
@@ -122,15 +125,15 @@ def main() -> int:
                 "--apply",
             ]
         )
-        errors.extend(expect("publish-bootstrap-vault", publish, True, "Active practices selected: 1"))
-        errors.extend(expect("publish-bootstrap-skill", publish, True, "Active assets selected: 1"))
+        errors.extend(expect("publish-bootstrap-vault", publish, True, "Active practices selected: 22"))
+        errors.extend(expect("publish-bootstrap-skill", publish, True, "Active assets selected: 2"))
         generated_text = "\n".join(path.read_text(encoding="utf-8") for path in generated.rglob("*") if path.is_file())
-        for expected in ["BOOT-001", "ASSET-BOOT-001", "Generated from the selected Agent Foundry Vault."]:
+        for expected in ["BOOT-001", "META-001", "ASSET-BOOT-001", "ASSET-META-001", "Generated from the selected Agent Foundry Vault."]:
             if expected not in generated_text:
                 errors.append(f"publish-bootstrap-vault: generated output missing {expected}")
 
         rerun = deploy_bootstrap(vault)
-        errors.extend(expect("deploy-bootstrap-rerun-skip", rerun, True, "skipped: 2"))
+        errors.extend(expect("deploy-bootstrap-rerun-skip", rerun, True, "skipped: 24"))
         errors.extend(expect("deploy-bootstrap-rerun-no-add", rerun, True, "added: 0"))
 
         record = vault / "practices" / "meta" / "BOOT-001-bootstrap-orientation.md"

--- a/scripts/test_bootstrap_pack_deployment.py
+++ b/scripts/test_bootstrap_pack_deployment.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Regression fixture for blank Vault to bootstrap pack deployment."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECK = ROOT / "scripts" / "check_foundry_roots.py"
+DEPLOY = ROOT / "scripts" / "deploy_capability_pack.py"
+INIT = ROOT / "scripts" / "init_vault.py"
+PUBLISH = ROOT / "scripts" / "publish_adapters.py"
+BOOTSTRAP_PACK = ROOT / "fixtures" / "capability-packs" / "bootstrap-minimal"
+OPTIONAL_PACK = ROOT / "fixtures" / "capability-packs" / "optional-multi-agent"
+
+
+def run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, *args],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def expect(name: str, result: subprocess.CompletedProcess[str], should_pass: bool, expected_text: str = "") -> list[str]:
+    output = result.stdout + result.stderr
+    if (result.returncode == 0) == should_pass and (not expected_text or expected_text in output):
+        print(f"{name}: ok")
+        return []
+    return [
+        f"{name}: expected {'pass' if should_pass else 'failure'}"
+        + (f" containing {expected_text!r}" if expected_text else "")
+        + f", got exit {result.returncode}\n{output.strip()}"
+    ]
+
+
+def init_blank(vault_root: Path) -> subprocess.CompletedProcess[str]:
+    return run([str(INIT), str(vault_root), "--core-root", str(ROOT), "--apply"])
+
+
+def deploy_bootstrap(vault_root: Path) -> subprocess.CompletedProcess[str]:
+    return run(
+        [
+            str(DEPLOY),
+            str(BOOTSTRAP_PACK),
+            "--core-root",
+            str(ROOT),
+            "--vault-root",
+            str(vault_root),
+            "--apply",
+        ]
+    )
+
+
+def main() -> int:
+    errors: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="agent-foundry-bootstrap-deploy-") as tmp:
+        base = Path(tmp)
+        vault = base / "vault"
+        generated = base / "generated-adapters"
+
+        errors.extend(expect("init-blank-vault", init_blank(vault), True, "Blank Vault initialized and validated."))
+        blank_practice_index = (vault / "indexes" / "practice_index.yaml").read_text(encoding="utf-8")
+        blank_asset_index = (vault / "indexes" / "asset_index.yaml").read_text(encoding="utf-8")
+        if "practices: []" not in blank_practice_index:
+            errors.append("init-blank-vault: practice index was not blank")
+        if "assets: []" not in blank_asset_index:
+            errors.append("init-blank-vault: asset index was not blank")
+
+        optional_result = run(
+            [
+                str(DEPLOY),
+                str(OPTIONAL_PACK),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(vault),
+                "--apply",
+            ]
+        )
+        errors.extend(expect("optional-pack-refused", optional_result, False, "only mandatory_bootstrap packs are supported"))
+
+        deploy_result = deploy_bootstrap(vault)
+        errors.extend(expect("deploy-bootstrap", deploy_result, True, "added: 2"))
+        errors.extend(expect("deploy-bootstrap-validates", deploy_result, True, "selected Vault validated"))
+        for expected in [
+            vault / "practices" / "meta" / "BOOT-001-bootstrap-orientation.md",
+            vault / "assets" / "skills" / "ASSET-BOOT-001-bootstrap-status.asset.yaml",
+        ]:
+            if not expected.exists():
+                errors.append(f"deploy-bootstrap: expected Vault record missing: {expected}")
+            else:
+                text = expected.read_text(encoding="utf-8")
+                for marker in [
+                    "provenance: \"Deployed from capability pack pack.bootstrap.minimal version 0.1.0",
+                    "pack_membership",
+                    "pack.bootstrap.minimal",
+                    "pack_source_version: \"0.1.0\"",
+                ]:
+                    if marker not in text:
+                        errors.append(f"deploy-bootstrap: {expected} missing deployment metadata marker {marker}")
+
+        check = run([str(CHECK), "--core-root", str(ROOT), "--vault-root", str(vault)])
+        errors.extend(expect("check-bootstrap-vault", check, True, "Foundry root validation passed."))
+
+        publish = run(
+            [
+                str(PUBLISH),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(vault),
+                "--output-root",
+                str(generated),
+                "--apply",
+            ]
+        )
+        errors.extend(expect("publish-bootstrap-vault", publish, True, "Active practices selected: 1"))
+        errors.extend(expect("publish-bootstrap-skill", publish, True, "Active assets selected: 1"))
+        generated_text = "\n".join(path.read_text(encoding="utf-8") for path in generated.rglob("*") if path.is_file())
+        for expected in ["BOOT-001", "ASSET-BOOT-001", "Generated from the selected Agent Foundry Vault."]:
+            if expected not in generated_text:
+                errors.append(f"publish-bootstrap-vault: generated output missing {expected}")
+
+        rerun = deploy_bootstrap(vault)
+        errors.extend(expect("deploy-bootstrap-rerun-skip", rerun, True, "skipped: 2"))
+        errors.extend(expect("deploy-bootstrap-rerun-no-add", rerun, True, "added: 0"))
+
+        record = vault / "practices" / "meta" / "BOOT-001-bootstrap-orientation.md"
+        record.write_text(record.read_text(encoding="utf-8") + "\nLocal edit fixture.\n", encoding="utf-8")
+        conflict = deploy_bootstrap(vault)
+        errors.extend(expect("deploy-bootstrap-conflict", conflict, False, "local Vault record differs from pack content"))
+        errors.extend(expect("deploy-bootstrap-conflict-summary", conflict, False, "conflicts: 1"))
+
+    if errors:
+        print("Bootstrap pack deployment fixture failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("Bootstrap pack deployment fixture passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_bootstrap_pack_deployment.py
+++ b/scripts/test_bootstrap_pack_deployment.py
@@ -3,12 +3,15 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
 
+import rollback_runtime
+import runtime_manifest
 
 ROOT = Path(__file__).resolve().parents[1]
 CHECK = ROOT / "scripts" / "check_foundry_roots.py"
@@ -60,6 +63,118 @@ def deploy_bootstrap(vault_root: Path) -> subprocess.CompletedProcess[str]:
             "--apply",
         ]
     )
+
+
+def tree_digest(root: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        digest.update(str(path.relative_to(root)).encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def exercise_restore_rollback_boundaries(base: Path, vault: Path) -> list[str]:
+    errors: list[str] = []
+    user_record = vault / "practices" / "user" / "USER-001-local-user-record.md"
+    user_record.parent.mkdir(parents=True, exist_ok=True)
+    user_record.write_text(
+        "\n".join(
+            [
+                "---",
+                'id: "USER-001"',
+                'title: "Local user record fixture"',
+                'status: "active"',
+                "---",
+                "",
+                "This fixture must survive runtime disable and rollback simulation.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    before_vault = tree_digest(vault)
+
+    original_manifest = runtime_manifest.LOCAL_MANIFEST
+    temp_manifest = base / "runtime-local" / "runtime_manifest.yaml"
+    runtime_manifest.LOCAL_MANIFEST = temp_manifest
+    try:
+        runtime_manifest.ensure_local_manifest()
+        runtime_manifest.set_target_status("codex", "enabled")
+        runtime_manifest.set_target_path("codex", str(base / "runtime" / "codex-skills"))
+        runtime_manifest.set_target_status("codex", "disabled")
+        targets = runtime_manifest.parse_targets(runtime_manifest.read_manifest())
+        if targets.get("codex", {}).get("status") != "disabled":
+            errors.append("runtime-disable: temp manifest did not disable codex")
+        if not temp_manifest.exists():
+            errors.append("runtime-disable: temp manifest missing")
+    finally:
+        runtime_manifest.LOCAL_MANIFEST = original_manifest
+
+    fake_claude = base / "runtime" / "claude" / "CLAUDE.md"
+    fake_claude.parent.mkdir(parents=True, exist_ok=True)
+    fake_claude.write_text(
+        "\n".join(
+            [
+                "User-owned Claude notes.",
+                rollback_runtime.CLAUDE_INCLUDE_START,
+                "# Agent Foundry managed instructions",
+                "@managed/CLAUDE.md",
+                rollback_runtime.CLAUDE_INCLUDE_END,
+                "User-owned footer.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    codex_root = base / "runtime" / "codex-skills"
+    managed_skill = codex_root / "pack-sourced-skill"
+    unmanaged_skill = codex_root / "user-owned-skill"
+    (managed_skill / ".agent-foundry-managed").parent.mkdir(parents=True, exist_ok=True)
+    (managed_skill / ".agent-foundry-managed").write_text("managed-by: agent-foundry\n", encoding="utf-8")
+    (managed_skill / "SKILL.md").write_text("managed runtime copy\n", encoding="utf-8")
+    unmanaged_skill.mkdir(parents=True, exist_ok=True)
+    (unmanaged_skill / "SKILL.md").write_text("user runtime copy\n", encoding="utf-8")
+
+    original_claude = rollback_runtime.CLAUDE_MD
+    original_roots = rollback_runtime.SKILL_ROOTS
+    rollback_runtime.CLAUDE_MD = fake_claude
+    rollback_runtime.SKILL_ROOTS = {"codex": codex_root, "hermes": base / "runtime" / "hermes-skills"}
+    try:
+        rollback_runtime.remove_skill("codex", "pack-sourced-skill", dry_run=True, force=False)
+        if not managed_skill.exists():
+            errors.append("rollback-dry-run: managed skill was removed during dry-run")
+        rollback_runtime.remove_skill("codex", "pack-sourced-skill", dry_run=False, force=False)
+        if managed_skill.exists():
+            errors.append("rollback-managed-skill: managed skill still exists after removal")
+        try:
+            rollback_runtime.remove_skill("codex", "user-owned-skill", dry_run=False, force=False)
+            errors.append("rollback-unmanaged-skill: unmanaged skill removal was not refused")
+        except SystemExit as exc:
+            if "Refusing to remove unmanaged directory" not in str(exc):
+                errors.append(f"rollback-unmanaged-skill: unexpected refusal text {exc}")
+        if not unmanaged_skill.exists():
+            errors.append("rollback-unmanaged-skill: unmanaged skill was removed")
+
+        rollback_runtime.remove_managed_block(dry_run=True)
+        if rollback_runtime.CLAUDE_INCLUDE_START not in fake_claude.read_text(encoding="utf-8"):
+            errors.append("rollback-block-dry-run: managed block was removed during dry-run")
+        rollback_runtime.remove_managed_block(dry_run=False)
+        claude_text = fake_claude.read_text(encoding="utf-8")
+        if rollback_runtime.CLAUDE_INCLUDE_START in claude_text:
+            errors.append("rollback-block: managed block remains after removal")
+        for expected in ["User-owned Claude notes.", "User-owned footer."]:
+            if expected not in claude_text:
+                errors.append(f"rollback-block: user text missing after removal: {expected}")
+    finally:
+        rollback_runtime.CLAUDE_MD = original_claude
+        rollback_runtime.SKILL_ROOTS = original_roots
+
+    after_vault = tree_digest(vault)
+    if before_vault != after_vault:
+        errors.append("restore-rollback-boundary: runtime disable/rollback changed Vault records")
+    return errors
 
 
 def main() -> int:
@@ -184,6 +299,8 @@ def main() -> int:
         rerun = deploy_bootstrap(vault)
         errors.extend(expect("deploy-bootstrap-rerun-skip", rerun, True, "skipped: 24"))
         errors.extend(expect("deploy-bootstrap-rerun-no-add", rerun, True, "added: 0"))
+
+        errors.extend(exercise_restore_rollback_boundaries(base, vault))
 
         record = vault / "practices" / "meta" / "BOOT-001-bootstrap-orientation.md"
         record.write_text(record.read_text(encoding="utf-8") + "\nLocal edit fixture.\n", encoding="utf-8")

--- a/scripts/test_bootstrap_pack_deployment.py
+++ b/scripts/test_bootstrap_pack_deployment.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import tempfile
@@ -13,15 +14,17 @@ ROOT = Path(__file__).resolve().parents[1]
 CHECK = ROOT / "scripts" / "check_foundry_roots.py"
 DEPLOY = ROOT / "scripts" / "deploy_capability_pack.py"
 INIT = ROOT / "scripts" / "init_vault.py"
+INSTALL = ROOT / "scripts" / "install_foundry.py"
 PUBLISH = ROOT / "scripts" / "publish_adapters.py"
 BOOTSTRAP_PACK = ROOT / "fixtures" / "capability-packs" / "bootstrap-minimal"
 OPTIONAL_PACK = ROOT / "fixtures" / "capability-packs" / "optional-multi-agent"
 
 
-def run(args: list[str]) -> subprocess.CompletedProcess[str]:
+def run(args: list[str], env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, *args],
         cwd=ROOT,
+        env=env,
         check=False,
         text=True,
         stdout=subprocess.PIPE,
@@ -73,6 +76,52 @@ def main() -> int:
             errors.append("init-blank-vault: practice index was not blank")
         if "assets: []" not in blank_asset_index:
             errors.append("init-blank-vault: asset index was not blank")
+
+        fresh_vault = base / "fresh-vault"
+        fresh_generated = base / "fresh-generated-adapters"
+        fake_home = base / "home"
+        fake_home.mkdir()
+        fresh_env = os.environ.copy()
+        fresh_env["HOME"] = str(fake_home)
+        fresh = run(
+            [
+                str(INSTALL),
+                "--fresh-install",
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(fresh_vault),
+                "--generated-root",
+                str(fresh_generated),
+                "--apply",
+                "--skip-check",
+            ],
+            env=fresh_env,
+        )
+        errors.extend(expect("fresh-install-report", fresh, True, "Agent Foundry setup/status report"))
+        for expected in [
+            "deployed_pack: pack.bootstrap.minimal",
+            f"generated_output: ready path={fresh_generated.resolve()}",
+            "- chatgpt: manual import required",
+            "receipt: missing",
+            "first_usable_command: python3 scripts/sync_status.py",
+            "chatgpt_manual_import: explicit",
+        ]:
+            errors.extend(expect(f"fresh-install-report-{expected}", fresh, True, expected))
+        if not (fresh_generated / "adapter-publish-manifest.yaml").exists():
+            errors.append("fresh-install-report: generated adapter manifest missing")
+        locator = fake_home / ".agent-foundry" / "config.yaml"
+        if not locator.exists():
+            errors.append("fresh-install-report: temp HOME locator was not written")
+        elif str(fresh_vault.resolve()) not in locator.read_text(encoding="utf-8"):
+            errors.append("fresh-install-report: temp HOME locator did not select fresh Vault")
+        for runtime_path in [
+            fake_home / ".codex" / "skills",
+            fake_home / ".claude",
+            fake_home / ".hermes" / "skills",
+        ]:
+            if runtime_path.exists():
+                errors.append(f"fresh-install-report: runtime dry-run unexpectedly wrote {runtime_path}")
 
         optional_result = run(
             [

--- a/scripts/test_import_runtime_assets.py
+++ b/scripts/test_import_runtime_assets.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Regression fixtures for runtime import staging."""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INIT = ROOT / "scripts" / "init_vault.py"
+IMPORT = ROOT / "scripts" / "import_runtime_assets.py"
+
+
+def run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, *args],
+        cwd=cwd,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def digest_tree(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+    digests: dict[str, str] = {}
+    for file_path in sorted(p for p in path.rglob("*") if p.is_file()):
+        rel = str(file_path.relative_to(path))
+        digests[rel] = hashlib.sha256(file_path.read_bytes()).hexdigest()
+    return digests
+
+
+def expect_contains(name: str, result: subprocess.CompletedProcess[str], expected: str) -> list[str]:
+    output = result.stdout + result.stderr
+    if result.returncode == 0 and expected in output:
+        print(f"{name}: ok")
+        return []
+    return [f"{name}: expected pass containing {expected!r}, got {result.returncode}\n{output}"]
+
+
+def init_blank(vault_root: Path) -> subprocess.CompletedProcess[str]:
+    return run([str(INIT), str(vault_root), "--core-root", str(ROOT), "--apply"], ROOT)
+
+
+def main() -> int:
+    errors: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="agent-foundry-runtime-import-") as tmp:
+        base = Path(tmp)
+        vault = base / "vault"
+        runtime = base / "runtime" / "codex" / "skills" / "sample-skill"
+        generated = base / "generated-adapters"
+        runtime.mkdir(parents=True)
+        generated.mkdir(parents=True)
+        (runtime / ".agent-foundry-managed").write_text("managed fixture\n", encoding="utf-8")
+        (generated / "adapter-publish-manifest.yaml").write_text("schema_version: 1\n", encoding="utf-8")
+        skill = runtime / "SKILL.md"
+        helper = runtime / "helper.py"
+        write(
+            skill,
+            "\n".join(
+                [
+                    "---",
+                    "name: sample-skill",
+                    "---",
+                    "",
+                    "# Sample Skill",
+                    "",
+                    "Use this as review evidence only.",
+                    "",
+                ]
+            ),
+        )
+        write(helper, "#!/usr/bin/env python3\nprint('not executed by import staging')\n")
+
+        init = init_blank(vault)
+        errors.extend(expect_contains("init-temp-vault", init, "Blank Vault initialized and validated."))
+
+        source_before = digest_tree(runtime)
+        vault_canonical_before = digest_tree(vault / "practices") | digest_tree(vault / "assets")
+        adapter_before = digest_tree(generated)
+
+        dry_run = run(
+            [
+                str(IMPORT),
+                "--source",
+                str(runtime),
+                "--source-runtime",
+                "codex",
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(vault),
+                "--adapter-root",
+                str(generated),
+                "--quiet-context",
+            ],
+            ROOT,
+        )
+        errors.extend(expect_contains("dry-run", dry_run, "Dry-run only. Re-run with --apply to stage records."))
+        if list((vault / "imports" / "inbox").glob("runtime-import-*.md")):
+            errors.append("dry-run: unexpectedly wrote import records")
+
+        apply = run(
+            [
+                str(IMPORT),
+                "--source",
+                str(runtime),
+                "--source-runtime",
+                "codex",
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(vault),
+                "--adapter-root",
+                str(generated),
+                "--apply",
+                "--quiet-context",
+            ],
+            ROOT,
+        )
+        errors.extend(expect_contains("apply", apply, "write staging root:"))
+        staged = sorted((vault / "imports" / "inbox").glob("runtime-import-*.md"))
+        if len(staged) != 2:
+            errors.append(f"apply: expected 2 staged records, got {len(staged)}")
+        combined = "\n".join(path.read_text(encoding="utf-8") for path in staged)
+        for expected in [
+            "record_type: runtime_import_evidence",
+            "source_runtime: codex",
+            "source_context: runtime_install_state",
+            "license_status: \"unknown-review-required\"",
+            "sensitivity: \"unknown-review-required\"",
+            "review_required: true",
+            "activation_performed: false",
+            "runtime_write_performed: false",
+            "routing_recommendation: practice_candidate",
+            "routing_recommendation: asset_candidate",
+            "Script or executable surface present: `yes`",
+        ]:
+            if expected not in combined:
+                errors.append(f"apply: staged record missing {expected!r}")
+        if "print('not executed by import staging')" not in combined:
+            errors.append("apply: helper source snapshot missing from staged evidence")
+        if digest_tree(runtime) != source_before:
+            errors.append("apply: runtime source tree changed")
+        if digest_tree(vault / "practices") | digest_tree(vault / "assets") != vault_canonical_before:
+            errors.append("apply: canonical Vault practices/assets changed")
+        if digest_tree(generated) != adapter_before:
+            errors.append("apply: generated adapter output changed")
+
+        core_source = run(
+            [
+                str(IMPORT),
+                "--source",
+                str(ROOT / "workflows" / "import-external-skills.md"),
+                "--source-runtime",
+                "codex",
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(vault),
+                "--adapter-root",
+                str(generated),
+                "--quiet-context",
+            ],
+            ROOT,
+        )
+        errors.extend(expect_contains("core-source-dry-run", core_source, "source context foundry_core_maintenance"))
+        core_apply = run(
+            [
+                str(IMPORT),
+                "--source",
+                str(ROOT / "workflows" / "import-external-skills.md"),
+                "--source-runtime",
+                "codex",
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(vault),
+                "--adapter-root",
+                str(generated),
+                "--apply",
+                "--quiet-context",
+            ],
+            ROOT,
+        )
+        errors.extend(expect_contains("core-source-apply", core_apply, "status: rejected"))
+
+        missing = run(
+            [
+                str(IMPORT),
+                "--source",
+                str(base / "missing.md"),
+                "--source-runtime",
+                "codex",
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(vault),
+                "--adapter-root",
+                str(generated),
+                "--quiet-context",
+            ],
+            ROOT,
+        )
+        errors.extend(expect_contains("missing-source", missing, "source file does not exist or is not a file"))
+
+    if errors:
+        print("Runtime import fixture failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("Runtime import fixture passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_operation_context.py
+++ b/scripts/test_operation_context.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Regression fixtures for operation-context preflight."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import operation_context
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INIT = ROOT / "scripts" / "init_vault.py"
+CONTEXT = ROOT / "scripts" / "operation_context.py"
+PUBLISH = ROOT / "scripts" / "publish_adapters.py"
+INSTALL = ROOT / "scripts" / "install_foundry.py"
+STATUS = ROOT / "scripts" / "sync_status.py"
+
+
+def run(args: list[str], cwd: Path, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, *args],
+        cwd=cwd,
+        env=env,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def init_blank(vault_root: Path) -> subprocess.CompletedProcess[str]:
+    return run([str(INIT), str(vault_root), "--core-root", str(ROOT), "--apply"], ROOT)
+
+
+def context_json(operation: str, cwd: Path, vault: Path, adapter: Path) -> subprocess.CompletedProcess[str]:
+    return run(
+        [
+            str(CONTEXT),
+            operation,
+            "--cwd",
+            str(cwd),
+            "--core-root",
+            str(ROOT),
+            "--vault-root",
+            str(vault),
+            "--adapter-root",
+            str(adapter),
+            "--json",
+        ],
+        cwd,
+    )
+
+
+def expect_context(name: str, result: subprocess.CompletedProcess[str], expected: str) -> list[str]:
+    if result.returncode != 0:
+        return [f"{name}: context command failed\n{result.stdout}{result.stderr}"]
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        return [f"{name}: invalid json {exc}\n{result.stdout}"]
+    errors: list[str] = []
+    if data.get("work_context") != expected:
+        errors.append(f"{name}: expected {expected}, got {data.get('work_context')}")
+    if data.get("core_root") != str(ROOT.resolve()):
+        errors.append(f"{name}: wrong core_root {data.get('core_root')}")
+    if data.get("root_validation") != "passed":
+        errors.append(f"{name}: root validation failed {data.get('root_validation_errors')}")
+    return errors
+
+
+def expect_text(name: str, result: subprocess.CompletedProcess[str], expected: str) -> list[str]:
+    output = result.stdout + result.stderr
+    if result.returncode == 0 and expected in output:
+        print(f"{name}: ok")
+        return []
+    return [f"{name}: expected pass containing {expected!r}, got {result.returncode}\n{output}"]
+
+
+def write_locator(home: Path, core: Path, vault: Path) -> dict[str, str]:
+    config = home / ".agent-foundry" / "config.yaml"
+    config.parent.mkdir(parents=True, exist_ok=True)
+    config.write_text(
+        "\n".join(
+            [
+                "schema_version: 1",
+                f'repo_root: "{core}"',
+                f'core_root: "{core}"',
+                f'vault_root: "{vault}"',
+                "core_markers:",
+                "  - .agent-foundry-core.yaml",
+                "  - workflows/harvest-practices.md",
+                "  - schemas/practice-entry.schema.yaml",
+                "  - scripts/foundry_config.py",
+                "vault_markers:",
+                "  - .agent-foundry-vault.yaml",
+                "  - indexes/practice_index.yaml",
+                "  - indexes/asset_index.yaml",
+                "  - usage/usage-aggregate.yaml",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    return env
+
+
+def main() -> int:
+    errors: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="agent-foundry-operation-context-") as tmp:
+        base = Path(tmp)
+        vault = base / "vault"
+        product = base / "product-project"
+        generated = base / "generated-adapters"
+        runtime = base / "runtime" / "skills" / "agent-collaboration"
+        local_private = base / ".agent-foundry" / "local"
+        fake_home = base / "home"
+        for path in [product, generated, runtime, local_private]:
+            path.mkdir(parents=True)
+        (product / "README.md").write_text("# Product fixture\n", encoding="utf-8")
+        (generated / "adapter-publish-manifest.yaml").write_text("schema_version: 1\n", encoding="utf-8")
+        (runtime / ".agent-foundry-managed").write_text("managed by fixture\n", encoding="utf-8")
+
+        init = init_blank(vault)
+        errors.extend(expect_text("init-blank-vault", init, "Blank Vault initialized and validated."))
+
+        original_manifest = operation_context.LOCAL_MANIFEST
+        missing_manifest = base / "missing-runtime" / "runtime_manifest.yaml"
+        operation_context.LOCAL_MANIFEST = missing_manifest
+        try:
+            report = operation_context.build_context("status", product, ROOT.resolve(), vault.resolve(), generated.resolve())
+            if missing_manifest.exists():
+                errors.append("missing-runtime-manifest: operation context created a runtime manifest")
+            if report.get("manual_targets") != []:
+                errors.append(f"missing-runtime-manifest: expected no manual targets, got {report.get('manual_targets')}")
+        finally:
+            operation_context.LOCAL_MANIFEST = original_manifest
+
+        for name, operation, cwd, expected in [
+            ("product-harvest", "harvest", product, "product_project_evidence"),
+            ("core-status", "status", ROOT, "foundry_core_maintenance"),
+            ("vault-maintenance", "vault-maintenance", vault, "foundry_vault_operation"),
+            ("generated-publish", "publish", generated, "generated_adapter_output"),
+            ("runtime-install", "install", runtime, "runtime_install_state"),
+            ("local-private-status", "status", local_private, "local_private_state"),
+        ]:
+            errors.extend(expect_context(name, context_json(operation, cwd, vault, generated), expected))
+
+        publish = run(
+            [
+                str(PUBLISH),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(vault),
+                "--output-root",
+                str(generated),
+            ],
+            product,
+        )
+        errors.extend(expect_text("publish-context-banner", publish, "work_context: product_project_evidence"))
+        errors.extend(expect_text("publish-context-route", publish, f"allowed_writes:\n  - {generated.resolve()}"))
+
+        default_generated = base / "default-locator-generated"
+        default_env = write_locator(fake_home, ROOT.resolve(), vault.resolve())
+        default_publish = run(
+            [
+                str(PUBLISH),
+                "--output-root",
+                str(default_generated),
+            ],
+            product,
+            env=default_env,
+        )
+        errors.extend(expect_text("publish-default-locator-context", default_publish, "work_context: product_project_evidence"))
+        errors.extend(expect_text("publish-default-locator-vault", default_publish, f"vault_root: {vault.resolve()}"))
+
+        install = run(
+            [
+                str(INSTALL),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(vault),
+                "--adapter-root",
+                str(generated),
+                "--skip-check",
+                "--target",
+                "chatgpt",
+            ],
+            product,
+        )
+        errors.extend(expect_text("install-context-banner", install, "operation: install"))
+        errors.extend(expect_text("install-context-route", install, "managed runtime files only"))
+
+        status = run([str(STATUS)], product)
+        errors.extend(expect_text("status-context-banner", status, "Agent Foundry operation context:"))
+        errors.extend(expect_text("status-context-readonly", status, "operation: status"))
+
+    if errors:
+        print("Operation-context fixture failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("Operation-context fixture passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_operation_context.py
+++ b/scripts/test_operation_context.py
@@ -144,6 +144,7 @@ def main() -> int:
 
         for name, operation, cwd, expected in [
             ("product-harvest", "harvest", product, "product_project_evidence"),
+            ("runtime-import", "import", runtime, "runtime_install_state"),
             ("core-status", "status", ROOT, "foundry_core_maintenance"),
             ("vault-maintenance", "vault-maintenance", vault, "foundry_vault_operation"),
             ("generated-publish", "publish", generated, "generated_adapter_output"),

--- a/workflows/check-consistency.md
+++ b/workflows/check-consistency.md
@@ -27,6 +27,7 @@ For Core/Vault root selection checks, also run:
 ```bash
 python3 scripts/foundry_config.py status
 python3 scripts/check_foundry_roots.py --core-root . --vault-root ~/.agent-foundry/vault/my-agent-foundry-vault
+python3 scripts/operation_context.py status --core-root . --vault-root ~/.agent-foundry/vault/my-agent-foundry-vault
 ```
 
 This checks:
@@ -39,11 +40,13 @@ This checks:
 - missing or corrupt Vault indexes fail with actionable messages.
 - blank Vault publishing reports nothing to publish;
 - populated Vault publishing can produce adapter outputs in a temporary output root.
+- operation-context status reports Core, selected Vault, allowed reads, and read-only forbidden writes.
 
 To exercise deterministic same-root, blank Vault, maintainer-like Vault, and failure fixtures, run:
 
 ```bash
 python3 scripts/test_foundry_roots.py
+python3 scripts/test_operation_context.py
 ```
 
 ## Manual Fallback

--- a/workflows/harvest-practices.md
+++ b/workflows/harvest-practices.md
@@ -35,6 +35,14 @@ During AF-3 compatibility mode, Core and Vault may share one root. After the phy
 
 If the Vault is locked, dirty in a conflicting way, or unavailable, produce candidate recommendations only and do not write files.
 
+Before any canonical write, display or run the operation-context preflight so nested use cannot confuse the current product project with Agent Foundry Core or the selected Vault:
+
+```bash
+python3 <core-root>/scripts/operation_context.py harvest --cwd . --core-root <core-root> --vault-root <vault-root>
+```
+
+The report must show the current project as evidence source when harvesting from another repository, Core as tooling/schema/workflow source, and the selected Vault as the canonical write target.
+
 ## 1. Current Capability Check
 
 Before routing or drafting, distinguish current repository capability from proposed or future architecture.

--- a/workflows/import-external-skills.md
+++ b/workflows/import-external-skills.md
@@ -23,6 +23,16 @@ Record:
 
 If a staged import file is needed, place it under `imports/inbox/` with a concise provenance header.
 
+For existing runtime or local source material, prefer the Core staging helper with explicit paths:
+
+```text
+python3 scripts/import_runtime_assets.py --source <explicit-path> --source-runtime <codex|claude-code|hermes|chatgpt|prompts|helper-files|other> --vault-root <vault-root>
+```
+
+Default behavior is dry-run. Use `--apply` only after confirming the operation context and target Vault/import inbox. Directories are explicit inputs; recursive directory reads require `--recursive`. Do not scan broad private runtime trees by default.
+
+The staging helper writes review evidence only under `imports/inbox/`. It must preserve source runtime files, avoid adapter writes, avoid canonical practice/asset activation, and never execute imported helper scripts.
+
 ## 2. License and Security Review
 
 Check:

--- a/workflows/install-adapters.md
+++ b/workflows/install-adapters.md
@@ -79,6 +79,64 @@ runtime/local/runtime_manifest.yaml
 
 10. For ChatGPT, manually upload `adapters/chatgpt/knowledge/` and copy `custom-instructions.md`.
 
+## Cross-Machine Restore
+
+Use this path when a deployment must recreate runtime state from public Core plus a selected Vault, not from another machine's runtime copy.
+
+1. Clone or update Core on the target machine.
+2. Clone, pull, or initialize the selected Vault on the target machine.
+3. Validate the pair before publishing or installing:
+
+   ```bash
+   python3 scripts/check_foundry_roots.py --core-root <core-root> --vault-root <vault-root>
+   ```
+
+4. Publish generated adapters from that selected Vault into a machine-local output directory:
+
+   ```bash
+   python3 scripts/publish_adapters.py --core-root <core-root> --vault-root <vault-root> --output-root <generated-root> --apply
+   ```
+
+5. Initialize and review the local runtime manifest on that machine:
+
+   ```bash
+   python3 scripts/runtime_manifest.py init
+   python3 scripts/runtime_manifest.py detect
+   python3 scripts/runtime_manifest.py plan
+   ```
+
+6. Dry-run install from the selected output and read the status report before applying:
+
+   ```bash
+   python3 scripts/install_foundry.py --core-root <core-root> --vault-root <vault-root> --adapter-root <generated-root>
+   python3 scripts/sync_status.py --core-root <core-root> --vault-root <vault-root> --adapter-root <generated-root>
+   ```
+
+7. Apply only after the report names the expected Core root, Vault root, generated output, enabled runtimes, manual targets, and receipt status.
+
+Do not copy `runtime/local/runtime_manifest.yaml`, `runtime/local/adapter-install-receipt.yaml`, `~/.agent-foundry/config.yaml`, managed runtime directories, or ChatGPT project imports from another machine as canonical truth. Recreate them locally from the selected Vault and generated output.
+
+## Disable And Rollback
+
+Disabling a target changes only the machine-local runtime manifest:
+
+```bash
+python3 scripts/runtime_manifest.py disable <target>
+python3 scripts/runtime_manifest.py plan
+python3 scripts/sync_status.py
+```
+
+Rollback helpers operate on managed runtime copies and Claude managed blocks. They do not delete or rewrite canonical Vault records:
+
+```bash
+python3 scripts/rollback_runtime.py status
+python3 scripts/rollback_runtime.py remove-skill <skill-name> --target codex --dry-run
+python3 scripts/rollback_runtime.py remove-block --target claude-code --dry-run
+python3 scripts/rollback_runtime.py restore-claude --dry-run
+```
+
+Remove only directories that contain `.agent-foundry-managed`, unless the user explicitly approves `--force` after inspecting the path. If `sync_status.py` reports selected-output drift, stale runtime files, or missing receipts, treat that as cleanup work on the current machine; do not repair it by editing unrelated Vault records. ChatGPT remains manual import and manual cleanup.
+
 ## Safety
 
 - Never install proposed/candidate content directly.

--- a/workflows/install-adapters.md
+++ b/workflows/install-adapters.md
@@ -59,6 +59,8 @@ runtime/local/runtime_manifest.yaml
    python3 scripts/install_foundry.py
    ```
 
+   The dry run prints an operation-context preflight. Confirm that Core, selected Vault, generated adapter output, managed runtime writes, manual targets, and forbidden writes are visible before applying.
+
 7. Apply only when destinations are correct:
 
    ```bash

--- a/workflows/publish-adapters.md
+++ b/workflows/publish-adapters.md
@@ -22,6 +22,14 @@ Example:
 python3 scripts/publish_adapters.py --core-root . --vault-root ~/.agent-foundry/vault/my-agent-foundry-vault --output-root /tmp/agent-foundry-adapters --apply
 ```
 
+The publish script prints an operation-context preflight before writing. If running the workflow manually, verify the report says:
+
+- operation: `publish`;
+- Core is the tooling/profile source;
+- Vault is the selected canonical record source;
+- allowed writes are limited to the generated adapter output root;
+- runtime install paths are forbidden until the install workflow runs.
+
 ## 1. Select Practices
 
 Publish only practices with:

--- a/workflows/refresh.md
+++ b/workflows/refresh.md
@@ -25,6 +25,14 @@ If the current working directory is inside the agent-foundry repo, use it. Other
 
 Change into the repo root before proceeding.
 
+Run a read-only operation-context preflight and keep the output in the final report:
+
+```bash
+python3 scripts/operation_context.py status
+```
+
+If the report cannot identify Core and the selected Vault, stop before pull, publish, or install. If the command is invoked from a product project, the report must show that project as evidence context only; refresh writes must stay within Core machine-local state, generated adapter output, and managed runtime targets.
+
 ---
 
 ## Step 1: Determine Local State


### PR DESCRIPTION
## Summary

Final AF5 integration from `af5/integration` to `main` after explicit human authorization.

This integrates the AF5 onboarding readiness work, including:
- operation-context preflight and nested-context guard
- fresh install status and bootstrap deployment path
- optional multi-agent capability pack candidate
- runtime asset import staging
- cross-machine restore / rollback onboarding docs and temp regression
- final AF5 end-to-end validation report

## Human Authorization

User approved both required authorization phrases in the current Codex thread:
- `批准 AF5 close`
- `批准 af5/integration 合入 main`

## Verification

- `python3 scripts/check_consistency.py`
- `python3 scripts/check_capability_pack_fixtures.py`
- `python3 scripts/test_operation_context.py`

## Residual Deferrals

- Physical second-machine execution remains deferred.
- ChatGPT import/cleanup remains manual.
- Optional pack deployment beyond MVP fixture remains later work.
- Real capability-owned helper install remains deferred.
- Advanced capability discovery / marketplace / M9 remain future work.
- Memory-system implementation remains out of AF5 scope.