### PR TITLE
Validate optional multi-agent pack apply

### DIFF
--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -759,7 +759,7 @@ Rejected-as-pack for this candidate:
 - Executing helpers from Tiny IPA, pack staging, or canonical Vault payload paths after import.
 - Packaging Tiny IPA design notes as active Agent Foundry practices without a separate harvest review.
 
-The candidate pack should therefore be evaluated as a reviewed snapshot: evidence from Tiny IPA, optional public pack fixture, stage-only included records, inert executable payload declarations, no runtime install, and no private path leakage. If later implementation imports the pack, the selected User Vault owns the resulting records and payload metadata; the pack remains provenance and update-comparison evidence, not a live authority.
+The candidate pack should therefore be evaluated as a reviewed snapshot: evidence from Tiny IPA, optional public pack fixture, deployable candidate practice and asset records, no executable payload metadata in the current manifest, no runtime install, and no private path leakage. If later implementation imports the pack, the selected User Vault owns the resulting records; the pack remains provenance and update-comparison evidence, not a live authority. Helper scripts remain deferred evidence until managed helper install, dependency checks, permissions, receipts, and rollback behavior are implemented.
 
 ### AF-6 Complete Install And Pack Lifecycle Boundary
 

--- a/fixtures/capability-packs/optional-multi-agent/manifest.yaml
+++ b/fixtures/capability-packs/optional-multi-agent/manifest.yaml
@@ -63,12 +63,6 @@ rejected_as_pack:
   - "execution from product project paths, pack staging, or canonical Vault payload paths"
   - "active Agent Foundry practices without separate harvest review"
 
-deferred_executable_payloads:
-  - id: helper.review-handoff-summary
-    title: Review Handoff Summary Helper Fixture
-    reason: "Executable helper install is deferred until managed helper install, permissions, dependency checks, receipts, and rollback behavior exist."
-    evidence_path: payloads/helpers/review_handoff_summary.py
-
 compatibility:
   core_schema_version_min: 1
   core_schema_version_max: 1

--- a/fixtures/capability-packs/optional-multi-agent/manifest.yaml
+++ b/fixtures/capability-packs/optional-multi-agent/manifest.yaml
@@ -10,7 +10,7 @@ source_provenance: "Agent Foundry public Core fixture for issue #79; Tiny IPA he
 maintainer_contact: "https://github.com/farmerhunter/agent-foundry"
 license: "repository license"
 sensitivity: public
-review_state: unreviewed
+review_state: accepted
 
 pack_contract:
   promised_use_case: "Help a project operate GitHub issues, PRs, labels, comments, and optional Project status as a lightweight multi-agent scheduler."
@@ -63,6 +63,12 @@ rejected_as_pack:
   - "execution from product project paths, pack staging, or canonical Vault payload paths"
   - "active Agent Foundry practices without separate harvest review"
 
+deferred_executable_payloads:
+  - id: helper.review-handoff-summary
+    title: Review Handoff Summary Helper Fixture
+    reason: "Executable helper install is deferred until managed helper install, permissions, dependency checks, receipts, and rollback behavior exist."
+    evidence_path: payloads/helpers/review_handoff_summary.py
+
 compatibility:
   core_schema_version_min: 1
   core_schema_version_max: 1
@@ -79,7 +85,7 @@ included_records:
     destination_layer: canonical_vault_record
     membership_role: optional_member
     activation_default: manual_review
-    import_action: stage_only
+    import_action: create_or_review_update
   - id: ASSET-COLLAB-PACK-001
     kind: asset
     lifecycle_status: candidate
@@ -89,20 +95,9 @@ included_records:
     destination_layer: canonical_vault_record
     membership_role: optional_member
     activation_default: manual_review
-    import_action: stage_only
+    import_action: create_or_review_update
 
-executable_payloads:
-  - id: helper.review-handoff-summary
-    title: Review Handoff Summary Helper Fixture
-    lifecycle_status: candidate
-    path: payloads/helpers/review_handoff_summary.py
-    source_sha256: "61ebb3b134a4ce82bba92103b8033a4474688057bfbf5be68e908d8322a1b334"
-    interpreter: python3
-    execute_from_pack: false
-    install_boundary: managed_runtime_copy_required
-    permissions: [filesystem-read]
-    dependencies: []
-    runtime_impact: "Fixture payload stands in for the broader helper set and may read reviewed issue or PR handoff text only after managed install."
+executable_payloads: []
 
 conflict_policy:
   id_collision: fail_closed

--- a/scripts/test_capability_pack_apply.py
+++ b/scripts/test_capability_pack_apply.py
@@ -14,6 +14,8 @@ ROOT = Path(__file__).resolve().parents[1]
 APPLY = ROOT / "scripts" / "apply_capability_pack.py"
 DEPLOY = ROOT / "scripts" / "deploy_capability_pack.py"
 INIT = ROOT / "scripts" / "init_vault.py"
+PUBLISH = ROOT / "scripts" / "publish_adapters.py"
+STATUS = ROOT / "scripts" / "sync_status.py"
 BOOTSTRAP_PACK = ROOT / "fixtures" / "capability-packs" / "bootstrap-minimal"
 OPTIONAL_PACK = ROOT / "fixtures" / "capability-packs" / "optional-multi-agent"
 
