### PR TITLE
Add optional capability pack apply

### DIFF
--- a/scripts/apply_capability_pack.py
+++ b/scripts/apply_capability_pack.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Apply a reviewed capability pack plan into the selected Vault."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import plan_capability_pack as planner
+from deploy_capability_pack import (
+    deployed_record_text,
+    destination_for as deploy_destination_for,
+    read,
+    update_index_text,
+    write,
+    yaml_string,
+)
+from foundry_config import ROOT
+
+
+BLOCKING_RECORD_OUTCOMES = {"fail", "merge_required", "update"}
+BLOCKING_PAYLOAD_OUTCOMES = {"blocked_executable_install"}
+
+
+def build_plan(core_root: Path, vault_root: Path, pack_root: Path):
+    root_errors = planner.validate(core_root, vault_root)
+    manifest, manifest_errors, manifest_text = planner.validate_manifest(core_root, vault_root, pack_root)
+    records_raw, record_errors = planner.validate_records(pack_root, manifest_text) if manifest_text else ([], [])
+    payloads, payload_errors = planner.validate_payloads(pack_root, manifest_text) if manifest_text else ([], [])
+    records, planning_errors = planner.plan_records(vault_root, pack_root, manifest, records_raw) if manifest else ([], [])
+    errors = root_errors + manifest_errors + record_errors + payload_errors + planning_errors
+    if manifest and planner.same_version_hash_mismatch(vault_root, manifest, planner.manifest_hash(pack_root)):
+        errors.append("same pack id and version has different manifest_sha256 in deployed-pack-index.yaml")
+    return manifest, manifest_text, records_raw, records, payloads, errors
+
+
+def blocking_reasons(records: list[planner.PlannedRecord], payloads: list[planner.PlannedPayload], errors: list[str]) -> list[str]:
+    reasons = list(errors)
+    for record in records:
+        if record.outcome in BLOCKING_RECORD_OUTCOMES:
+            reasons.append(f"{record.item_id}: blocking record outcome {record.outcome}")
+    for payload in payloads:
+        if payload.outcome in BLOCKING_PAYLOAD_OUTCOMES:
+            reasons.append(f"{payload.payload_id}: blocking payload outcome {payload.outcome}")
+    return reasons
+
+
+def existing_pack_metadata_state(vault_root: Path, pack_id: str, manifest_sha256: str) -> str:
+    path = vault_root / "packs" / "deployed-pack-index.yaml"
+    if not path.exists():
+        return "absent"
+    text = path.read_text(encoding="utf-8")
+    if f"  - pack_id: {pack_id}" not in text:
+        return "absent"
+    if manifest_sha256 in text:
+        return "same"
+    return "different"
+
+
+def record_entry_by_id(records_raw: list[dict[str, str]]) -> dict[str, dict[str, str]]:
+    return {entry.get("id", ""): entry for entry in records_raw if entry.get("id", "")}
+
+
+def metadata_text(
+    *,
+    vault_root: Path,
+    pack_root: Path,
+    manifest: dict[str, str],
+    records_raw: list[dict[str, str]],
+    records: list[planner.PlannedRecord],
+) -> str:
+    manifest_sha = planner.manifest_hash(pack_root)
+    by_id = record_entry_by_id(records_raw)
+    lines = [
+        f"  - pack_id: {manifest.get('pack_id', '')}",
+        f"    title: {yaml_string(manifest.get('title', ''))}",
+        f"    version: {yaml_string(manifest.get('version', ''))}",
+        "    lifecycle_status: deployed",
+        f"    distribution_type: {manifest.get('distribution_type', '')}",
+        f"    deployed_at: {datetime.now(timezone.utc).replace(microsecond=0).isoformat()}",
+        "    source:",
+        "      kind: local_path",
+        f"      locator: {yaml_string(str(pack_root))}",
+        f"      manifest_sha256: {manifest_sha}",
+        "      reviewed_by: architect",
+        "    records:",
+    ]
+    if not records:
+        lines.append("      []")
+    for record in records:
+        raw = by_id.get(record.item_id, {})
+        deployed_sha = record.current_sha256
+        if record.outcome == "add":
+            deployed_sha = hashlib.sha256(
+                deployed_record_text(record.kind, read(record.source_path), manifest).encode("utf-8")
+            ).hexdigest()
+        current_state = "unchanged" if record.outcome in {"add", "skip"} else "unknown"
+        lines.extend(
+            [
+                f"      - id: {record.item_id}",
+                f"        kind: {record.kind}",
+                f"        path: {planner.rel(record.destination_path, vault_root)}",
+                f"        imported_version: {yaml_string(raw.get('source_version', ''))}",
+                f"        imported_sha256: {record.source_sha256}",
+                f"        deployed_sha256: {deployed_sha}",
+                f"        lifecycle_status_at_import: {raw.get('lifecycle_status', '')}",
+                f"        current_state: {current_state}",
+                f"        membership_role: {raw.get('membership_role', '')}",
+                f"        activation_default: {raw.get('activation_default', '')}",
+            ]
+        )
+    lines.append("    executable_payloads: []")
+    lines.append("    decisions:")
+    lines.append("      conflict_policy: fail_closed")
+    lines.append("      notes: []")
+    return "\n".join(lines) + "\n"
+
+
+def update_deployed_pack_index(
+    vault_root: Path,
+    pack_root: Path,
+    manifest: dict[str, str],
+    records_raw: list[dict[str, str]],
+    records: list[planner.PlannedRecord],
+    apply: bool,
+) -> None:
+    path = vault_root / "packs" / "deployed-pack-index.yaml"
+    state = existing_pack_metadata_state(vault_root, manifest.get("pack_id", ""), planner.manifest_hash(pack_root))
+    if state == "same":
+        print(f"pack metadata already present: {manifest.get('pack_id', '')}")
+        return
+    if state == "different":
+        raise SystemExit("Refusing to overwrite existing pack metadata with a different manifest hash; use #101 update flow")
+    if path.exists():
+        text = path.read_text(encoding="utf-8").rstrip() + "\n" + metadata_text(
+            vault_root=vault_root,
+            pack_root=pack_root,
+            manifest=manifest,
+            records_raw=records_raw,
+            records=records,
+        )
+    else:
+        today = datetime.now(timezone.utc).date().isoformat()
+        text = "\n".join(["schema_version: 1", f"updated: {today}", "deployed_packs:"]) + "\n" + metadata_text(
+            vault_root=vault_root,
+            pack_root=pack_root,
+            manifest=manifest,
+            records_raw=records_raw,
+            records=records,
+        )
+    write(path, text, apply)
+
+
+def apply_records(vault_root: Path, manifest: dict[str, str], records: list[planner.PlannedRecord], apply: bool) -> None:
+    added = [record for record in records if record.outcome == "add" and record.import_action != "stage_only"]
+    for record in added:
+        text = deployed_record_text(record.kind, read(record.source_path), manifest)
+        write(record.destination_path, text, apply)
+
+    practice_adds = []
+    asset_adds = []
+    for record in added:
+        destination_path, index_entry, errors = deploy_destination_for(vault_root, record.kind, record.source_path)
+        if errors:
+            raise SystemExit("; ".join(errors))
+        if destination_path != record.destination_path:
+            raise SystemExit(f"{record.item_id}: destination changed during apply planning")
+        if record.kind == "practice":
+            practice_adds.append(index_entry)
+        elif record.kind == "asset":
+            asset_adds.append(index_entry)
+
+    if practice_adds:
+        index_path = vault_root / "indexes" / "practice_index.yaml"
+        fake_records = [
+            type("IndexRecord", (), {"kind": "practice", "index_entry": entry, "item_id": entry["id"]})()
+            for entry in practice_adds
+        ]
+        write(index_path, update_index_text(read(index_path), "practice", fake_records), apply)
+    if asset_adds:
+        index_path = vault_root / "indexes" / "asset_index.yaml"
+        fake_records = [
+            type("IndexRecord", (), {"kind": "asset", "index_entry": entry, "item_id": entry["id"]})()
+            for entry in asset_adds
+        ]
+        write(index_path, update_index_text(read(index_path), "asset", fake_records), apply)
+
+
+def apply_pack(core_root: Path, vault_root: Path, pack_root: Path, apply: bool) -> int:
+    manifest, _manifest_text, records_raw, records, payloads, errors = build_plan(core_root, vault_root, pack_root)
+    planner.print_plan(pack_root, vault_root, manifest, records, payloads, errors)
+    blockers = blocking_reasons(records, payloads, errors)
+    if blockers:
+        print("Apply refused:")
+        for reason in blockers:
+            print(f"- {reason}")
+        return 1
+    if not manifest:
+        print("Apply refused: manifest unavailable")
+        return 1
+    metadata_state = existing_pack_metadata_state(vault_root, manifest.get("pack_id", ""), planner.manifest_hash(pack_root))
+    if metadata_state == "different":
+        print("Apply refused:")
+        print("- existing pack metadata has a different manifest hash; use #101 update flow")
+        return 1
+
+    apply_records(vault_root, manifest, records, apply)
+    update_deployed_pack_index(vault_root, pack_root, manifest, records_raw, records, apply)
+    print("Apply summary:")
+    print(f"added: {sum(1 for record in records if record.outcome == 'add')}")
+    print(f"skipped: {sum(1 for record in records if record.outcome == 'skip')}")
+    print(f"stage_only: {sum(1 for record in records if record.outcome == 'stage_only')}")
+    print(f"metadata: {'written' if apply else 'would write'}")
+    if not apply:
+        print("Dry-run only. Re-run with --apply to write Vault records and pack metadata.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Apply a reviewed capability pack plan into the selected Vault.")
+    parser.add_argument("pack_root", help="Capability pack directory containing manifest.yaml.")
+    parser.add_argument("--core-root", default=str(ROOT), help="Agent Foundry Core root.")
+    parser.add_argument("--vault-root", required=True, help="Selected Agent Foundry Vault root.")
+    parser.add_argument("--apply", action="store_true", help="Write Vault records and pack metadata. Default is dry-run.")
+    args = parser.parse_args()
+    return apply_pack(
+        Path(args.core_root).expanduser().resolve(),
+        Path(args.vault_root).expanduser().resolve(),
+        Path(args.pack_root).expanduser().resolve(),
+        args.apply,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -633,6 +633,26 @@ def check_capability_pack_plan_script() -> list[str]:
     return output.splitlines()
 
 
+def check_capability_pack_apply_script() -> list[str]:
+    script = ROOT / "scripts" / "test_capability_pack_apply.py"
+    if not script.exists():
+        return ["Missing scripts/test_capability_pack_apply.py"]
+    result = subprocess.run(
+        ["python3", str(script)],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode == 0:
+        return []
+    output = (result.stdout + result.stderr).strip()
+    if not output:
+        return ["Capability pack apply fixture failed without output"]
+    return output.splitlines()
+
+
 def check_runtime_import_script() -> list[str]:
     script = ROOT / "scripts" / "test_import_runtime_assets.py"
     if not script.exists():
@@ -675,6 +695,7 @@ def main() -> int:
     errors += check_capability_pack_fixtures_script()
     errors += check_bootstrap_pack_deployment_script()
     errors += check_capability_pack_plan_script()
+    errors += check_capability_pack_apply_script()
     errors += check_runtime_import_script()
 
     if errors:

--- a/scripts/deploy_capability_pack.py
+++ b/scripts/deploy_capability_pack.py
@@ -47,6 +47,7 @@ REQUIRED_RECORD_FIELDS = {
 }
 
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
 
 
 @dataclass(frozen=True)
@@ -159,6 +160,16 @@ def yaml_string(value: str) -> str:
     return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
 
 
+def safe_segment(value: str, label: str, errors: list[str], fallback: str) -> str:
+    if not value:
+        errors.append(f"{label} missing")
+        return fallback
+    if not SAFE_SEGMENT_RE.match(value):
+        errors.append(f"{label} must be a safe single path segment: {value}")
+        return fallback
+    return value
+
+
 def destination_for(vault_root: Path, kind: str, source_path: Path) -> tuple[Path, dict[str, str], list[str]]:
     errors: list[str] = []
     if kind == "practice":
@@ -167,9 +178,7 @@ def destination_for(vault_root: Path, kind: str, source_path: Path) -> tuple[Pat
         domain = metadata.get("domain", "")
         if not item_id:
             errors.append(f"{source_path}: practice missing id")
-        if not domain:
-            errors.append(f"{source_path}: practice missing domain")
-            domain = "uncategorized"
+        domain = safe_segment(domain, f"{source_path}: practice domain", errors, "uncategorized")
         return (
             vault_root / "practices" / domain / source_path.name,
             {
@@ -186,9 +195,7 @@ def destination_for(vault_root: Path, kind: str, source_path: Path) -> tuple[Pat
         asset_type = scan_yaml_field(source_path, "asset_type") or ""
         if not item_id:
             errors.append(f"{source_path}: asset missing id")
-        if not asset_type:
-            errors.append(f"{source_path}: asset missing asset_type")
-            asset_type = "asset"
+        asset_type = safe_segment(asset_type, f"{source_path}: asset_type", errors, "asset")
         directory = {"skill": "skills", "subagent": "subagents", "automation": "automations"}.get(
             asset_type, f"{asset_type}s"
         )

--- a/scripts/plan_capability_pack.py
+++ b/scripts/plan_capability_pack.py
@@ -25,6 +25,7 @@ from deploy_capability_pack import (
     inline_list,
     list_entries,
     read,
+    safe_segment,
     section_scalars,
     sha256,
     top_level_scalars,
@@ -105,18 +106,14 @@ def destination_for(vault_root: Path, kind: str, source_path: Path) -> tuple[Pat
         domain = metadata.get("domain", "")
         if not item_id:
             errors.append(f"{source_path}: practice missing id")
-        if not domain:
-            errors.append(f"{source_path}: practice missing domain")
-            domain = "uncategorized"
+        domain = safe_segment(domain, f"{source_path}: practice domain", errors, "uncategorized")
         return vault_root / "practices" / domain / source_path.name, errors
     if kind == "asset":
         item_id = scan_yaml_field(source_path, "id") or ""
         asset_type = scan_yaml_field(source_path, "asset_type") or ""
         if not item_id:
             errors.append(f"{source_path}: asset missing id")
-        if not asset_type:
-            errors.append(f"{source_path}: asset missing asset_type")
-            asset_type = "asset"
+        asset_type = safe_segment(asset_type, f"{source_path}: asset_type", errors, "asset")
         directory = {"skill": "skills", "subagent": "subagents", "automation": "automations"}.get(
             asset_type, f"{asset_type}s"
         )

--- a/scripts/test_capability_pack_apply.py
+++ b/scripts/test_capability_pack_apply.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Regression tests for reviewed capability pack apply behavior."""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APPLY = ROOT / "scripts" / "apply_capability_pack.py"
+DEPLOY = ROOT / "scripts" / "deploy_capability_pack.py"
+INIT = ROOT / "scripts" / "init_vault.py"
+BOOTSTRAP_PACK = ROOT / "fixtures" / "capability-packs" / "bootstrap-minimal"
+OPTIONAL_PACK = ROOT / "fixtures" / "capability-packs" / "optional-multi-agent"
+
+
+def run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, *args],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def expect(name: str, result: subprocess.CompletedProcess[str], should_pass: bool, expected_text: str = "") -> list[str]:
+    output = result.stdout + result.stderr
+    if (result.returncode == 0) == should_pass and (not expected_text or expected_text in output):
+        print(f"{name}: ok")
+        return []
+    return [
+        f"{name}: expected {'pass' if should_pass else 'failure'}"
+        + (f" containing {expected_text!r}" if expected_text else "")
+        + f", got exit {result.returncode}\n{output.strip()}"
+    ]
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def practice_text(item_id: str, domain: str = "meta") -> str:
+    return "\n".join(
+        [
+            "---",
+            f'id: "{item_id}"',
+            f'title: "{item_id}"',
+            f'domain: "{domain}"',
+            'status: "candidate"',
+            "---",
+            "",
+            "Apply fixture practice.",
+            "",
+        ]
+    )
+
+
+def write_apply_pack(
+    base: Path,
+    name: str = "apply-pack",
+    pack_id: str = "pack.probe.apply",
+    item_id: str = "APPLY-001",
+    domain: str = "meta",
+) -> Path:
+    pack = base / name
+    record = pack / "records" / f"{item_id}.md"
+    record.parent.mkdir(parents=True, exist_ok=True)
+    record.write_text(practice_text(item_id, domain=domain), encoding="utf-8")
+    (pack / "manifest.yaml").write_text(
+        "\n".join(
+            [
+                "manifest_schema_version: 1",
+                f"pack_id: {pack_id}",
+                "title: Apply Probe Pack",
+                "description: Probe pack for apply regression tests.",
+                "lifecycle_status: reviewed",
+                "version: 0.1.0",
+                "exported_at: 2026-06-12",
+                "distribution_type: optional_capability",
+                "source_provenance: test fixture",
+                "maintainer_contact: test",
+                "license: test",
+                "sensitivity: public",
+                "review_state: reviewed",
+                "",
+                "compatibility:",
+                "  core_schema_version_min: 1",
+                "  core_schema_version_max: 1",
+                "  vault_layout_versions: [1]",
+                "  requires_bootstrap_pack: false",
+                "",
+                "included_records:",
+                f"  - id: {item_id}",
+                "    kind: practice",
+                "    lifecycle_status: candidate",
+                f"    path: records/{item_id}.md",
+                "    source_version: 1",
+                f"    content_sha256: \"{sha256(record)}\"",
+                "    destination_layer: canonical_vault_record",
+                "    membership_role: optional_member",
+                "    activation_default: manual_review",
+                "    import_action: create_or_review_update",
+                "",
+                "executable_payloads: []",
+                "",
+                "conflict_policy:",
+                "  id_collision: fail_closed",
+                "  same_version_hash_mismatch: fail_closed",
+                "  newer_version_update: reviewed_diff_required",
+                "  local_edit_behavior: preserve_vault_and_propose_merge",
+                "  rollback_notes: test",
+                "",
+                "integrity:",
+                "  digest_algorithm: sha256",
+                "  manifest_paths_are_relative: true",
+                "  private_vault_content: excluded",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return pack
+
+
+def write_conflicting_metadata(vault: Path) -> None:
+    packs = vault / "packs"
+    packs.mkdir(parents=True, exist_ok=True)
+    (packs / "deployed-pack-index.yaml").write_text(
+        "\n".join(
+            [
+                "schema_version: 1",
+                "updated: 2026-06-12",
+                "deployed_packs:",
+                "  - pack_id: pack.probe.apply",
+                "    version: \"0.1.0\"",
+                "    source:",
+                f"      manifest_sha256: {'0' * 64}",
+                "    records: []",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def init_blank(vault_root: Path) -> subprocess.CompletedProcess[str]:
+    return run([str(INIT), str(vault_root), "--core-root", str(ROOT), "--apply"])
+
+
+def deploy_bootstrap(vault_root: Path) -> subprocess.CompletedProcess[str]:
+    return run(
+        [
+            str(DEPLOY),
+            str(BOOTSTRAP_PACK),
+            "--core-root",
+            str(ROOT),
+            "--vault-root",
+            str(vault_root),
+            "--apply",
+        ]
+    )
+
+
+def apply_pack(pack_root: Path, vault_root: Path, apply: bool) -> subprocess.CompletedProcess[str]:
+    args = [str(APPLY), str(pack_root), "--core-root", str(ROOT), "--vault-root", str(vault_root)]
+    if apply:
+        args.append("--apply")
+    return run(args)
+
+
+def main() -> int:
+    errors: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="agent-foundry-pack-apply-") as tmp:
+        base = Path(tmp)
+        vault = base / "vault"
+        pack = write_apply_pack(base)
+
+        errors.extend(expect("init-blank-vault", init_blank(vault), True, "Blank Vault initialized and validated."))
+
+        dry_run = apply_pack(pack, vault, apply=False)
+        errors.extend(expect("apply-dry-run", dry_run, True, "Dry-run only"))
+        if (vault / "practices" / "meta" / "APPLY-001.md").exists():
+            errors.append("apply-dry-run: practice record was written")
+        if (vault / "packs" / "deployed-pack-index.yaml").exists():
+            errors.append("apply-dry-run: deployed pack metadata was written")
+
+        applied = apply_pack(pack, vault, apply=True)
+        errors.extend(expect("apply-writes-records", applied, True, "metadata: written"))
+        practice_path = vault / "practices" / "meta" / "APPLY-001.md"
+        metadata_path = vault / "packs" / "deployed-pack-index.yaml"
+        if not practice_path.exists():
+            errors.append("apply-writes-records: practice record missing")
+        if "APPLY-001" not in (vault / "indexes" / "practice_index.yaml").read_text(encoding="utf-8"):
+            errors.append("apply-writes-records: practice index missing APPLY-001")
+        if not metadata_path.exists() or "pack.probe.apply" not in metadata_path.read_text(encoding="utf-8"):
+            errors.append("apply-writes-records: pack metadata missing")
+
+        reapplied = apply_pack(pack, vault, apply=True)
+        errors.extend(expect("apply-idempotent-same-metadata", reapplied, True, "pack metadata already present"))
+
+        conflict_vault = base / "conflict-vault"
+        errors.extend(
+            expect("init-conflict-vault", init_blank(conflict_vault), True, "Blank Vault initialized and validated.")
+        )
+        write_conflicting_metadata(conflict_vault)
+        conflict = apply_pack(pack, conflict_vault, apply=True)
+        errors.extend(expect("apply-refuses-metadata-conflict", conflict, False, "different manifest_sha256"))
+        if (conflict_vault / "practices" / "meta" / "APPLY-001.md").exists():
+            errors.append("apply-refuses-metadata-conflict: practice was written before metadata refusal")
+
+        unsafe_vault = base / "unsafe-vault"
+        unsafe_pack = write_apply_pack(
+            base,
+            name="unsafe-domain-pack",
+            pack_id="pack.probe.unsafe-domain",
+            item_id="UNSAFE-APPLY-001",
+            domain="../outside",
+        )
+        errors.extend(expect("init-unsafe-vault", init_blank(unsafe_vault), True, "Blank Vault initialized and validated."))
+        unsafe = apply_pack(unsafe_pack, unsafe_vault, apply=True)
+        errors.extend(expect("apply-refuses-unsafe-domain", unsafe, False, "safe single path segment"))
+        if any(path.name == "UNSAFE-APPLY-001.md" for path in unsafe_vault.rglob("*")):
+            errors.append("apply-refuses-unsafe-domain: unsafe destination was written")
+
+        errors.extend(expect("deploy-bootstrap", deploy_bootstrap(vault), True, "selected Vault validated"))
+        blocked = apply_pack(OPTIONAL_PACK, vault, apply=True)
+        errors.extend(expect("apply-refuses-executable-block", blocked, False, "blocking payload outcome"))
+
+    if errors:
+        print("Capability pack apply test failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("Capability pack apply test passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_capability_pack_plan.py
+++ b/scripts/test_capability_pack_plan.py
@@ -45,17 +45,29 @@ def sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def practice_text(item_id: str, filename: str = "") -> str:
+def practice_text(item_id: str, filename: str = "", domain: str = "meta") -> str:
     return "\n".join(
         [
             "---",
             f'id: "{item_id}"',
             f'title: "{filename or item_id}"',
-            'domain: "meta"',
+            f'domain: "{domain}"',
             'status: "candidate"',
             "---",
             "",
             "Fixture practice.",
+            "",
+        ]
+    )
+
+
+def asset_text(item_id: str, asset_type: str = "skill") -> str:
+    return "\n".join(
+        [
+            f"id: {item_id}",
+            f"title: {item_id}",
+            "status: candidate",
+            f"asset_type: {asset_type}",
             "",
         ]
     )
@@ -101,10 +113,11 @@ def write_probe_pack(
     if include_source_provenance:
         lines.insert(8, "source_provenance: test fixture")
     for record in records:
+        kind = record.get("kind", "practice")
         lines.extend(
             [
                 f"  - id: {record['id']}",
-                "    kind: practice",
+                f"    kind: {kind}",
                 "    lifecycle_status: candidate",
             ]
         )
@@ -428,6 +441,35 @@ def main() -> int:
                 "pack does not support Core schema version",
             )
         )
+
+        unsafe_domain_file = base / "unsafe-domain" / "records" / "UNSAFE.md"
+        unsafe_domain_file.parent.mkdir(parents=True, exist_ok=True)
+        unsafe_domain_file.write_text(practice_text("UNSAFE-DOMAIN-001", domain="../outside"), encoding="utf-8")
+        unsafe_domain_pack = write_probe_pack(
+            base,
+            "unsafe-domain",
+            [{"id": "UNSAFE-DOMAIN-001", "path": "records/UNSAFE.md", "sha": sha256(unsafe_domain_file)}],
+        )
+        unsafe_domain = plan_pack(unsafe_domain_pack, vault)
+        errors.extend(expect("plan-unsafe-domain-fails-closed", unsafe_domain, False, "safe single path segment"))
+
+        unsafe_asset_file = base / "unsafe-asset-type" / "records" / "UNSAFE.asset.yaml"
+        unsafe_asset_file.parent.mkdir(parents=True, exist_ok=True)
+        unsafe_asset_file.write_text(asset_text("UNSAFE-ASSET-001", asset_type="../outside"), encoding="utf-8")
+        unsafe_asset_pack = write_probe_pack(
+            base,
+            "unsafe-asset-type",
+            [
+                {
+                    "id": "UNSAFE-ASSET-001",
+                    "kind": "asset",
+                    "path": "records/UNSAFE.asset.yaml",
+                    "sha": sha256(unsafe_asset_file),
+                }
+            ],
+        )
+        unsafe_asset_type = plan_pack(unsafe_asset_pack, vault)
+        errors.extend(expect("plan-unsafe-asset-type-fails-closed", unsafe_asset_type, False, "safe single path segment"))
 
     if errors:
         print("Capability pack plan test failed:")


### PR DESCRIPTION
## Summary

- Adds `scripts/apply_capability_pack.py` for reviewed capability pack apply into the selected Vault.
- Reuses #106 plan/check and refuses apply when the plan has validation errors, `fail`, `merge_required`, `update`, or blocked executable payload outcomes.
- Writes canonical Vault records, indexes, and `packs/deployed-pack-index.yaml` only with explicit `--apply`; dry-run writes nothing.
- Adds `scripts/test_capability_pack_apply.py` and wires it into `scripts/check_consistency.py`.

## Verification

- `python3 scripts/check_capability_pack_fixtures.py`
- `python3 scripts/test_capability_pack_plan.py`
- `python3 scripts/test_capability_pack_apply.py`
- `python3 scripts/check_consistency.py`
- `git diff --check`

## Boundaries

No runtime install, generated output mutation, executable helper install/execution, update merge, or disable/rollback behavior is included. #101 owns update comparison/merge; #104 owns disable/rollback.