### PR TITLE
Add generic capability pack planning

### DIFF
--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -613,6 +613,26 @@ def check_bootstrap_pack_deployment_script() -> list[str]:
     return output.splitlines()
 
 
+def check_capability_pack_plan_script() -> list[str]:
+    script = ROOT / "scripts" / "test_capability_pack_plan.py"
+    if not script.exists():
+        return ["Missing scripts/test_capability_pack_plan.py"]
+    result = subprocess.run(
+        ["python3", str(script)],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode == 0:
+        return []
+    output = (result.stdout + result.stderr).strip()
+    if not output:
+        return ["Capability pack plan fixture failed without output"]
+    return output.splitlines()
+
+
 def check_runtime_import_script() -> list[str]:
     script = ROOT / "scripts" / "test_import_runtime_assets.py"
     if not script.exists():
@@ -654,6 +674,7 @@ def main() -> int:
     errors += check_activation_script()
     errors += check_capability_pack_fixtures_script()
     errors += check_bootstrap_pack_deployment_script()
+    errors += check_capability_pack_plan_script()
     errors += check_runtime_import_script()
 
     if errors:

--- a/scripts/plan_capability_pack.py
+++ b/scripts/plan_capability_pack.py
@@ -1,0 +1,557 @@
+#!/usr/bin/env python3
+"""Plan a capability pack deployment without writing Vault or runtime files."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from check_foundry_roots import (
+    VAULT_LAYOUT_MARKER,
+    frontmatter,
+    parse_marker,
+    scan_yaml_field,
+    simple_yaml_entries,
+    validate,
+)
+from deploy_capability_pack import (
+    REQUIRED_RECORD_FIELDS,
+    SHA256_RE,
+    deployed_record_text,
+    inline_list,
+    list_entries,
+    read,
+    section_scalars,
+    sha256,
+    top_level_scalars,
+)
+from foundry_config import ROOT
+
+
+ALLOWED_DISTRIBUTION_TYPES = {"mandatory_bootstrap", "optional_capability", "product_project_candidate"}
+ALLOWED_IMPORT_ACTIONS = {"create_or_review_update", "skip_if_present", "stage_only"}
+ALLOWED_DESTINATION_LAYERS = {"canonical_vault_record", "vault_metadata", "import_staging_reference"}
+ALLOWED_PAYLOAD_INSTALL_BOUNDARIES = {"managed_runtime_copy_required", "manual_import_only", "no_install"}
+REQUIRED_PLAN_MANIFEST_FIELDS = {
+    "manifest_schema_version",
+    "pack_id",
+    "title",
+    "description",
+    "lifecycle_status",
+    "version",
+    "exported_at",
+    "distribution_type",
+    "source_provenance",
+    "maintainer_contact",
+    "license",
+    "sensitivity",
+    "review_state",
+}
+SUPPORTED_MANIFEST_SCHEMA_VERSION = "1"
+SUPPORTED_CORE_SCHEMA_VERSION = 1
+REQUIRED_CONFLICT_POLICY_FIELDS = {
+    "id_collision",
+    "same_version_hash_mismatch",
+    "newer_version_update",
+    "local_edit_behavior",
+    "rollback_notes",
+}
+REQUIRED_INTEGRITY_FIELDS = {
+    "digest_algorithm",
+    "manifest_paths_are_relative",
+    "private_vault_content",
+}
+
+
+@dataclass(frozen=True)
+class PlannedRecord:
+    item_id: str
+    kind: str
+    import_action: str
+    source_path: Path
+    destination_path: Path
+    source_sha256: str
+    current_sha256: str
+    imported_sha256: str
+    outcome: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class PlannedPayload:
+    payload_id: str
+    path: Path
+    install_boundary: str
+    outcome: str
+    detail: str
+
+
+def rel(path: Path, root: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+def destination_for(vault_root: Path, kind: str, source_path: Path) -> tuple[Path, list[str]]:
+    errors: list[str] = []
+    if kind == "practice":
+        metadata = frontmatter(source_path)
+        item_id = metadata.get("id", "")
+        domain = metadata.get("domain", "")
+        if not item_id:
+            errors.append(f"{source_path}: practice missing id")
+        if not domain:
+            errors.append(f"{source_path}: practice missing domain")
+            domain = "uncategorized"
+        return vault_root / "practices" / domain / source_path.name, errors
+    if kind == "asset":
+        item_id = scan_yaml_field(source_path, "id") or ""
+        asset_type = scan_yaml_field(source_path, "asset_type") or ""
+        if not item_id:
+            errors.append(f"{source_path}: asset missing id")
+        if not asset_type:
+            errors.append(f"{source_path}: asset missing asset_type")
+            asset_type = "asset"
+        directory = {"skill": "skills", "subagent": "subagents", "automation": "automations"}.get(
+            asset_type, f"{asset_type}s"
+        )
+        return vault_root / "assets" / directory / source_path.name, errors
+    return vault_root / source_path.name, [f"{source_path}: unsupported record kind {kind}"]
+
+
+def indexed_records(vault_root: Path) -> dict[str, dict[str, str]]:
+    records: dict[str, dict[str, str]] = {}
+    practice_index = vault_root / "indexes" / "practice_index.yaml"
+    asset_index = vault_root / "indexes" / "asset_index.yaml"
+    if practice_index.exists():
+        for entry in simple_yaml_entries(read(practice_index), "practices")[0]:
+            item_id = entry.get("id", "")
+            if item_id:
+                records[item_id] = {"kind": "practice", **entry}
+    if asset_index.exists():
+        for entry in simple_yaml_entries(read(asset_index), "assets")[0]:
+            item_id = entry.get("id", "")
+            if item_id:
+                records[item_id] = {"kind": "asset", **entry}
+    return records
+
+
+def deployed_pack_records(vault_root: Path, pack_id: str) -> dict[str, dict[str, str]]:
+    path = vault_root / "packs" / "deployed-pack-index.yaml"
+    if not path.exists():
+        return {}
+    records: dict[str, dict[str, str]] = {}
+    lines = path.read_text(encoding="utf-8").splitlines()
+    in_pack = False
+    in_records = False
+    current: dict[str, str] | None = None
+    for raw in lines:
+        stripped = raw.strip()
+        if raw.startswith("  - pack_id:"):
+            if current and in_pack:
+                records[current.get("id", "")] = current
+            current = None
+            in_records = False
+            in_pack = stripped.split(":", 1)[1].strip().strip('"') == pack_id
+            continue
+        if not in_pack:
+            continue
+        if raw.startswith("    records:"):
+            in_records = True
+            continue
+        if in_records and raw.startswith("    ") and not raw.startswith("      "):
+            if current and current.get("id"):
+                records[current["id"]] = current
+            current = None
+            if stripped and not stripped.startswith("- "):
+                in_records = False
+            continue
+        if in_records and raw.startswith("      - "):
+            if current and current.get("id"):
+                records[current["id"]] = current
+            current = {}
+            item = stripped[2:].strip()
+            if ":" in item:
+                key, value = item.split(":", 1)
+                current[key.strip()] = value.strip().strip('"')
+            continue
+        if in_records and current is not None and raw.startswith("        ") and ":" in stripped:
+            key, value = stripped.split(":", 1)
+            current[key.strip()] = value.strip().strip('"')
+    if current and in_pack and current.get("id"):
+        records[current["id"]] = current
+    return records
+
+
+def vault_mentions_pack(vault_root: Path, pack_id: str) -> bool:
+    metadata = vault_root / "packs" / "deployed-pack-index.yaml"
+    if metadata.exists() and pack_id in metadata.read_text(encoding="utf-8"):
+        return True
+    for base in [vault_root / "practices", vault_root / "assets"]:
+        if not base.exists():
+            continue
+        for path in base.rglob("*"):
+            if path.is_file() and pack_id in path.read_text(encoding="utf-8"):
+                return True
+    return False
+
+
+def safe_pack_path(pack_root: Path, raw_path: str, label: str) -> tuple[Path | None, str]:
+    if not raw_path:
+        return None, f"{label} missing path"
+    relative = Path(raw_path)
+    if relative.is_absolute():
+        return None, f"{label} path must be relative: {raw_path}"
+    root = pack_root.resolve()
+    candidate = (pack_root / relative).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None, f"{label} path escapes pack root: {raw_path}"
+    return candidate, ""
+
+
+def source_record_id(kind: str, source_path: Path) -> str:
+    if kind == "practice":
+        return frontmatter(source_path).get("id", "")
+    if kind == "asset":
+        return scan_yaml_field(source_path, "id") or ""
+    return ""
+
+
+def validate_manifest(core_root: Path, vault_root: Path, pack_root: Path) -> tuple[dict[str, str], list[str], str]:
+    manifest_path = pack_root / "manifest.yaml"
+    if not manifest_path.exists():
+        return {}, [f"Capability pack manifest missing: {manifest_path}"], ""
+    manifest_text = read(manifest_path)
+    manifest = top_level_scalars(manifest_text)
+    errors: list[str] = []
+    for field in sorted(REQUIRED_PLAN_MANIFEST_FIELDS - manifest.keys()):
+        errors.append(f"manifest missing {field}")
+    if manifest.get("manifest_schema_version", "") != SUPPORTED_MANIFEST_SCHEMA_VERSION:
+        errors.append(
+            "unsupported manifest_schema_version "
+            f"{manifest.get('manifest_schema_version', '')}; expected {SUPPORTED_MANIFEST_SCHEMA_VERSION}"
+        )
+    if manifest.get("distribution_type") not in ALLOWED_DISTRIBUTION_TYPES:
+        errors.append(f"invalid distribution_type {manifest.get('distribution_type', '')}")
+    if manifest.get("sensitivity") != "public":
+        errors.append("only public fixture packs are supported by this planner")
+    if manifest.get("review_state") not in {"reviewed", "accepted", "unreviewed"}:
+        errors.append(f"invalid review_state {manifest.get('review_state', '')}")
+
+    compatibility = section_scalars(manifest_text, "compatibility")
+    for field in ["core_schema_version_min", "core_schema_version_max", "vault_layout_versions", "requires_bootstrap_pack"]:
+        if field not in compatibility:
+            errors.append(f"compatibility missing {field}")
+    try:
+        core_min = int(compatibility.get("core_schema_version_min", "0"))
+        core_max = int(compatibility.get("core_schema_version_max", "0"))
+        if not (core_min <= SUPPORTED_CORE_SCHEMA_VERSION <= core_max):
+            errors.append(f"pack does not support Core schema version {SUPPORTED_CORE_SCHEMA_VERSION}")
+    except ValueError:
+        errors.append("compatibility core schema versions must be integers")
+    vault_marker, marker_errors = parse_marker(vault_root / VAULT_LAYOUT_MARKER)
+    errors.extend(f"vault marker {error}" for error in marker_errors)
+    vault_layout = str(vault_marker.get("layout_version", ""))
+    if vault_layout and vault_layout not in inline_list(compatibility.get("vault_layout_versions", "")):
+        errors.append(f"pack does not support selected Vault layout version {vault_layout}")
+    if compatibility.get("requires_bootstrap_pack") == "true" and not vault_mentions_pack(
+        vault_root, "pack.bootstrap.minimal"
+    ):
+        errors.append("pack requires bootstrap pack but selected Vault does not show pack.bootstrap.minimal")
+
+    conflict_policy = section_scalars(manifest_text, "conflict_policy")
+    for field in sorted(REQUIRED_CONFLICT_POLICY_FIELDS - conflict_policy.keys()):
+        errors.append(f"conflict_policy missing {field}")
+    if conflict_policy.get("id_collision") != "fail_closed":
+        errors.append("conflict_policy id_collision must be fail_closed")
+    if conflict_policy.get("same_version_hash_mismatch") != "fail_closed":
+        errors.append("conflict_policy same_version_hash_mismatch must be fail_closed")
+
+    integrity = section_scalars(manifest_text, "integrity")
+    for field in sorted(REQUIRED_INTEGRITY_FIELDS - integrity.keys()):
+        errors.append(f"integrity missing {field}")
+    if integrity.get("digest_algorithm") != "sha256":
+        errors.append("integrity digest_algorithm must be sha256")
+    if integrity.get("manifest_paths_are_relative") != "true":
+        errors.append("integrity manifest_paths_are_relative must be true")
+    if integrity.get("private_vault_content") != "excluded":
+        errors.append("integrity private_vault_content must be excluded")
+
+    if not (core_root / "schemas" / "capability-pack-manifest.schema.yaml").exists():
+        errors.append("core capability pack manifest schema missing")
+    return manifest, errors, manifest_text
+
+
+def validate_records(pack_root: Path, manifest_text: str) -> tuple[list[dict[str, str]], list[str]]:
+    errors: list[str] = []
+    valid_records: list[dict[str, str]] = []
+    records = list_entries(manifest_text, "included_records")
+    if not records:
+        errors.append("included_records must not be empty")
+        return valid_records, errors
+    seen: set[str] = set()
+    for entry in records:
+        item_id = entry.get("id", "<unknown>")
+        entry_errors: list[str] = []
+        for field in sorted(REQUIRED_RECORD_FIELDS - entry.keys()):
+            entry_errors.append(f"included_record {item_id} missing {field}")
+        if item_id in seen:
+            entry_errors.append(f"duplicate included_record id {item_id}")
+        seen.add(item_id)
+        if entry.get("destination_layer") not in ALLOWED_DESTINATION_LAYERS:
+            entry_errors.append(
+                f"included_record {item_id} has unsupported destination_layer {entry.get('destination_layer', '')}"
+            )
+        if entry.get("import_action") not in ALLOWED_IMPORT_ACTIONS:
+            entry_errors.append(f"included_record {item_id} has unsupported import_action {entry.get('import_action', '')}")
+        digest = entry.get("content_sha256", "")
+        if not SHA256_RE.match(digest):
+            entry_errors.append(f"included_record {item_id} has invalid content_sha256")
+        source_path, path_error = safe_pack_path(pack_root, entry.get("path", ""), f"included_record {item_id}")
+        if path_error:
+            entry_errors.append(path_error)
+        elif source_path is None:
+            entry_errors.append(f"included_record {item_id} source path unavailable")
+        elif not source_path.exists():
+            entry_errors.append(f"included_record {item_id} source path missing: {entry.get('path', '')}")
+        elif sha256(source_path) != digest:
+            entry_errors.append(f"included_record {item_id} content_sha256 mismatch")
+        else:
+            source_id = source_record_id(entry.get("kind", ""), source_path)
+            if source_id and source_id != item_id:
+                entry_errors.append(f"included_record {item_id} does not match source metadata id {source_id}")
+        errors.extend(entry_errors)
+        if not entry_errors and source_path is not None:
+            valid_entry = dict(entry)
+            valid_entry["_source_path"] = str(source_path)
+            valid_records.append(valid_entry)
+    return valid_records, errors
+
+
+def validate_payloads(pack_root: Path, manifest_text: str) -> tuple[list[PlannedPayload], list[str]]:
+    errors: list[str] = []
+    planned: list[PlannedPayload] = []
+    for payload in list_entries(manifest_text, "executable_payloads"):
+        payload_id = payload.get("id", "<unknown>")
+        install_boundary = payload.get("install_boundary", "")
+        source_path, path_error = safe_pack_path(pack_root, payload.get("path", ""), f"executable_payload {payload_id}")
+        if payload.get("execute_from_pack") != "false":
+            errors.append(f"executable_payload {payload_id} must not execute from pack")
+        if install_boundary not in ALLOWED_PAYLOAD_INSTALL_BOUNDARIES:
+            errors.append(f"executable_payload {payload_id} has unsupported install_boundary {install_boundary}")
+        digest = payload.get("source_sha256", "")
+        if not SHA256_RE.match(digest):
+            errors.append(f"executable_payload {payload_id} has invalid source_sha256")
+        elif path_error:
+            errors.append(path_error)
+        elif source_path is None:
+            errors.append(f"executable_payload {payload_id} source path unavailable")
+        elif not source_path.exists():
+            errors.append(f"executable_payload {payload_id} source path missing: {payload.get('path', '')}")
+        elif sha256(source_path) != digest:
+            errors.append(f"executable_payload {payload_id} source_sha256 mismatch")
+        if source_path is not None:
+            planned.append(
+                PlannedPayload(
+                    payload_id=payload_id,
+                    path=source_path,
+                    install_boundary=install_boundary,
+                    outcome="blocked_executable_install"
+                    if install_boundary == "managed_runtime_copy_required"
+                    else "no_install",
+                    detail="Executable payloads are inert in #106; managed install belongs to later issues.",
+                )
+            )
+    return planned, errors
+
+
+def plan_records(
+    vault_root: Path,
+    pack_root: Path,
+    manifest: dict[str, str],
+    record_entries: list[dict[str, str]],
+) -> tuple[list[PlannedRecord], list[str]]:
+    errors: list[str] = []
+    planned: list[PlannedRecord] = []
+    indexed = indexed_records(vault_root)
+    imported = deployed_pack_records(vault_root, manifest.get("pack_id", ""))
+    id_kind = {item_id: entry.get("kind", "") for item_id, entry in indexed.items()}
+    planned_destinations: dict[Path, str] = {}
+
+    for entry in record_entries:
+        item_id = entry.get("id", "<unknown>")
+        kind = entry.get("kind", "")
+        import_action = entry.get("import_action", "")
+        source_path = Path(entry.get("_source_path", ""))
+        destination_path, destination_errors = destination_for(vault_root, kind, source_path)
+        if destination_errors:
+            errors.extend(destination_errors)
+            continue
+        current_hash = sha256(destination_path) if destination_path.exists() else ""
+        imported_hash = imported.get(item_id, {}).get("deployed_sha256", "") or imported.get(item_id, {}).get(
+            "imported_sha256", ""
+        )
+        source_hash = entry.get("content_sha256", "")
+        deployed_hash = ""
+        if source_path.exists():
+            deployed_text = deployed_record_text(kind, read(source_path), manifest)
+            deployed_hash = hashlib.sha256(deployed_text.encode("utf-8")).hexdigest()
+        indexed_entry = indexed.get(item_id)
+
+        outcome = "add"
+        detail = f"would create {rel(destination_path, vault_root)}"
+        if destination_path in planned_destinations:
+            outcome = "fail"
+            detail = f"duplicate planned destination also used by {planned_destinations[destination_path]}"
+        elif indexed_entry and indexed_entry.get("kind") != kind:
+            outcome = "fail"
+            detail = f"id exists as {indexed_entry.get('kind')} but pack record is {kind}"
+        elif indexed_entry and indexed_entry.get("path") != rel(destination_path, vault_root):
+            outcome = "fail"
+            detail = f"index path {indexed_entry.get('path')} differs from destination {rel(destination_path, vault_root)}"
+        elif destination_path.exists() and not indexed_entry:
+            outcome = "fail"
+            detail = "record file exists without matching index entry"
+        elif indexed_entry and not destination_path.exists():
+            outcome = "fail"
+            detail = "index entry exists but record file is missing"
+        elif import_action == "stage_only":
+            outcome = "stage_only"
+            detail = "record is stage_only; #106 reports it but does not plan canonical write"
+        elif destination_path.exists() and current_hash in {source_hash, deployed_hash}:
+            outcome = "skip"
+            detail = "current Vault record hash matches pack source or deployed form"
+        elif destination_path.exists() and imported_hash and current_hash != imported_hash:
+            outcome = "merge_required"
+            detail = "current Vault record differs from prior deployed hash; preserve local edit"
+        elif destination_path.exists():
+            outcome = "update"
+            detail = "record exists and differs from pack source; reviewed update required"
+        elif item_id in id_kind:
+            outcome = "fail"
+            detail = "id exists in Vault index without a usable destination"
+        planned_destinations.setdefault(destination_path, item_id)
+
+        planned.append(
+            PlannedRecord(
+                item_id=item_id,
+                kind=kind,
+                import_action=import_action,
+                source_path=source_path,
+                destination_path=destination_path,
+                source_sha256=source_hash,
+                current_sha256=current_hash,
+                imported_sha256=imported_hash,
+                outcome=outcome,
+                detail=detail,
+            )
+        )
+    return planned, errors
+
+
+def manifest_hash(pack_root: Path) -> str:
+    return sha256(pack_root / "manifest.yaml")
+
+
+def same_version_hash_mismatch(vault_root: Path, manifest: dict[str, str], current_manifest_hash: str) -> bool:
+    path = vault_root / "packs" / "deployed-pack-index.yaml"
+    if not path.exists():
+        return False
+    text = path.read_text(encoding="utf-8")
+    pattern = re.compile(
+        rf"  - pack_id:\s*{re.escape(manifest.get('pack_id', ''))}\n(?P<body>(?:    .*\n)*)",
+        re.MULTILINE,
+    )
+    match = pattern.search(text)
+    if not match:
+        return False
+    body = match.group("body")
+    version_match = re.search(r"    version:\s*\"?([^\"\n]+)\"?", body)
+    hash_match = re.search(r"      manifest_sha256:\s*\"?([0-9a-f]{64})\"?", body)
+    return bool(
+        version_match
+        and hash_match
+        and version_match.group(1).strip() == manifest.get("version", "")
+        and hash_match.group(1).strip() != current_manifest_hash
+    )
+
+
+def print_plan(
+    pack_root: Path,
+    vault_root: Path,
+    manifest: dict[str, str],
+    records: list[PlannedRecord],
+    payloads: list[PlannedPayload],
+    errors: list[str],
+) -> None:
+    print("Capability pack plan/check report")
+    print(f"pack_root: {pack_root}")
+    print(f"vault_root: {vault_root}")
+    if manifest:
+        print(f"pack_id: {manifest.get('pack_id', '')}")
+        print(f"version: {manifest.get('version', '')}")
+        print(f"distribution_type: {manifest.get('distribution_type', '')}")
+        print(f"review_state: {manifest.get('review_state', '')}")
+        print(f"manifest_sha256: {manifest_hash(pack_root) if (pack_root / 'manifest.yaml').exists() else ''}")
+    counts: dict[str, int] = {}
+    for record in records:
+        counts[record.outcome] = counts.get(record.outcome, 0) + 1
+    for payload in payloads:
+        counts[payload.outcome] = counts.get(payload.outcome, 0) + 1
+    if errors:
+        counts["fail"] = counts.get("fail", 0) + len(errors)
+    print("summary:")
+    for key in ["add", "update", "skip", "merge_required", "stage_only", "blocked_executable_install", "no_install", "fail"]:
+        print(f"{key}: {counts.get(key, 0)}")
+    print("records:")
+    if not records:
+        print("- none")
+    for record in records:
+        print(f"- {record.item_id} {record.kind} {record.outcome}: {record.detail}")
+    print("executable_payloads:")
+    if not payloads:
+        print("- none")
+    for payload in payloads:
+        print(f"- {payload.payload_id} {payload.outcome}: {payload.detail}")
+    if errors:
+        print("failures:")
+        for error in errors:
+            print(f"- {error}")
+    print("writes: none")
+
+
+def plan(core_root: Path, vault_root: Path, pack_root: Path) -> int:
+    root_errors = validate(core_root, vault_root)
+    manifest, manifest_errors, manifest_text = validate_manifest(core_root, vault_root, pack_root)
+    records_raw, record_errors = validate_records(pack_root, manifest_text) if manifest_text else ([], [])
+    payloads, payload_errors = validate_payloads(pack_root, manifest_text) if manifest_text else ([], [])
+    records, planning_errors = plan_records(vault_root, pack_root, manifest, records_raw) if manifest else ([], [])
+    errors = root_errors + manifest_errors + record_errors + payload_errors + planning_errors
+    if manifest and same_version_hash_mismatch(vault_root, manifest, manifest_hash(pack_root)):
+        errors.append("same pack id and version has different manifest_sha256 in deployed-pack-index.yaml")
+    print_plan(pack_root, vault_root, manifest, records, payloads, errors)
+    return 1 if errors or any(record.outcome == "fail" for record in records) else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Plan a capability pack deployment without writing Vault or runtime files.")
+    parser.add_argument("pack_root", help="Capability pack directory containing manifest.yaml.")
+    parser.add_argument("--core-root", default=str(ROOT), help="Agent Foundry Core root.")
+    parser.add_argument("--vault-root", required=True, help="Selected Agent Foundry Vault root.")
+    args = parser.parse_args()
+    return plan(
+        Path(args.core_root).expanduser().resolve(),
+        Path(args.vault_root).expanduser().resolve(),
+        Path(args.pack_root).expanduser().resolve(),
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_capability_pack_plan.py
+++ b/scripts/test_capability_pack_plan.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Regression tests for read-only capability pack planning."""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEPLOY = ROOT / "scripts" / "deploy_capability_pack.py"
+INIT = ROOT / "scripts" / "init_vault.py"
+PLAN = ROOT / "scripts" / "plan_capability_pack.py"
+BOOTSTRAP_PACK = ROOT / "fixtures" / "capability-packs" / "bootstrap-minimal"
+OPTIONAL_PACK = ROOT / "fixtures" / "capability-packs" / "optional-multi-agent"
+
+
+def run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, *args],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def expect(name: str, result: subprocess.CompletedProcess[str], should_pass: bool, expected_text: str = "") -> list[str]:
+    output = result.stdout + result.stderr
+    if (result.returncode == 0) == should_pass and (not expected_text or expected_text in output):
+        print(f"{name}: ok")
+        return []
+    return [
+        f"{name}: expected {'pass' if should_pass else 'failure'}"
+        + (f" containing {expected_text!r}" if expected_text else "")
+        + f", got exit {result.returncode}\n{output.strip()}"
+    ]
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def practice_text(item_id: str, filename: str = "") -> str:
+    return "\n".join(
+        [
+            "---",
+            f'id: "{item_id}"',
+            f'title: "{filename or item_id}"',
+            'domain: "meta"',
+            'status: "candidate"',
+            "---",
+            "",
+            "Fixture practice.",
+            "",
+        ]
+    )
+
+
+def write_probe_pack(
+    base: Path,
+    name: str,
+    records: list[dict[str, str]],
+    payloads: list[dict[str, str]] | None = None,
+    *,
+    manifest_schema_version: str = "1",
+    include_source_provenance: bool = True,
+    include_conflict_policy: bool = True,
+    include_integrity: bool = True,
+    core_schema_min: str = "1",
+    core_schema_max: str = "1",
+) -> Path:
+    pack = base / name
+    pack.mkdir(parents=True, exist_ok=True)
+    lines = [
+        f"manifest_schema_version: {manifest_schema_version}",
+        f"pack_id: pack.probe.{name}",
+        f"title: Probe Pack {name}",
+        "description: Probe pack for planner regression tests.",
+        "lifecycle_status: candidate",
+        "version: 0.1.0",
+        "exported_at: 2026-06-12",
+        "distribution_type: optional_capability",
+        "maintainer_contact: test",
+        "license: test",
+        "sensitivity: public",
+        "review_state: unreviewed",
+        "",
+        "compatibility:",
+        f"  core_schema_version_min: {core_schema_min}",
+        f"  core_schema_version_max: {core_schema_max}",
+        "  vault_layout_versions: [1]",
+        "  requires_bootstrap_pack: false",
+        "",
+        "included_records:",
+    ]
+    if include_source_provenance:
+        lines.insert(8, "source_provenance: test fixture")
+    for record in records:
+        lines.extend(
+            [
+                f"  - id: {record['id']}",
+                "    kind: practice",
+                "    lifecycle_status: candidate",
+            ]
+        )
+        if "path" in record:
+            lines.append(f"    path: {record['path']}")
+        lines.extend(
+            [
+                "    source_version: 1",
+                f"    content_sha256: \"{record['sha']}\"",
+                "    destination_layer: canonical_vault_record",
+                "    membership_role: optional_member",
+                "    activation_default: manual_review",
+                "    import_action: create_or_review_update",
+            ]
+        )
+    lines.append("")
+    lines.append("executable_payloads:")
+    for payload in payloads or []:
+        lines.extend(
+            [
+                f"  - id: {payload['id']}",
+                f"    title: {payload['id']}",
+                "    lifecycle_status: candidate",
+                f"    path: {payload['path']}",
+                f"    source_sha256: \"{payload['sha']}\"",
+                "    interpreter: python3",
+                "    execute_from_pack: false",
+                "    install_boundary: managed_runtime_copy_required",
+                "    permissions: [filesystem-read]",
+                "    dependencies: []",
+                "    runtime_impact: test",
+            ]
+        )
+    if not payloads:
+        lines[-1] = "executable_payloads: []"
+    if include_conflict_policy:
+        lines.extend(
+            [
+                "",
+                "conflict_policy:",
+                "  id_collision: fail_closed",
+                "  same_version_hash_mismatch: fail_closed",
+                "  newer_version_update: reviewed_diff_required",
+                "  local_edit_behavior: preserve_vault_and_propose_merge",
+                "  rollback_notes: test",
+            ]
+        )
+    if include_integrity:
+        lines.extend(
+            [
+                "",
+                "integrity:",
+                "  digest_algorithm: sha256",
+                "  manifest_paths_are_relative: true",
+                "  private_vault_content: excluded",
+            ]
+        )
+    (pack / "manifest.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return pack
+
+
+def init_blank(vault_root: Path) -> subprocess.CompletedProcess[str]:
+    return run([str(INIT), str(vault_root), "--core-root", str(ROOT), "--apply"])
+
+
+def plan_pack(pack_root: Path, vault_root: Path) -> subprocess.CompletedProcess[str]:
+    return run([str(PLAN), str(pack_root), "--core-root", str(ROOT), "--vault-root", str(vault_root)])
+
+
+def deploy_bootstrap(vault_root: Path) -> subprocess.CompletedProcess[str]:
+    return run(
+        [
+            str(DEPLOY),
+            str(BOOTSTRAP_PACK),
+            "--core-root",
+            str(ROOT),
+            "--vault-root",
+            str(vault_root),
+            "--apply",
+        ]
+    )
+
+
+def write_deployed_index(vault: Path, pack_id: str, version: str, manifest_hash: str, record_id: str, record_hash: str) -> None:
+    packs = vault / "packs"
+    packs.mkdir(parents=True, exist_ok=True)
+    (packs / "deployed-pack-index.yaml").write_text(
+        "\n".join(
+            [
+                "schema_version: 1",
+                "updated: 2026-06-12",
+                "deployed_packs:",
+                f"  - pack_id: {pack_id}",
+                f"    version: {version}",
+                "    source:",
+                f"      manifest_sha256: {manifest_hash}",
+                "    records:",
+                f"      - id: {record_id}",
+                f"        deployed_sha256: {record_hash}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    errors: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="agent-foundry-pack-plan-") as tmp:
+        base = Path(tmp)
+        vault = base / "vault"
+        errors.extend(expect("init-blank-vault", init_blank(vault), True, "Blank Vault initialized and validated."))
+
+        bootstrap_plan = plan_pack(BOOTSTRAP_PACK, vault)
+        errors.extend(expect("plan-bootstrap-add", bootstrap_plan, True, "add: 24"))
+        errors.extend(expect("plan-bootstrap-no-writes", bootstrap_plan, True, "writes: none"))
+
+        optional_without_bootstrap = plan_pack(OPTIONAL_PACK, vault)
+        errors.extend(
+            expect(
+                "plan-optional-requires-bootstrap",
+                optional_without_bootstrap,
+                False,
+                "pack requires bootstrap pack",
+            )
+        )
+
+        errors.extend(expect("deploy-bootstrap", deploy_bootstrap(vault), True, "selected Vault validated"))
+
+        bootstrap_after_deploy = plan_pack(BOOTSTRAP_PACK, vault)
+        errors.extend(expect("plan-bootstrap-skip-after-deploy", bootstrap_after_deploy, True, "skip: 24"))
+
+        optional_after_bootstrap = plan_pack(OPTIONAL_PACK, vault)
+        errors.extend(expect("plan-optional-stage-only", optional_after_bootstrap, True, "stage_only: 2"))
+        errors.extend(
+            expect(
+                "plan-optional-blocks-executable",
+                optional_after_bootstrap,
+                True,
+                "blocked_executable_install: 1",
+            )
+        )
+
+        write_deployed_index(
+            vault,
+            "pack.multi-agent.optional",
+            "0.2.0",
+            "0" * 64,
+            "COLLAB-PACK-001",
+            "",
+        )
+        mismatch = plan_pack(OPTIONAL_PACK, vault)
+        errors.extend(expect("plan-same-version-hash-mismatch", mismatch, False, "different manifest_sha256"))
+
+        target = vault / "practices" / "meta" / "BOOT-001-bootstrap-orientation.md"
+        current_hash = sha256(target)
+        write_deployed_index(
+            vault,
+            "pack.bootstrap.minimal",
+            "0.2.0",
+            sha256(BOOTSTRAP_PACK / "manifest.yaml"),
+            "BOOT-001",
+            current_hash,
+        )
+        target.write_text(target.read_text(encoding="utf-8") + "\nLocal user edit fixture.\n", encoding="utf-8")
+        local_edit = plan_pack(BOOTSTRAP_PACK, vault)
+        errors.extend(expect("plan-local-edit-merge-required", local_edit, True, "merge_required: 1"))
+
+        missing_pack = write_probe_pack(
+            base,
+            "missing-path",
+            [{"id": "MISSING-PATH-001", "sha": "0" * 64}],
+        )
+        missing_path = plan_pack(missing_pack, vault)
+        errors.extend(expect("plan-missing-path-fails-closed", missing_path, False, "missing path"))
+
+        outside = base / "outside.md"
+        outside.write_text(practice_text("OUTSIDE-001"), encoding="utf-8")
+        traversal_pack = write_probe_pack(
+            base,
+            "path-traversal",
+            [{"id": "OUTSIDE-001", "path": "../outside.md", "sha": sha256(outside)}],
+        )
+        traversal = plan_pack(traversal_pack, vault)
+        errors.extend(expect("plan-path-traversal-fails-closed", traversal, False, "path escapes pack root"))
+
+        mismatch_file = base / "id-mismatch" / "records" / "WRONG.md"
+        mismatch_file.parent.mkdir(parents=True, exist_ok=True)
+        mismatch_file.write_text(practice_text("RIGHT-001"), encoding="utf-8")
+        mismatch_pack = write_probe_pack(
+            base,
+            "id-mismatch",
+            [{"id": "WRONG-001", "path": "records/WRONG.md", "sha": sha256(mismatch_file)}],
+        )
+        mismatch_id = plan_pack(mismatch_pack, vault)
+        errors.extend(expect("plan-id-mismatch-fails-closed", mismatch_id, False, "does not match source metadata id"))
+
+        duplicate_a = base / "duplicate-destination" / "a" / "DUP.md"
+        duplicate_b = base / "duplicate-destination" / "b" / "DUP.md"
+        duplicate_a.parent.mkdir(parents=True, exist_ok=True)
+        duplicate_b.parent.mkdir(parents=True, exist_ok=True)
+        duplicate_a.write_text(practice_text("DUP-001", "Duplicate A"), encoding="utf-8")
+        duplicate_b.write_text(practice_text("DUP-002", "Duplicate B"), encoding="utf-8")
+        duplicate_pack = write_probe_pack(
+            base,
+            "duplicate-destination",
+            [
+                {"id": "DUP-001", "path": "a/DUP.md", "sha": sha256(duplicate_a)},
+                {"id": "DUP-002", "path": "b/DUP.md", "sha": sha256(duplicate_b)},
+            ],
+        )
+        duplicate_destination = plan_pack(duplicate_pack, vault)
+        errors.extend(
+            expect(
+                "plan-duplicate-destination-fails-closed",
+                duplicate_destination,
+                False,
+                "duplicate planned destination",
+            )
+        )
+
+        payload_outside = base / "outside_payload.py"
+        payload_outside.write_text("print('do not execute')\n", encoding="utf-8")
+        payload_record = base / "payload-traversal" / "records" / "PAYLOAD.md"
+        payload_record.parent.mkdir(parents=True, exist_ok=True)
+        payload_record.write_text(practice_text("PAYLOAD-001"), encoding="utf-8")
+        payload_pack = write_probe_pack(
+            base,
+            "payload-traversal",
+            [{"id": "PAYLOAD-001", "path": "records/PAYLOAD.md", "sha": sha256(payload_record)}],
+            [{"id": "helper.outside", "path": "../outside_payload.py", "sha": sha256(payload_outside)}],
+        )
+        payload_traversal = plan_pack(payload_pack, vault)
+        errors.extend(expect("plan-payload-traversal-fails-closed", payload_traversal, False, "path escapes pack root"))
+
+        provenance_record = base / "missing-provenance" / "records" / "PROV.md"
+        provenance_record.parent.mkdir(parents=True, exist_ok=True)
+        provenance_record.write_text(practice_text("PROV-001"), encoding="utf-8")
+        missing_provenance_pack = write_probe_pack(
+            base,
+            "missing-provenance",
+            [{"id": "PROV-001", "path": "records/PROV.md", "sha": sha256(provenance_record)}],
+            include_source_provenance=False,
+        )
+        missing_provenance = plan_pack(missing_provenance_pack, vault)
+        errors.extend(
+            expect(
+                "plan-missing-provenance-fails-closed",
+                missing_provenance,
+                False,
+                "manifest missing source_provenance",
+            )
+        )
+
+        schema_record = base / "schema-version" / "records" / "SCHEMA.md"
+        schema_record.parent.mkdir(parents=True, exist_ok=True)
+        schema_record.write_text(practice_text("SCHEMA-001"), encoding="utf-8")
+        schema_pack = write_probe_pack(
+            base,
+            "schema-version",
+            [{"id": "SCHEMA-001", "path": "records/SCHEMA.md", "sha": sha256(schema_record)}],
+            manifest_schema_version="999",
+        )
+        schema_version = plan_pack(schema_pack, vault)
+        errors.extend(
+            expect(
+                "plan-unsupported-schema-version-fails-closed",
+                schema_version,
+                False,
+                "unsupported manifest_schema_version",
+            )
+        )
+
+        conflict_record = base / "missing-conflict-policy" / "records" / "CONFLICT.md"
+        conflict_record.parent.mkdir(parents=True, exist_ok=True)
+        conflict_record.write_text(practice_text("CONFLICT-001"), encoding="utf-8")
+        conflict_pack = write_probe_pack(
+            base,
+            "missing-conflict-policy",
+            [{"id": "CONFLICT-001", "path": "records/CONFLICT.md", "sha": sha256(conflict_record)}],
+            include_conflict_policy=False,
+        )
+        missing_conflict = plan_pack(conflict_pack, vault)
+        errors.extend(
+            expect(
+                "plan-missing-conflict-policy-fails-closed",
+                missing_conflict,
+                False,
+                "conflict_policy missing",
+            )
+        )
+
+        integrity_record = base / "missing-integrity" / "records" / "INTEGRITY.md"
+        integrity_record.parent.mkdir(parents=True, exist_ok=True)
+        integrity_record.write_text(practice_text("INTEGRITY-001"), encoding="utf-8")
+        integrity_pack = write_probe_pack(
+            base,
+            "missing-integrity",
+            [{"id": "INTEGRITY-001", "path": "records/INTEGRITY.md", "sha": sha256(integrity_record)}],
+            include_integrity=False,
+        )
+        missing_integrity = plan_pack(integrity_pack, vault)
+        errors.extend(expect("plan-missing-integrity-fails-closed", missing_integrity, False, "integrity missing"))
+
+        core_schema_record = base / "core-schema-range" / "records" / "CORE.md"
+        core_schema_record.parent.mkdir(parents=True, exist_ok=True)
+        core_schema_record.write_text(practice_text("CORE-SCHEMA-001"), encoding="utf-8")
+        core_schema_pack = write_probe_pack(
+            base,
+            "core-schema-range",
+            [{"id": "CORE-SCHEMA-001", "path": "records/CORE.md", "sha": sha256(core_schema_record)}],
+            core_schema_min="2",
+            core_schema_max="3",
+        )
+        core_schema_range = plan_pack(core_schema_pack, vault)
+        errors.extend(
+            expect(
+                "plan-core-schema-range-fails-closed",
+                core_schema_range,
+                False,
+                "pack does not support Core schema version",
+            )
+        )
+
+    if errors:
+        print("Capability pack plan test failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("Capability pack plan test passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds `scripts/plan_capability_pack.py`, a read-only plan/check command for known capability pack snapshots.
- Reports add/update/skip/merge_required/stage_only/fail outcomes plus blocked executable payload install boundaries.
- Validates manifest compatibility, checksums, bootstrap dependency, same-version manifest hash mismatch, id/path conflicts, and local edit detection from deployed pack metadata.
- Adds `scripts/test_capability_pack_plan.py` and wires it into `scripts/check_consistency.py`.

## Verification

- `python3 scripts/check_capability_pack_fixtures.py`
- `python3 scripts/test_capability_pack_plan.py`
- `python3 scripts/check_consistency.py`
- `git diff --check`

## Boundaries

This PR is read-only planning/checking. It does not apply optional packs, mutate the selected Vault, write generated output, install runtimes, or execute helper payloads.