### PR TITLE
Improve install status reporting

### DIFF
--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -673,6 +673,26 @@ def check_capability_pack_update_script() -> list[str]:
     return output.splitlines()
 
 
+def check_sync_status_report_script() -> list[str]:
+    script = ROOT / "scripts" / "test_sync_status_report.py"
+    if not script.exists():
+        return ["Missing scripts/test_sync_status_report.py"]
+    result = subprocess.run(
+        ["python3", str(script)],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode == 0:
+        return []
+    output = (result.stdout + result.stderr).strip()
+    if not output:
+        return ["Sync status report fixture failed without output"]
+    return output.splitlines()
+
+
 def check_runtime_import_script() -> list[str]:
     script = ROOT / "scripts" / "test_import_runtime_assets.py"
     if not script.exists():
@@ -717,6 +737,7 @@ def main() -> int:
     errors += check_capability_pack_plan_script()
     errors += check_capability_pack_apply_script()
     errors += check_capability_pack_update_script()
+    errors += check_sync_status_report_script()
     errors += check_runtime_import_script()
 
     if errors:

--- a/scripts/sync_status.py
+++ b/scripts/sync_status.py
@@ -14,6 +14,7 @@ from operation_context import text_report, build_context
 
 
 ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_GENERATED_ROOT = Path.home() / ".agent-foundry" / "generated" / "agent-foundry-adapters"
 
 
 def run_git(args: list[str]) -> str:
@@ -148,7 +149,47 @@ def locator_mode() -> tuple[str, str]:
     )
 
 
-def deployed_packs(vault_root: Path) -> list[str]:
+def parse_deployed_pack_index(path: Path) -> list[dict[str, str]]:
+    packs: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    in_packs = False
+    in_source = False
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line == "deployed_packs:":
+            in_packs = True
+            continue
+        if not in_packs:
+            continue
+        stripped = line.strip()
+        if line.startswith("  - "):
+            if current:
+                packs.append(current)
+            current = {}
+            in_source = False
+            rest = stripped[2:]
+            if ":" in rest:
+                key, value = rest.split(":", 1)
+                current[key.strip()] = value.strip().strip('"')
+            continue
+        if current is None:
+            continue
+        if line.startswith("    ") and not line.startswith("      ") and stripped.endswith(":"):
+            in_source = stripped.removesuffix(":") == "source"
+            continue
+        if ":" not in stripped:
+            continue
+        key, value = stripped.split(":", 1)
+        if in_source and line.startswith("      "):
+            current[f"source.{key.strip()}"] = value.strip().strip('"')
+        elif line.startswith("    ") and not line.startswith("      "):
+            current[key.strip()] = value.strip().strip('"')
+            in_source = False
+    if current:
+        packs.append(current)
+    return packs
+
+
+def legacy_pack_scan(vault_root: Path) -> list[str]:
     packs: set[str] = set()
     for base in [vault_root / "practices", vault_root / "assets"]:
         if not base.exists():
@@ -160,6 +201,32 @@ def deployed_packs(vault_root: Path) -> list[str]:
     return sorted(packs)
 
 
+def deployed_packs(vault_root: Path) -> list[str]:
+    index = vault_root / "packs" / "deployed-pack-index.yaml"
+    if index.exists():
+        packs = []
+        for entry in parse_deployed_pack_index(index):
+            pack_id = entry.get("pack_id", "")
+            if not pack_id:
+                continue
+            version = entry.get("version", "")
+            status = entry.get("lifecycle_status", "")
+            distribution = entry.get("distribution_type", "")
+            source = entry.get("source.kind", "")
+            suffix = []
+            if version:
+                suffix.append(f"version={version}")
+            if status:
+                suffix.append(f"status={status}")
+            if distribution:
+                suffix.append(f"type={distribution}")
+            if source:
+                suffix.append(f"source={source}")
+            packs.append(f"{pack_id} ({', '.join(suffix)})" if suffix else pack_id)
+        return packs
+    return legacy_pack_scan(vault_root)
+
+
 def generated_output_status(adapter_root: Path) -> tuple[str, int]:
     manifest = adapter_root / "adapter-publish-manifest.yaml"
     if not adapter_root.exists():
