### PR TITLE
Add capability pack lifecycle management

### DIFF
--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -673,6 +673,26 @@ def check_capability_pack_update_script() -> list[str]:
     return output.splitlines()
 
 
+def check_capability_pack_lifecycle_script() -> list[str]:
+    script = ROOT / "scripts" / "test_capability_pack_lifecycle.py"
+    if not script.exists():
+        return ["Missing scripts/test_capability_pack_lifecycle.py"]
+    result = subprocess.run(
+        ["python3", str(script)],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode == 0:
+        return []
+    output = (result.stdout + result.stderr).strip()
+    if not output:
+        return ["Capability pack lifecycle fixture failed without output"]
+    return output.splitlines()
+
+
 def check_sync_status_report_script() -> list[str]:
     script = ROOT / "scripts" / "test_sync_status_report.py"
     if not script.exists():
@@ -737,6 +757,7 @@ def main() -> int:
     errors += check_capability_pack_plan_script()
     errors += check_capability_pack_apply_script()
     errors += check_capability_pack_update_script()
+    errors += check_capability_pack_lifecycle_script()
     errors += check_sync_status_report_script()
     errors += check_runtime_import_script()
 

--- a/scripts/manage_capability_pack_lifecycle.py
+++ b/scripts/manage_capability_pack_lifecycle.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Plan or apply disable/retire lifecycle transitions for deployed packs."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from check_foundry_roots import validate
+from foundry_config import ROOT
+
+
+PRACTICE_RETIRE_STATUS = "archived"
+ASSET_RETIRE_STATUS = "retired"
+
+
+@dataclass(frozen=True)
+class PackRecord:
+    item_id: str
+    kind: str
+    path: str
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def write(path: Path, text: str, apply: bool) -> None:
+    print(f"{'write' if apply else 'would write'}: {path}")
+    if apply:
+        path.write_text(text, encoding="utf-8")
+
+
+def safe_vault_path(vault_root: Path, relative: str) -> Path:
+    rel = Path(relative)
+    if rel.is_absolute():
+        raise SystemExit(f"Refusing absolute Vault record path: {relative}")
+    target = (vault_root / rel).resolve()
+    try:
+        target.relative_to(vault_root.resolve())
+    except ValueError as exc:
+        raise SystemExit(f"Refusing Vault record path outside Vault: {relative}") from exc
+    return target
+
+
+def pack_block_bounds(lines: list[str], pack_id: str) -> tuple[int, int]:
+    start = -1
+    for index, line in enumerate(lines):
+        if line.startswith("  - pack_id:") and line.split(":", 1)[1].strip().strip('"') == pack_id:
+            start = index
+            break
+    if start == -1:
+        return -1, -1
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  - pack_id:"):
+            end = index
+            break
+    return start, end
+
+
+def deployed_pack_records(vault_root: Path, pack_id: str) -> tuple[list[PackRecord], list[str], int, int]:
+    metadata_path = vault_root / "packs" / "deployed-pack-index.yaml"
+    if not metadata_path.exists():
+        return [], [], -1, -1
+    lines = metadata_path.read_text(encoding="utf-8").splitlines()
+    start, end = pack_block_bounds(lines, pack_id)
+    if start == -1:
+        return [], lines, -1, -1
+    records: list[PackRecord] = []
+    in_records = False
+    current: dict[str, str] | None = None
+    for raw in lines[start:end]:
+        stripped = raw.strip()
+        if raw.startswith("    records:"):
+            in_records = True
+            continue
+        if in_records and raw.startswith("    ") and not raw.startswith("      "):
+            if current and current.get("id"):
+                records.append(PackRecord(current["id"], current.get("kind", ""), current.get("path", "")))
+            current = None
+            if stripped and not stripped.startswith("- "):
+                in_records = False
+            continue
+        if in_records and raw.startswith("      - "):
+            if current and current.get("id"):
+                records.append(PackRecord(current["id"], current.get("kind", ""), current.get("path", "")))
+            current = {}
+            item = stripped[2:].strip()
+            if ":" in item:
+                key, value = item.split(":", 1)
+                current[key.strip()] = value.strip().strip('"')
+            continue
+        if in_records and current is not None and raw.startswith("        ") and ":" in stripped:
+            key, value = stripped.split(":", 1)
+            current[key.strip()] = value.strip().strip('"')
+    if current and current.get("id"):
+        records.append(PackRecord(current["id"], current.get("kind", ""), current.get("path", "")))
+    return records, lines, start, end
+
+
+def set_markdown_frontmatter_status(text: str, status: str) -> str:
+    if not text.startswith("---\n"):
+        raise SystemExit("Practice record missing frontmatter")
+    end = text.find("\n---", 4)
+    if end == -1:
+        raise SystemExit("Practice record frontmatter is malformed")
+    prefix = text[:end]
+    suffix = text[end:]
+    lines = prefix.splitlines()
+    for index, line in enumerate(lines):
+        if line.startswith("status:"):
+            lines[index] = f"status: {status}"
+            return "\n".join(lines) + suffix
+    raise SystemExit("Practice record frontmatter missing status")
+
+
+def set_yaml_status(text: str, status: str) -> str:
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        if line.startswith("status:"):
+            lines[index] = f"status: {status}"
+            return "\n".join(lines).rstrip() + "\n"
+    raise SystemExit("Asset record missing status")
+
+
+def set_index_status(text: str, item_id: str, status: str) -> str:
+    lines = text.splitlines()
+    in_entry = False
+    found = False
+    for index, line in enumerate(lines):
+        if line.startswith("  - id: "):
+            in_entry = line.split(":", 1)[1].strip().strip('"') == item_id
+            found = found or in_entry
+            continue
+        if in_entry and line.startswith("    status:"):
+            lines[index] = f"    status: {status}"
+            return "\n".join(lines).rstrip() + "\n"
+    if not found:
+        raise SystemExit(f"Index entry not found for {item_id}")
+    raise SystemExit(f"Index entry missing status for {item_id}")
+
+
+def update_metadata(lines: list[str], start: int, end: int, action: str, state_by_id: dict[str, str]) -> str:
+    updated = list(lines)
+    current_record = ""
+    for index in range(start, end):
+        stripped = updated[index].strip()
+        if updated[index].startswith("    lifecycle_status:"):
+            updated[index] = f"    lifecycle_status: {action}d" if action == "disable" else "    lifecycle_status: retired"
+            continue
+        if updated[index].startswith("      - id:"):
+            current_record = stripped.split(":", 1)[1].strip().strip('"')
+            continue
+        if current_record and updated[index].startswith("        current_state:") and current_record in state_by_id:
+            updated[index] = f"        current_state: {state_by_id[current_record]}"
+    return "\n".join(updated).rstrip() + "\n"
+
+
+def retire_status(kind: str) -> tuple[str, str]:
+    if kind == "practice":
+        return PRACTICE_RETIRE_STATUS, "archived"
+    if kind == "asset":
+        return ASSET_RETIRE_STATUS, "retired"
+    raise SystemExit(f"Unsupported pack record kind: {kind}")
+
+
+def lifecycle(core_root: Path, vault_root: Path, pack_id: str, action: str, apply: bool) -> int:
+    errors = validate(core_root, vault_root)
+    if errors:
+        print("Pack lifecycle refused:")
+        for error in errors:
+            print(f"- {error}")
+        print("writes: none")
+        return 1
+
+    records, metadata_lines, start, end = deployed_pack_records(vault_root, pack_id)
+    metadata_path = vault_root / "packs" / "deployed-pack-index.yaml"
+    print("Capability pack lifecycle report")
+    print(f"pack_id: {pack_id}")
+    print(f"action: {action}")
+    print(f"vault_root: {vault_root}")
+    print(f"metadata: {metadata_path}")
+    if start == -1:
+        print("status: not_deployed")
+        print("writes: none")
+        return 1
+    print("records:")
+    if not records:
+        print("- none")
+
+    state_by_id: dict[str, str] = {}
+    for record in records:
+        path = safe_vault_path(vault_root, record.path)
+        if not path.exists():
+            print(f"- {record.item_id} missing: {record.path}")
+            state_by_id[record.item_id] = "missing"
+            continue
+        if action == "disable":
+            print(f"- {record.item_id} metadata_only: {record.path}")
+            state_by_id[record.item_id] = "unchanged"
+            continue
+        status, state = retire_status(record.kind)
+        print(f"- {record.item_id} {record.kind} -> {status}: {record.path}")
+        text = read(path)
+        updated = set_markdown_frontmatter_status(text, status) if record.kind == "practice" else set_yaml_status(text, status)
+        if updated != text:
+            write(path, updated, apply)
+        index_path = vault_root / "indexes" / ("practice_index.yaml" if record.kind == "practice" else "asset_index.yaml")
+        write(index_path, set_index_status(read(index_path), record.item_id, status), apply)
+        state_by_id[record.item_id] = state
+
+    updated_metadata = update_metadata(metadata_lines, start, end, action, state_by_id)
+    if updated_metadata != "\n".join(metadata_lines).rstrip() + "\n":
+        write(metadata_path, updated_metadata, apply)
+    print("runtime_cleanup: use selected generated-output refresh and managed runtime receipt rollback; ChatGPT remains manual")
+    print("restore: rebuild from public Core plus selected Vault; do not copy another machine's runtime files")
+    print(f"writes: {'applied' if apply else 'none'}")
+    if not apply:
+        print("Dry-run only. Re-run with --apply to write Vault metadata or lifecycle states.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Plan or apply deployed capability pack disable/retire transitions.")
+    parser.add_argument("--core-root", default=str(ROOT), help="Agent Foundry Core root.")
+    parser.add_argument("--vault-root", required=True, help="Selected Agent Foundry Vault root.")
+    parser.add_argument("--pack-id", required=True, help="Deployed capability pack id.")
+    parser.add_argument("--action", choices=["disable", "retire"], required=True)
+    parser.add_argument("--apply", action="store_true", help="Write lifecycle changes. Default is dry-run.")
+    args = parser.parse_args()
+    return lifecycle(
+        Path(args.core_root).expanduser().resolve(),
+        Path(args.vault_root).expanduser().resolve(),
+        args.pack_id,
+        args.action,
+        args.apply,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/manage_capability_pack_lifecycle.py
+++ b/scripts/manage_capability_pack_lifecycle.py
@@ -23,6 +23,12 @@ class PackRecord:
     path: str
 
 
+@dataclass(frozen=True)
+class PlannedWrite:
+    path: Path
+    text: str
+
+
 def read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
@@ -126,6 +132,45 @@ def set_yaml_status(text: str, status: str) -> str:
     raise SystemExit("Asset record missing status")
 
 
+def record_id(kind: str, text: str) -> str:
+    if kind == "practice":
+        if not text.startswith("---\n"):
+            return ""
+        end = text.find("\n---", 4)
+        if end == -1:
+            return ""
+        for line in text[:end].splitlines():
+            if line.startswith("id:"):
+                return line.split(":", 1)[1].strip().strip('"')
+        return ""
+    if kind == "asset":
+        for line in text.splitlines():
+            if line.startswith("id:"):
+                return line.split(":", 1)[1].strip().strip('"')
+        return ""
+    return ""
+
+
+def index_entry_matches(text: str, item_id: str, relative_path: str) -> bool:
+    lines = text.splitlines()
+    in_entry = False
+    found = False
+    path_matches = False
+    status_seen = False
+    for line in lines:
+        if line.startswith("  - id: "):
+            in_entry = line.split(":", 1)[1].strip().strip('"') == item_id
+            found = found or in_entry
+            continue
+        if not in_entry:
+            continue
+        if line.startswith("    path:"):
+            path_matches = line.split(":", 1)[1].strip().strip('"') == relative_path
+        if line.startswith("    status:"):
+            status_seen = True
+    return found and path_matches and status_seen
+
+
 def set_index_status(text: str, item_id: str, status: str) -> str:
     lines = text.splitlines()
     in_entry = False
@@ -167,6 +212,70 @@ def retire_status(kind: str) -> tuple[str, str]:
     raise SystemExit(f"Unsupported pack record kind: {kind}")
 
 
+def plan_lifecycle_writes(
+    vault_root: Path,
+    records: list[PackRecord],
+    metadata_lines: list[str],
+    start: int,
+    end: int,
+    action: str,
+) -> tuple[list[PlannedWrite], dict[str, str], list[str]]:
+    writes: list[PlannedWrite] = []
+    state_by_id: dict[str, str] = {}
+    errors: list[str] = []
+    for record in records:
+        try:
+            path = safe_vault_path(vault_root, record.path)
+        except SystemExit as exc:
+            errors.append(str(exc))
+            continue
+        if not path.exists():
+            errors.append(f"{record.item_id}: record path missing: {record.path}")
+            state_by_id[record.item_id] = "missing"
+            continue
+        text = read(path)
+        actual_id = record_id(record.kind, text)
+        if actual_id != record.item_id:
+            errors.append(f"{record.item_id}: metadata path points to record id {actual_id or '<missing>'}: {record.path}")
+            continue
+        if action == "disable":
+            state_by_id[record.item_id] = "unchanged"
+            continue
+        try:
+            status, state = retire_status(record.kind)
+        except SystemExit as exc:
+            errors.append(str(exc))
+            continue
+        index_path = vault_root / "indexes" / ("practice_index.yaml" if record.kind == "practice" else "asset_index.yaml")
+        if not index_path.exists():
+            errors.append(f"{record.item_id}: index missing: {index_path.relative_to(vault_root)}")
+            continue
+        index_text = read(index_path)
+        if not index_entry_matches(index_text, record.item_id, record.path):
+            errors.append(f"{record.item_id}: index entry missing or path mismatch for {record.path}")
+            continue
+        try:
+            updated_record = (
+                set_markdown_frontmatter_status(text, status)
+                if record.kind == "practice"
+                else set_yaml_status(text, status)
+            )
+            updated_index = set_index_status(index_text, record.item_id, status)
+        except SystemExit as exc:
+            errors.append(f"{record.item_id}: {exc}")
+            continue
+        if updated_record != text:
+            writes.append(PlannedWrite(path, updated_record))
+        if updated_index != index_text:
+            writes.append(PlannedWrite(index_path, updated_index))
+        state_by_id[record.item_id] = state
+
+    updated_metadata = update_metadata(metadata_lines, start, end, action, state_by_id)
+    if updated_metadata != "\n".join(metadata_lines).rstrip() + "\n":
+        writes.append(PlannedWrite(vault_root / "packs" / "deployed-pack-index.yaml", updated_metadata))
+    return writes, state_by_id, errors
+
+
 def lifecycle(core_root: Path, vault_root: Path, pack_id: str, action: str, apply: bool) -> int:
     errors = validate(core_root, vault_root)
     if errors:
@@ -191,30 +300,28 @@ def lifecycle(core_root: Path, vault_root: Path, pack_id: str, action: str, appl
     if not records:
         print("- none")
 
-    state_by_id: dict[str, str] = {}
     for record in records:
         path = safe_vault_path(vault_root, record.path)
         if not path.exists():
             print(f"- {record.item_id} missing: {record.path}")
-            state_by_id[record.item_id] = "missing"
             continue
         if action == "disable":
             print(f"- {record.item_id} metadata_only: {record.path}")
-            state_by_id[record.item_id] = "unchanged"
             continue
         status, state = retire_status(record.kind)
         print(f"- {record.item_id} {record.kind} -> {status}: {record.path}")
-        text = read(path)
-        updated = set_markdown_frontmatter_status(text, status) if record.kind == "practice" else set_yaml_status(text, status)
-        if updated != text:
-            write(path, updated, apply)
-        index_path = vault_root / "indexes" / ("practice_index.yaml" if record.kind == "practice" else "asset_index.yaml")
-        write(index_path, set_index_status(read(index_path), record.item_id, status), apply)
-        state_by_id[record.item_id] = state
 
-    updated_metadata = update_metadata(metadata_lines, start, end, action, state_by_id)
-    if updated_metadata != "\n".join(metadata_lines).rstrip() + "\n":
-        write(metadata_path, updated_metadata, apply)
+    planned_writes, _state_by_id, planning_errors = plan_lifecycle_writes(
+        vault_root, records, metadata_lines, start, end, action
+    )
+    if planning_errors:
+        print("status: failed")
+        for error in planning_errors:
+            print(f"- {error}")
+        print("writes: none")
+        return 1
+    for planned in planned_writes:
+        write(planned.path, planned.text, apply)
     print("runtime_cleanup: use selected generated-output refresh and managed runtime receipt rollback; ChatGPT remains manual")
     print("restore: rebuild from public Core plus selected Vault; do not copy another machine's runtime files")
     print(f"writes: {'applied' if apply else 'none'}")

--- a/scripts/test_capability_pack_lifecycle.py
+++ b/scripts/test_capability_pack_lifecycle.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Regression tests for disable/retire pack lifecycle behavior."""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INIT = ROOT / "scripts" / "init_vault.py"
+DEPLOY = ROOT / "scripts" / "deploy_capability_pack.py"
+APPLY = ROOT / "scripts" / "apply_capability_pack.py"
+LIFECYCLE = ROOT / "scripts" / "manage_capability_pack_lifecycle.py"
+PUBLISH = ROOT / "scripts" / "publish_adapters.py"
+STATUS = ROOT / "scripts" / "sync_status.py"
+BOOTSTRAP_PACK = ROOT / "fixtures" / "capability-packs" / "bootstrap-minimal"
+OPTIONAL_PACK = ROOT / "fixtures" / "capability-packs" / "optional-multi-agent"
+OPTIONAL_ID = "pack.multi-agent.optional"
+
+
+def run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, *args],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def expect(name: str, result: subprocess.CompletedProcess[str], should_pass: bool, expected_text: str = "") -> list[str]:
+    output = result.stdout + result.stderr
+    if (result.returncode == 0) == should_pass and (not expected_text or expected_text in output):
+        print(f"{name}: ok")
+        return []
+    return [
+        f"{name}: expected {'pass' if should_pass else 'failure'}"
+        + (f" containing {expected_text!r}" if expected_text else "")
+        + f", got exit {result.returncode}\n{output.strip()}"
+    ]
+
+
+def digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def init_blank(vault: Path) -> subprocess.CompletedProcess[str]:
+    return run([str(INIT), str(vault), "--core-root", str(ROOT), "--apply"])
+
+
+def deploy_bootstrap(vault: Path) -> subprocess.CompletedProcess[str]:
+    return run([str(DEPLOY), str(BOOTSTRAP_PACK), "--core-root", str(ROOT), "--vault-root", str(vault), "--apply"])
+
+
+def apply_optional(vault: Path) -> subprocess.CompletedProcess[str]:
+    return run([str(APPLY), str(OPTIONAL_PACK), "--core-root", str(ROOT), "--vault-root", str(vault), "--apply"])
+
+
+def lifecycle(vault: Path, action: str, apply: bool) -> subprocess.CompletedProcess[str]:
+    args = [
+        str(LIFECYCLE),
+        "--core-root",
+        str(ROOT),
+        "--vault-root",
+        str(vault),
+        "--pack-id",
+        OPTIONAL_ID,
+        "--action",
+        action,
+    ]
+    if apply:
+        args.append("--apply")
+    return run(args)
+
+
+def publish(vault: Path, generated: Path) -> subprocess.CompletedProcess[str]:
+    return run(
+        [
+            str(PUBLISH),
+            "--core-root",
+            str(ROOT),
+            "--vault-root",
+            str(vault),
+            "--output-root",
+            str(generated),
+            "--apply",
+        ]
+    )
+
+
+def status(vault: Path, generated: Path, receipt: Path) -> subprocess.CompletedProcess[str]:
+    return run(
+        [
+            str(STATUS),
+            "--core-root",
+            str(ROOT),
+            "--vault-root",
+            str(vault),
+            "--adapter-root",
+            str(generated),
+            "--receipt-path",
+            str(receipt),
+        ]
+    )
+
+
+def main() -> int:
+    errors: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="agent-foundry-pack-lifecycle-") as tmp:
+        base = Path(tmp)
+        vault = base / "vault"
+        generated = base / "generated"
+        errors.extend(expect("init-blank-vault", init_blank(vault), True, "Blank Vault initialized and validated."))
+        errors.extend(expect("deploy-bootstrap", deploy_bootstrap(vault), True, "selected Vault validated"))
+        errors.extend(expect("apply-optional", apply_optional(vault), True, "metadata: written"))
+
+        user_record = vault / "practices" / "user" / "USER-LOCAL-001.md"
+        write(
+            user_record,
+            "\n".join(
+                [
+                    "---",
+                    "id: USER-LOCAL-001",
+                    "title: Local User Record",
+                    "domain: user",
+                    "status: active",
+                    "---",
+                    "",
+                    "Unrelated user record.",
+                    "",
+                ]
+            ),
+        )
+        user_before = digest(user_record)
+        practice = vault / "practices" / "agent-collaboration" / "COLLAB-PACK-001-review-handoff.md"
+        asset = vault / "assets" / "skills" / "ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml"
+        metadata = vault / "packs" / "deployed-pack-index.yaml"
+        metadata_before = digest(metadata)
+
+        dry_disable = lifecycle(vault, "disable", apply=False)
+        errors.extend(expect("disable-dry-run", dry_disable, True, "writes: none"))
+        if digest(metadata) != metadata_before:
+            errors.append("disable-dry-run: metadata changed")
+
+        apply_disable = lifecycle(vault, "disable", apply=True)
+        errors.extend(expect("disable-apply", apply_disable, True, "writes: applied"))
+        metadata_text = metadata.read_text(encoding="utf-8")
+        if "lifecycle_status: disabled" not in metadata_text:
+            errors.append("disable-apply: metadata missing disabled lifecycle")
+        if "status: candidate" not in practice.read_text(encoding="utf-8"):
+            errors.append("disable-apply: practice status changed during metadata-only disable")
+        if "status: candidate" not in asset.read_text(encoding="utf-8"):
+            errors.append("disable-apply: asset status changed during metadata-only disable")
+
+        apply_retire = lifecycle(vault, "retire", apply=True)
+        errors.extend(expect("retire-apply", apply_retire, True, "runtime_cleanup:"))
+        if "status: archived" not in practice.read_text(encoding="utf-8"):
+            errors.append("retire-apply: practice was not archived")
+        if "status: retired" not in asset.read_text(encoding="utf-8"):
+            errors.append("retire-apply: asset was not retired")
+        if "    status: archived" not in (vault / "indexes" / "practice_index.yaml").read_text(encoding="utf-8"):
+            errors.append("retire-apply: practice index status was not archived")
+        if "    status: retired" not in (vault / "indexes" / "asset_index.yaml").read_text(encoding="utf-8"):
+            errors.append("retire-apply: asset index status was not retired")
+        retired_metadata = metadata.read_text(encoding="utf-8")
+        for expected in ["lifecycle_status: retired", "current_state: archived", "current_state: retired"]:
+            if expected not in retired_metadata:
+                errors.append(f"retire-apply: metadata missing {expected}")
+        if digest(user_record) != user_before:
+            errors.append("retire-apply: unrelated user record changed")
+
+        errors.extend(expect("publish-after-retire", publish(vault, generated), True, "Adapter publish wrote"))
+        generated_text = "\n".join(path.read_text(encoding="utf-8") for path in generated.rglob("*") if path.is_file())
+        for retired_id in ["COLLAB-PACK-001", "ASSET-COLLAB-PACK-001"]:
+            if retired_id in generated_text:
+                errors.append(f"publish-after-retire: retired candidate leaked into generated output: {retired_id}")
+        restore_status = status(vault, generated, base / "missing-receipt.json")
+        for expected in [
+            "root_validation: passed",
+            "generated_output: ready",
+            "receipt: missing",
+            "chatgpt_manual_import: explicit",
+            "status-only: no files were written by this report",
+        ]:
+            errors.extend(expect(f"restore-status-{expected}", restore_status, True, expected))
+
+    if errors:
+        print("Capability pack lifecycle test failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("Capability pack lifecycle test passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_capability_pack_lifecycle.py
+++ b/scripts/test_capability_pack_lifecycle.py
@@ -194,6 +194,96 @@ def main() -> int:
         ]:
             errors.extend(expect(f"restore-status-{expected}", restore_status, True, expected))
 
+        wrong_path_vault = base / "wrong-path-vault"
+        errors.extend(expect("init-wrong-path-vault", init_blank(wrong_path_vault), True, "Blank Vault initialized"))
+        errors.extend(expect("deploy-wrong-path-bootstrap", deploy_bootstrap(wrong_path_vault), True, "selected Vault validated"))
+        errors.extend(expect("apply-wrong-path-optional", apply_optional(wrong_path_vault), True, "metadata: written"))
+        wrong_user = wrong_path_vault / "practices" / "user" / "USER-LOCAL-001.md"
+        write(
+            wrong_user,
+            "---\nid: USER-LOCAL-001\ntitle: Local User Record\ndomain: user\nstatus: active\n---\n\nUnrelated.\n",
+        )
+        wrong_user_before = digest(wrong_user)
+        wrong_metadata = wrong_path_vault / "packs" / "deployed-pack-index.yaml"
+        wrong_metadata.write_text(
+            wrong_metadata.read_text(encoding="utf-8").replace(
+                "path: practices/agent-collaboration/COLLAB-PACK-001-review-handoff.md",
+                "path: practices/user/USER-LOCAL-001.md",
+            ),
+            encoding="utf-8",
+        )
+        wrong_path = lifecycle(wrong_path_vault, "retire", apply=True)
+        errors.extend(expect("retire-refuses-wrong-path", wrong_path, False, "metadata path points to record id USER-LOCAL-001"))
+        if digest(wrong_user) != wrong_user_before:
+            errors.append("retire-refuses-wrong-path: unrelated user record changed")
+        original_pack_record = (
+            wrong_path_vault
+            / "practices"
+            / "agent-collaboration"
+            / "COLLAB-PACK-001-review-handoff.md"
+        )
+        if "status: candidate" not in original_pack_record.read_text(encoding="utf-8"):
+            errors.append("retire-refuses-wrong-path: original pack record changed")
+
+        partial_vault = base / "partial-vault"
+        errors.extend(expect("init-partial-vault", init_blank(partial_vault), True, "Blank Vault initialized"))
+        errors.extend(expect("deploy-partial-bootstrap", deploy_bootstrap(partial_vault), True, "selected Vault validated"))
+        errors.extend(expect("apply-partial-optional", apply_optional(partial_vault), True, "metadata: written"))
+        partial_practice = partial_vault / "practices" / "agent-collaboration" / "COLLAB-PACK-001-review-handoff.md"
+        partial_asset = partial_vault / "assets" / "skills" / "ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml"
+        partial_metadata = partial_vault / "packs" / "deployed-pack-index.yaml"
+        before_partial = {
+            "practice": digest(partial_practice),
+            "asset": digest(partial_asset),
+            "practice_index": digest(partial_vault / "indexes" / "practice_index.yaml"),
+            "asset_index": digest(partial_vault / "indexes" / "asset_index.yaml"),
+            "metadata": digest(partial_metadata),
+        }
+        asset_index = partial_vault / "indexes" / "asset_index.yaml"
+        other_asset = partial_vault / "assets" / "skills" / "ASSET-OTHER-001.yaml"
+        write(
+            other_asset,
+            "\n".join(
+                [
+                    "id: ASSET-OTHER-001",
+                    "title: Other Asset",
+                    "asset_type: skill",
+                    "status: candidate",
+                    "purpose: Fixture.",
+                    "responsibility: Fixture.",
+                    "non_responsibility: Fixture.",
+                    "inputs: []",
+                    "process: []",
+                    "outputs: []",
+                    "canonical_practices: []",
+                    "published_to: []",
+                    "usage_triggers: []",
+                    "success_criteria: []",
+                    "",
+                ]
+            ),
+        )
+        asset_index.write_text(
+            asset_index.read_text(encoding="utf-8").replace(
+                "path: assets/skills/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml",
+                "path: assets/skills/ASSET-OTHER-001.yaml",
+            ),
+            encoding="utf-8",
+        )
+        expected_asset_index_after_tamper = digest(asset_index)
+        partial = lifecycle(partial_vault, "retire", apply=True)
+        errors.extend(expect("retire-refuses-partial-write", partial, False, "index entry missing or path mismatch"))
+        if digest(partial_practice) != before_partial["practice"]:
+            errors.append("retire-refuses-partial-write: practice changed before failure")
+        if digest(partial_asset) != before_partial["asset"]:
+            errors.append("retire-refuses-partial-write: asset changed before failure")
+        if digest(partial_vault / "indexes" / "practice_index.yaml") != before_partial["practice_index"]:
+            errors.append("retire-refuses-partial-write: practice index changed before failure")
+        if digest(asset_index) != expected_asset_index_after_tamper:
+            errors.append("retire-refuses-partial-write: asset index changed after preflight failure")
+        if digest(partial_metadata) != before_partial["metadata"]:
+            errors.append("retire-refuses-partial-write: metadata changed before failure")
+
     if errors:
         print("Capability pack lifecycle test failed:")
         for error in errors:


### PR DESCRIPTION
## Summary
- Add `scripts/manage_capability_pack_lifecycle.py` for deployed pack `disable` and `retire` transitions.
- Keep `disable` metadata-only; `retire` updates pack-sourced canonical record lifecycle states and indexes without deleting records.
- Add temp Vault lifecycle regression coverage and wire it into consistency checks.

## Verification
- `python3 scripts/test_capability_pack_lifecycle.py`
- `python3 scripts/test_capability_pack_apply.py`
- `python3 scripts/test_bootstrap_pack_deployment.py`
- `python3 scripts/check_consistency.py`

Closes #104.