@@ -174,6 +176,37 @@ def apply_pack(pack_root: Path, vault_root: Path, apply: bool) -> subprocess.Com
     return run(args)
 
 
+def publish_adapters(vault_root: Path, output_root: Path) -> subprocess.CompletedProcess[str]:
+    return run(
+        [
+            str(PUBLISH),
+            "--core-root",
+            str(ROOT),
+            "--vault-root",
+            str(vault_root),
+            "--output-root",
+            str(output_root),
+            "--apply",
+        ]
+    )
+
+
+def status_report(vault_root: Path, output_root: Path, receipt_path: Path) -> subprocess.CompletedProcess[str]:
+    return run(
+        [
+            str(STATUS),
+            "--core-root",
+            str(ROOT),
+            "--vault-root",
+            str(vault_root),
+            "--adapter-root",
+            str(output_root),
+            "--receipt-path",
+            str(receipt_path),
+        ]
+    )
+
+
 def main() -> int:
     errors: list[str] = []
     with tempfile.TemporaryDirectory(prefix="agent-foundry-pack-apply-") as tmp:
@@ -229,8 +262,31 @@ def main() -> int:
             errors.append("apply-refuses-unsafe-domain: unsafe destination was written")
 
         errors.extend(expect("deploy-bootstrap", deploy_bootstrap(vault), True, "selected Vault validated"))
-        blocked = apply_pack(OPTIONAL_PACK, vault, apply=True)
-        errors.extend(expect("apply-refuses-executable-block", blocked, False, "blocking payload outcome"))
+        optional = apply_pack(OPTIONAL_PACK, vault, apply=True)
+        errors.extend(expect("apply-optional-multi-agent", optional, True, "metadata: written"))
+        optional_practice = vault / "practices" / "agent-collaboration" / "COLLAB-PACK-001-review-handoff.md"
+        optional_asset = vault / "assets" / "skills" / "ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml"
+        if not optional_practice.exists():
+            errors.append("apply-optional-multi-agent: candidate practice missing")
+        if not optional_asset.exists():
+            errors.append("apply-optional-multi-agent: candidate asset missing")
+        vault_text = "\n".join(path.read_text(encoding="utf-8") for path in vault.rglob("*") if path.is_file())
+        for expected in ["pack.multi-agent.optional", "COLLAB-PACK-001", "ASSET-COLLAB-PACK-001"]:
+            if expected not in vault_text:
+                errors.append(f"apply-optional-multi-agent: Vault missing {expected}")
+        if "review_handoff_summary.py" in vault_text:
+            errors.append("apply-optional-multi-agent: deferred helper payload leaked into Vault records")
+
+        generated = base / "generated-after-optional"
+        published = publish_adapters(vault, generated)
+        errors.extend(expect("publish-after-optional", published, True, "Adapter publish wrote"))
+        generated_text = "\n".join(path.read_text(encoding="utf-8") for path in generated.rglob("*") if path.is_file())
+        for candidate_id in ["COLLAB-PACK-001", "ASSET-COLLAB-PACK-001"]:
+            if candidate_id in generated_text:
+                errors.append(f"publish-after-optional: candidate record leaked into generated output: {candidate_id}")
+
+        status = status_report(vault, generated, base / "missing-receipt.json")
+        errors.extend(expect("status-reports-optional-pack", status, True, "pack.multi-agent.optional"))
 
     if errors:
         print("Capability pack apply test failed:")

--- a/scripts/test_capability_pack_plan.py
+++ b/scripts/test_capability_pack_plan.py
@@ -251,15 +251,8 @@ def main() -> int:
         errors.extend(expect("plan-bootstrap-skip-after-deploy", bootstrap_after_deploy, True, "skip: 24"))
 
         optional_after_bootstrap = plan_pack(OPTIONAL_PACK, vault)
-        errors.extend(expect("plan-optional-stage-only", optional_after_bootstrap, True, "stage_only: 2"))
-        errors.extend(
-            expect(
-                "plan-optional-blocks-executable",
-                optional_after_bootstrap,
-                True,
-                "blocked_executable_install: 1",
-            )
-        )
+        errors.extend(expect("plan-optional-adds-records", optional_after_bootstrap, True, "add: 2"))
+        errors.extend(expect("plan-optional-no-executable-block", optional_after_bootstrap, True, "blocked_executable_install: 0"))
 
         write_deployed_index(
             vault,


### PR DESCRIPTION
## Summary
- Promote the optional multi-agent pack fixture from stage-only records to deployable candidate Vault records.
- Keep executable helper payloads deferred rather than part of current apply/install behavior.
- Extend plan/apply regression tests to cover optional pack add/apply, refresh/publish without candidate leakage, and sync status pack reporting.

## Verification
- `python3 scripts/check_capability_pack_fixtures.py`
- `python3 scripts/test_capability_pack_plan.py`
- `python3 scripts/test_capability_pack_apply.py`
- `python3 scripts/test_capability_pack_update.py`
- `python3 scripts/check_consistency.py`

Closes #103.