@@ -168,6 +235,18 @@ def generated_output_status(adapter_root: Path) -> tuple[str, int]:
     if not manifest.exists():
         return "missing-manifest", len(files)
     return "ready", len(files)
+
+
+def default_adapter_root(core_root: Path, vault_root: Path, receipt_path: Path) -> Path:
+    if core_root != vault_root:
+        receipt = read_receipt(receipt_path)
+        if isinstance(receipt, dict):
+            receipt_root = str(receipt.get("adapter_root", ""))
+            if receipt_root:
+                return Path(receipt_root).expanduser().resolve()
+        if DEFAULT_GENERATED_ROOT.exists():
+            return DEFAULT_GENERATED_ROOT.resolve()
+    return core_root / "adapters"
 
 
 def receipt_summary(receipt_path: Path) -> list[str]:
@@ -191,6 +270,29 @@ def receipt_summary(receipt_path: Path) -> list[str]:
     return lines
 
 
+def next_safe_actions(
+    core_root: Path,
+    vault_root: Path,
+    adapter_root: Path,
+    receipt_path: Path,
+    output_state: str,
+) -> list[str]:
+    actions: list[str] = ["status-only: no files were written by this report"]
+    config_errors = validate_config(CONFIG_PATH) if CONFIG_PATH.exists() else [f"locator missing: {CONFIG_PATH}"]
+    if config_errors:
+        actions.append("repair locator/root configuration before any publish, install, or pack apply")
+    if not core_root.exists():
+        actions.append("fix core_root before running Core maintenance commands")
+    if not vault_root.exists():
+        actions.append("select or initialize a Vault before harvesting, refreshing, or applying packs")
+    if output_state != "ready":
+        actions.append("regenerate selected Vault adapter output before runtime install or refresh")
+    if read_receipt(receipt_path) is None:
+        actions.append("run runtime install only after generated output dry-run/review; receipt is currently missing")
+    actions.append("treat ChatGPT as manual import unless a future managed target is explicitly implemented")
+    return actions
+
+
 def setup_report(core_root: Path, vault_root: Path, adapter_root: Path, receipt_path: Path = RECEIPT_PATH) -> str:
     manifest_path = ROOT / "runtime" / "local" / "runtime_manifest.yaml"
     targets = parse_runtime_manifest(manifest_path.read_text(encoding="utf-8")) if manifest_path.exists() else {}
@@ -203,6 +305,9 @@ def setup_report(core_root: Path, vault_root: Path, adapter_root: Path, receipt_
         f"core_root: {core_root}",
         f"vault_root: {vault_root}",
         f"deployed_pack: {', '.join(packs) if packs else 'none detected'}",
+        "deployed_packs:",
+        *(f"- {pack}" for pack in packs),
+        *(["- none detected"] if not packs else []),
         f"generated_output: {output_state} path={adapter_root} files={output_count}",
         "runtime targets:",
     ]
