### PR TITLE
Add capability pack update comparison

### DIFF
--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -653,6 +653,26 @@ def check_capability_pack_apply_script() -> list[str]:
     return output.splitlines()
 
 
+def check_capability_pack_update_script() -> list[str]:
+    script = ROOT / "scripts" / "test_capability_pack_update.py"
+    if not script.exists():
+        return ["Missing scripts/test_capability_pack_update.py"]
+    result = subprocess.run(
+        ["python3", str(script)],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode == 0:
+        return []
+    output = (result.stdout + result.stderr).strip()
+    if not output:
+        return ["Capability pack update fixture failed without output"]
+    return output.splitlines()
+
+
 def check_runtime_import_script() -> list[str]:
     script = ROOT / "scripts" / "test_import_runtime_assets.py"
     if not script.exists():
@@ -696,6 +716,7 @@ def main() -> int:
     errors += check_bootstrap_pack_deployment_script()
     errors += check_capability_pack_plan_script()
     errors += check_capability_pack_apply_script()
+    errors += check_capability_pack_update_script()
     errors += check_runtime_import_script()
 
     if errors:

--- a/scripts/compare_capability_pack_update.py
+++ b/scripts/compare_capability_pack_update.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Compare an available capability pack snapshot with selected Vault state."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import plan_capability_pack as planner
+from foundry_config import ROOT
+
+
+def pack_block(vault_root: Path, pack_id: str) -> str:
+    path = vault_root / "packs" / "deployed-pack-index.yaml"
+    if not path.exists():
+        return ""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    capture = False
+    captured: list[str] = []
+    for line in lines:
+        if line.startswith("  - pack_id:"):
+            if capture:
+                break
+            capture = line.split(":", 1)[1].strip().strip('"') == pack_id
+        if capture:
+            captured.append(line)
+    return "\n".join(captured)
+
+
+def block_scalar(block: str, key: str) -> str:
+    match = re.search(rf"^\s+{re.escape(key)}:\s*\"?([^\"\n]+)\"?", block, re.MULTILINE)
+    return match.group(1).strip() if match else ""
+
+
+def compare_versions(current: str, available: str) -> str:
+    def parts(value: str) -> tuple[int, ...]:
+        raw = value.split("-", 1)[0]
+        parsed: list[int] = []
+        for part in raw.split("."):
+            try:
+                parsed.append(int(part))
+            except ValueError:
+                parsed.append(0)
+        return tuple(parsed)
+
+    current_parts = parts(current)
+    available_parts = parts(available)
+    if available_parts > current_parts:
+        return "newer"
+    if available_parts == current_parts:
+        return "same"
+    return "older"
+
+
+def compare(core_root: Path, vault_root: Path, pack_root: Path) -> int:
+    root_errors = planner.validate(core_root, vault_root)
+    manifest, manifest_errors, manifest_text = planner.validate_manifest(core_root, vault_root, pack_root)
+    records_raw, record_errors = planner.validate_records(pack_root, manifest_text) if manifest_text else ([], [])
+    payloads, payload_errors = planner.validate_payloads(pack_root, manifest_text) if manifest_text else ([], [])
+    records, planning_errors = planner.plan_records(vault_root, pack_root, manifest, records_raw) if manifest else ([], [])
+    errors = root_errors + manifest_errors + record_errors + payload_errors + planning_errors
+
+    print("Capability pack update comparison")
+    print(f"pack_root: {pack_root}")
+    print(f"vault_root: {vault_root}")
+    if manifest:
+        print(f"pack_id: {manifest.get('pack_id', '')}")
+        print(f"available_version: {manifest.get('version', '')}")
+        print(f"available_manifest_sha256: {planner.manifest_hash(pack_root)}")
+
+    if errors:
+        print("status: failed")
+        for error in errors:
+            print(f"- {error}")
+        print("writes: none")
+        return 1
+
+    block = pack_block(vault_root, manifest.get("pack_id", ""))
+    if not block:
+        print("status: not_deployed")
+        print("detail: use optional pack apply before update comparison")
+        print("writes: none")
+        return 1
+
+    current_version = block_scalar(block, "version")
+    current_manifest_sha = block_scalar(block, "manifest_sha256")
+    available_manifest_sha = planner.manifest_hash(pack_root)
+    relation = compare_versions(current_version, manifest.get("version", ""))
+    print(f"current_version: {current_version}")
+    print(f"current_manifest_sha256: {current_manifest_sha}")
+    print(f"version_relation: {relation}")
+
+    if relation == "same" and current_manifest_sha == available_manifest_sha:
+        print("status: unchanged")
+        print("writes: none")
+        return 0
+    if relation == "same" and current_manifest_sha != available_manifest_sha:
+        print("status: failed")
+        print("detail: same pack id and version has different manifest_sha256")
+        print("writes: none")
+        return 1
+    if relation == "older":
+        print("status: failed")
+        print("detail: available pack version is older than deployed version; downgrade is unsupported")
+        print("writes: none")
+        return 1
+
+    counts: dict[str, int] = {
+        "clean_update": 0,
+        "merge_required": 0,
+        "add": 0,
+        "skip": 0,
+        "stage_only": 0,
+        "fail": 0,
+        "blocked_executable_install": 0,
+    }
+    print("records:")
+    for record in records:
+        if record.outcome == "update":
+            outcome = "clean_update"
+        else:
+            outcome = record.outcome
+        counts[outcome] = counts.get(outcome, 0) + 1
+        print(f"- {record.item_id} {outcome}: {record.detail}")
+    print("executable_payloads:")
+    if not payloads:
+        print("- none")
+    for payload in payloads:
+        counts[payload.outcome] = counts.get(payload.outcome, 0) + 1
+        print(f"- {payload.payload_id} {payload.outcome}: {payload.detail}")
+    print("summary:")
+    for key in [
+        "clean_update",
+        "merge_required",
+        "add",
+        "skip",
+        "stage_only",
+        "fail",
+        "blocked_executable_install",
+    ]:
+        print(f"{key}: {counts.get(key, 0)}")
+    if counts.get("fail", 0):
+        print("status: failed")
+        print("writes: none")
+        return 1
+    if counts.get("blocked_executable_install", 0):
+        print("status: blocked_executable_install")
+        print("writes: none")
+        return 1
+    if counts.get("merge_required", 0):
+        print("status: merge_required")
+    elif counts.get("clean_update", 0) or counts.get("add", 0):
+        print("status: clean_update_available")
+    else:
+        print("status: review_only")
+    print("writes: none")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Compare an available capability pack snapshot with selected Vault state.")
+    parser.add_argument("pack_root", help="Capability pack directory containing manifest.yaml.")
+    parser.add_argument("--core-root", default=str(ROOT), help="Agent Foundry Core root.")
+    parser.add_argument("--vault-root", required=True, help="Selected Agent Foundry Vault root.")
+    args = parser.parse_args()
+    return compare(
+        Path(args.core_root).expanduser().resolve(),
+        Path(args.vault_root).expanduser().resolve(),
+        Path(args.pack_root).expanduser().resolve(),
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_capability_pack_update.py
+++ b/scripts/test_capability_pack_update.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Regression tests for capability pack update comparison."""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APPLY = ROOT / "scripts" / "apply_capability_pack.py"
+COMPARE = ROOT / "scripts" / "compare_capability_pack_update.py"
+INIT = ROOT / "scripts" / "init_vault.py"
+
+
+def run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, *args],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def expect(name: str, result: subprocess.CompletedProcess[str], should_pass: bool, expected_text: str = "") -> list[str]:
+    output = result.stdout + result.stderr
+    if (result.returncode == 0) == should_pass and (not expected_text or expected_text in output):
+        print(f"{name}: ok")
+        return []
+    return [
+        f"{name}: expected {'pass' if should_pass else 'failure'}"
+        + (f" containing {expected_text!r}" if expected_text else "")
+        + f", got exit {result.returncode}\n{output.strip()}"
+    ]
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def practice_text(item_id: str, body: str) -> str:
+    return "\n".join(
+        [
+            "---",
+            f'id: "{item_id}"',
+            f'title: "{item_id}"',
+            'domain: "meta"',
+            'status: "candidate"',
+            "---",
+            "",
+            body,
+            "",
+        ]
+    )
+
+
+def write_pack(
+    base: Path,
+    name: str,
+    version: str,
+    body: str,
+    *,
+    include_source_provenance: bool = True,
+    schema_version: str = "1",
+    core_min: str = "1",
+    core_max: str = "1",
+    include_payload: bool = False,
+) -> Path:
+    pack = base / name
+    record = pack / "records" / "UPDATE-001.md"
+    record.parent.mkdir(parents=True, exist_ok=True)
+    record.write_text(practice_text("UPDATE-001", body), encoding="utf-8")
+    payload = pack / "payloads" / "helper.py"
+    if include_payload:
+        payload.parent.mkdir(parents=True, exist_ok=True)
+        payload.write_text("print('do not execute')\n", encoding="utf-8")
+    lines = [
+        f"manifest_schema_version: {schema_version}",
+        "pack_id: pack.probe.update",
+        "title: Update Probe Pack",
+        "description: Probe pack for update comparison tests.",
+        "lifecycle_status: reviewed",
+        f"version: {version}",
+        "exported_at: 2026-06-12",
+        "distribution_type: optional_capability",
+        "maintainer_contact: test",
+        "license: test",
+        "sensitivity: public",
+        "review_state: reviewed",
+        "",
+        "compatibility:",
+        f"  core_schema_version_min: {core_min}",
+        f"  core_schema_version_max: {core_max}",
+        "  vault_layout_versions: [1]",
+        "  requires_bootstrap_pack: false",
+        "",
+        "included_records:",
+        "  - id: UPDATE-001",
+        "    kind: practice",
+        "    lifecycle_status: candidate",
+        "    path: records/UPDATE-001.md",
+        "    source_version: 1",
+        f"    content_sha256: \"{sha256(record)}\"",
+        "    destination_layer: canonical_vault_record",
+        "    membership_role: optional_member",
+        "    activation_default: manual_review",
+        "    import_action: create_or_review_update",
+        "",
+        "executable_payloads:",
+    ]
+    if include_source_provenance:
+        lines.insert(8, "source_provenance: test fixture")
+    if include_payload:
+        lines.extend(
+            [
+                "  - id: helper.update",
+                "    title: Update Helper",
+                "    lifecycle_status: candidate",
+                "    path: payloads/helper.py",
+                f"    source_sha256: \"{sha256(payload)}\"",
+                "    interpreter: python3",
+                "    execute_from_pack: false",
+                "    install_boundary: managed_runtime_copy_required",
+                "    permissions: [filesystem-read]",
+                "    dependencies: []",
+                "    runtime_impact: test",
+            ]
+        )
+    else:
+        lines[-1] = "executable_payloads: []"
+    lines.extend(
+        [
+            "",
+            "conflict_policy:",
+            "  id_collision: fail_closed",
+            "  same_version_hash_mismatch: fail_closed",
+            "  newer_version_update: reviewed_diff_required",
+            "  local_edit_behavior: preserve_vault_and_propose_merge",
+            "  rollback_notes: test",
+            "",
+            "integrity:",
+            "  digest_algorithm: sha256",
+            "  manifest_paths_are_relative: true",
+            "  private_vault_content: excluded",
+            "",
+        ]
+    )
+    (pack / "manifest.yaml").write_text("\n".join(lines), encoding="utf-8")
+    return pack
+
+
+def init_blank(vault_root: Path) -> subprocess.CompletedProcess[str]:
+    return run([str(INIT), str(vault_root), "--core-root", str(ROOT), "--apply"])
+
+
+def apply_pack(pack_root: Path, vault_root: Path) -> subprocess.CompletedProcess[str]:
+    return run([str(APPLY), str(pack_root), "--core-root", str(ROOT), "--vault-root", str(vault_root), "--apply"])
+
+
+def compare_pack(pack_root: Path, vault_root: Path) -> subprocess.CompletedProcess[str]:
+    return run([str(COMPARE), str(pack_root), "--core-root", str(ROOT), "--vault-root", str(vault_root)])
+
+
+def main() -> int:
+    errors: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="agent-foundry-pack-update-") as tmp:
+        base = Path(tmp)
+        vault = base / "vault"
+        v1 = write_pack(base, "pack-v1", "0.1.0", "Version one.")
+        v1_same_version_changed = write_pack(base, "pack-v1-changed", "0.1.0", "Version one changed.")
+        v2 = write_pack(base, "pack-v2", "0.2.0", "Version two.")
+        v2_payload = write_pack(base, "pack-v2-payload", "0.2.0", "Version two.", include_payload=True)
+        missing_provenance = write_pack(
+            base,
+            "pack-missing-provenance",
+            "0.2.0",
+            "Version two.",
+            include_source_provenance=False,
+        )
+        incompatible = write_pack(base, "pack-incompatible", "0.2.0", "Version two.", schema_version="999")
+        incompatible_core = write_pack(base, "pack-incompatible-core", "0.2.0", "Version two.", core_min="2", core_max="3")
+
+        errors.extend(expect("init-blank-vault", init_blank(vault), True, "Blank Vault initialized and validated."))
+        errors.extend(expect("apply-v1", apply_pack(v1, vault), True, "metadata: written"))
+        errors.extend(expect("compare-unchanged", compare_pack(v1, vault), True, "status: unchanged"))
+        errors.extend(expect("compare-same-version-mismatch", compare_pack(v1_same_version_changed, vault), False, "same pack id and version"))
+        errors.extend(expect("compare-clean-update", compare_pack(v2, vault), True, "status: clean_update_available"))
+        errors.extend(expect("compare-clean-update-count", compare_pack(v2, vault), True, "clean_update: 1"))
+
+        target = vault / "practices" / "meta" / "UPDATE-001.md"
+        target.write_text(target.read_text(encoding="utf-8") + "\nLocal edit.\n", encoding="utf-8")
+        errors.extend(expect("compare-local-edit-merge", compare_pack(v2, vault), True, "status: merge_required"))
+        errors.extend(expect("compare-local-edit-count", compare_pack(v2, vault), True, "merge_required: 1"))
+
+        errors.extend(expect("compare-missing-provenance", compare_pack(missing_provenance, vault), False, "source_provenance"))
+        errors.extend(expect("compare-incompatible-schema", compare_pack(incompatible, vault), False, "manifest_schema_version"))
+        errors.extend(expect("compare-incompatible-core", compare_pack(incompatible_core, vault), False, "Core schema version"))
+        errors.extend(expect("compare-blocked-payload", compare_pack(v2_payload, vault), False, "blocked_executable_install: 1"))
+        errors.extend(
+            expect(
+                "compare-blocked-payload-status",
+                compare_pack(v2_payload, vault),
+                False,
+                "status: blocked_executable_install",
+            )
+        )
+
+    if errors:
+        print("Capability pack update test failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("Capability pack update test passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds `scripts/compare_capability_pack_update.py`, a read-only update comparison command for deployed packs and available snapshots.
- Distinguishes unchanged, clean update available, local-edit merge required, same-version manifest mismatch, missing provenance, incompatible schema/core range, not deployed, downgrade unsupported, and blocked executable payload states.
- Adds `scripts/test_capability_pack_update.py` and wires it into `scripts/check_consistency.py`.

## Verification

- `python3 scripts/check_capability_pack_fixtures.py`
- `python3 scripts/test_capability_pack_plan.py`
- `python3 scripts/test_capability_pack_apply.py`
- `python3 scripts/test_capability_pack_update.py`
- `python3 scripts/check_consistency.py`
- `git diff --check`

## Boundaries

This PR is read-only comparison/report behavior. It does not apply updates, merge local edits, mutate the selected Vault, write generated outputs, install runtimes, or execute helper payloads.