@@ -221,6 +326,8 @@ def setup_report(core_root: Path, vault_root: Path, adapter_root: Path, receipt_
     lines.extend(receipt_summary(receipt_path))
     lines.append("first_usable_command: python3 scripts/sync_status.py")
     lines.append("chatgpt_manual_import: explicit; import generated ChatGPT files manually when desired")
+    lines.append("next_safe_actions:")
+    lines.extend(f"- {action}" for action in next_safe_actions(core_root, vault_root, adapter_root, receipt_path, output_state))
     return "\n".join(lines)
 
 
@@ -302,8 +409,12 @@ def main() -> int:
     config = parse_config(CONFIG_PATH)
     core_root = Path(args.core_root or str(config.get("core_root", "") or ROOT)).expanduser().resolve()
     vault_root = Path(args.vault_root or str(config.get("vault_root", "") or core_root)).expanduser().resolve()
-    adapter_root = Path(args.adapter_root).expanduser().resolve() if args.adapter_root else core_root / "adapters"
     receipt_path = Path(args.receipt_path).expanduser().resolve() if args.receipt_path else RECEIPT_PATH
+    adapter_root = (
+        Path(args.adapter_root).expanduser().resolve()
+        if args.adapter_root
+        else default_adapter_root(core_root, vault_root, receipt_path)
+    )
 
     print(setup_report(core_root, vault_root, adapter_root, receipt_path))
     print(f"root: {ROOT}")

--- a/scripts/sync_status.py
+++ b/scripts/sync_status.py
@@ -82,21 +82,28 @@ def parse_runtime_manifest(text: str) -> dict[str, dict[str, str]]:
 
 
 def runtime_manifest_text() -> str:
-    script = ROOT / "scripts" / "runtime_manifest.py"
-    result = subprocess.run(
-        ["python3", str(script), "status"],
-        cwd=ROOT,
-        check=False,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    return result.stdout.strip() or result.stderr.strip() or "none"
+    local_manifest = ROOT / "runtime" / "local" / "runtime_manifest.yaml"
+    template_manifest = ROOT / "runtime" / "templates" / "runtime_manifest.template.yaml"
+    manifest = local_manifest if local_manifest.exists() else template_manifest
+    if not manifest.exists():
+        return f"runtime manifest missing: {local_manifest}; template missing: {template_manifest}"
+    targets = parse_runtime_manifest(manifest.read_text(encoding="utf-8"))
+    lines = [
+        f"local_manifest: {local_manifest}",
+        f"template_manifest: {template_manifest}",
+        f"manifest_source: {'local' if local_manifest.exists() else 'template-read-only'}",
+    ]
+    for name, config in targets.items():
+        path = config.get("install_path", "")
+        exists = "yes" if path and Path(path).expanduser().exists() else "no"
+        lines.append(
+            f"{name}: status={config.get('status', '')} path={path or '<manual>'} "
+            f"exists={exists} ownership={config.get('ownership_mode', '')}"
+        )
+    return "\n".join(lines)
 
 
 def runtime_status() -> str:
-    if not (ROOT / "scripts" / "runtime_manifest.py").exists():
-        return "runtime manifest tooling unavailable"
     return runtime_manifest_text()
 
 
@@ -244,8 +251,7 @@ def default_adapter_root(core_root: Path, vault_root: Path, receipt_path: Path) 
             receipt_root = str(receipt.get("adapter_root", ""))
             if receipt_root:
                 return Path(receipt_root).expanduser().resolve()
-        if DEFAULT_GENERATED_ROOT.exists():
-            return DEFAULT_GENERATED_ROOT.resolve()
+        return DEFAULT_GENERATED_ROOT.resolve()
     return core_root / "adapters"
 
 

--- a/scripts/test_sync_status_report.py
+++ b/scripts/test_sync_status_report.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
-from sync_status import ROOT, default_adapter_root, deployed_packs, setup_report
+import sync_status
+from sync_status import ROOT, DEFAULT_GENERATED_ROOT, default_adapter_root, deployed_packs, runtime_status, setup_report
 
 
 def write(path: Path, text: str) -> None:
@@ -63,6 +64,7 @@ def main() -> int:
             "pack.bootstrap.minimal (version=0.1.0, status=deployed, type=mandatory_bootstrap, source=local_path)"
         ], packs
         assert default_adapter_root(ROOT, vault, receipt) == generated.resolve()
+        assert default_adapter_root(ROOT, vault, base / "absent-receipt.json") == DEFAULT_GENERATED_ROOT.resolve()
 
         missing_receipt = base / "missing-receipt.json"
         report = setup_report(ROOT, vault, generated, missing_receipt)
@@ -81,6 +83,39 @@ def main() -> int:
         ]
         for text in expected:
             assert text in report, text
+
+        local_manifest = ROOT / "runtime" / "local" / "runtime_manifest.yaml"
+        before = local_manifest.read_bytes() if local_manifest.exists() else None
+        original_root = sync_status.ROOT
+        try:
+            fake_core = base / "fake-core"
+            write(
+                fake_core / "runtime" / "templates" / "runtime_manifest.template.yaml",
+                "\n".join(
+                    [
+                        "targets:",
+                        "  codex:",
+                        "    status: enabled",
+                        "    install_path: ~/.codex/skills",
+                        "    ownership_mode: managed-directories",
+                        "  chatgpt:",
+                        "    status: manual",
+                        "    install_path: \"\"",
+                        "    ownership_mode: manual-import",
+                        "",
+                    ]
+                ),
+            )
+            sync_status.ROOT = fake_core
+            text = runtime_status()
+            assert "manifest_source: template-read-only" in text, text
+            assert not (fake_core / "runtime" / "local" / "runtime_manifest.yaml").exists()
+        finally:
+            sync_status.ROOT = original_root
+        if before is None:
+            assert not local_manifest.exists()
+        else:
+            assert local_manifest.read_bytes() == before
 
     print("Sync status report tests passed.")
     return 0

--- a/scripts/test_sync_status_report.py
+++ b/scripts/test_sync_status_report.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Regression tests for read-only install/status reporting."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from sync_status import ROOT, default_adapter_root, deployed_packs, setup_report
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="agent-foundry-sync-status.") as raw:
+        base = Path(raw)
+        vault = base / "vault"
+        generated = base / "generated-adapters"
+        receipt = base / "adapter-install-receipt.json"
+        (vault / "practices").mkdir(parents=True)
+        (generated / "codex" / "skills").mkdir(parents=True)
+        write(generated / "adapter-publish-manifest.yaml", "active_assets: []\n")
+        write(
+            receipt,
+            "{\n"
+            '  "schema_version": 1,\n'
+            f'  "adapter_root": "{generated}",\n'
+            '  "installed_files": []\n'
+            "}\n",
+        )
+        write(
+            vault / "packs" / "deployed-pack-index.yaml",
+            "\n".join(
+                [
+                    "schema_version: 1",
+                    "updated: 2026-06-12",
+                    "deployed_packs:",
+                    "  - pack_id: pack.bootstrap.minimal",
+                    '    title: "Bootstrap Pack"',
+                    '    version: "0.1.0"',
+                    "    lifecycle_status: deployed",
+                    "    distribution_type: mandatory_bootstrap",
+                    "    source:",
+                    "      kind: local_path",
+                    f'      locator: "{base / "pack"}"',
+                    "      manifest_sha256: abc123",
+                    "      reviewed_by: architect",
+                    "    records: []",
+                    "    executable_payloads: []",
+                    "    decisions:",
+                    "      conflict_policy: fail_closed",
+                    "      notes: []",
+                    "",
+                ]
+            ),
+        )
+
+        packs = deployed_packs(vault)
+        assert packs == [
+            "pack.bootstrap.minimal (version=0.1.0, status=deployed, type=mandatory_bootstrap, source=local_path)"
+        ], packs
+        assert default_adapter_root(ROOT, vault, receipt) == generated.resolve()
+
+        missing_receipt = base / "missing-receipt.json"
+        report = setup_report(ROOT, vault, generated, missing_receipt)
+        expected = [
+            "Agent Foundry setup/status report",
+            "deployed_pack: pack.bootstrap.minimal",
+            "deployed_packs:",
+            "- pack.bootstrap.minimal (version=0.1.0, status=deployed, type=mandatory_bootstrap, source=local_path)",
+            f"generated_output: ready path={generated} files=1",
+            "receipt: missing",
+            "- chatgpt: manual import required",
+            "next_safe_actions:",
+            "- status-only: no files were written by this report",
+            "- run runtime install only after generated output dry-run/review; receipt is currently missing",
+            "- treat ChatGPT as manual import unless a future managed target is explicitly implemented",
+        ]
+        for text in expected:
+            assert text in report, text
+
+    print("Sync status report tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Report deployed capability packs from the selected Vault's `packs/deployed-pack-index.yaml`.
- Default split-mode status to the selected generated output recorded in the install receipt instead of Core adapter templates.
- Add explicit read-only `next_safe_actions` and a sync status regression fixture wired into consistency checks.

## Verification
- `python3 scripts/test_sync_status_report.py`
- `python3 scripts/test_bootstrap_pack_deployment.py`
- `python3 scripts/sync_status.py`
- `python3 scripts/check_consistency.py`

Closes #102.