### PR TITLE
Address AF6 close review gaps

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,7 +2,7 @@
 
 Agent Foundry is local-first. Core tooling, User Vault records, and installed runtime files are separate layers.
 
-Current scope: this document describes the AF-3 split Core/Vault deployment model. A clean public Core checkout contains workflows, schemas, scripts, templates, docs, and adapter profiles. Canonical practice and asset records live in a selected User Vault, typically outside the Core checkout. AF-5 owns polished onboarding, bootstrap pack deployment, and optional capability packs after AF-4 proves current-user deployment and upgrade migration.
+Current scope: this document describes the AF-6 Core/Vault deployment lifecycle. A clean public Core checkout contains workflows, schemas, scripts, templates, docs, adapter profiles, validation tooling, install orchestration, pack planning/apply/update/lifecycle helpers, and runtime status/rollback helpers. Canonical practice and asset records live in a selected User Vault, typically outside the Core checkout. AF-6 implements the tested baseline for blank-Vault initialization, mandatory bootstrap pack deployment, optional pack deployment, selected generated output, managed runtime status/receipt reporting, and pack disable/retire lifecycle behavior.
 
 ```text
 Agent Foundry Core + selected User Vault
@@ -209,9 +209,9 @@ Fail closed if the private Vault is absent, its `.agent-foundry-vault.yaml` mark
 
 ## External-User Boundary
 
-AF-2 defines the setup boundary but does not implement the public setup path.
+AF-6 provides a tested local-first setup baseline for a new user or machine: clone Core, initialize or select a Vault, deploy the mandatory bootstrap pack, publish selected generated output, inspect status, and then explicitly dry-run or apply managed runtime installs. This is not yet a marketplace, hosted installer, or fully polished product wizard, but it is no longer only maintainer implementation evidence.
 
-A future external-user setup needs:
+The supported public setup baseline expects:
 
 - public Core that does not require current-user Vault content;
 - a user-owned Vault location, private by default;
@@ -219,9 +219,10 @@ A future external-user setup needs:
 - locator support for distinct `core_root` and `vault_root`;
 - adapter generation from the selected user's Vault, not a bundled current-user Vault;
 - runtime install that can verify split Core/Vault state before writing managed runtime files;
-- onboarding choices for empty Vault, starter capability packs, runtime-asset imports, or mixed setup.
+- mandatory bootstrap pack deployment followed by optional capability pack deployment when the user selects a known pack;
+- ChatGPT manual import boundaries and managed runtime receipt/status reporting for Codex, Claude Code, and Hermes.
 
-Until that work is complete, deployment commands in this file are safe for the maintainer workflow and useful as implementation evidence, but they are not a tested new-user onboarding path.
+Remaining productization work includes friendlier command wrapping, broader pack distribution/update UX, remote trust policy, and physical multi-machine onboarding documentation. Final merge from AF-6 integration to `main` remains human-gated.
 
 ## Daily Update
 

--- a/scripts/sync_status.py
+++ b/scripts/sync_status.py
@@ -210,12 +210,15 @@ def legacy_pack_scan(vault_root: Path) -> list[str]:
 
 def deployed_packs(vault_root: Path) -> list[str]:
     index = vault_root / "packs" / "deployed-pack-index.yaml"
+    legacy_packs = legacy_pack_scan(vault_root)
     if index.exists():
         packs = []
+        seen: set[str] = set()
         for entry in parse_deployed_pack_index(index):
             pack_id = entry.get("pack_id", "")
             if not pack_id:
                 continue
+            seen.add(pack_id)
             version = entry.get("version", "")
             status = entry.get("lifecycle_status", "")
             distribution = entry.get("distribution_type", "")
@@ -230,8 +233,11 @@ def deployed_packs(vault_root: Path) -> list[str]:
             if source:
                 suffix.append(f"source={source}")
             packs.append(f"{pack_id} ({', '.join(suffix)})" if suffix else pack_id)
+        for pack_id in legacy_packs:
+            if pack_id not in seen:
+                packs.append(f"{pack_id} (legacy-detected)")
         return packs
-    return legacy_pack_scan(vault_root)
+    return legacy_packs
 
 
 def generated_output_status(adapter_root: Path) -> tuple[str, int]:

--- a/scripts/test_capability_pack_apply.py
+++ b/scripts/test_capability_pack_apply.py
@@ -287,6 +287,7 @@ def main() -> int:
 
         status = status_report(vault, generated, base / "missing-receipt.json")
         errors.extend(expect("status-reports-optional-pack", status, True, "pack.multi-agent.optional"))
+        errors.extend(expect("status-reports-bootstrap-pack", status, True, "pack.bootstrap.minimal"))
 
     if errors:
         print("Capability pack apply test failed:")


### PR DESCRIPTION
## Summary
- Merge legacy bootstrap pack detection with deployed pack metadata in `sync_status.py`.
- Add regression coverage so status reports both bootstrap and optional packs after optional apply.
- Update deployment docs from stale AF3/AF5 wording to the AF6 tested local-first lifecycle baseline.

## Verification
- `python3 scripts/test_capability_pack_apply.py`
- `python3 scripts/test_sync_status_report.py`
- `python3 scripts/check_consistency.py`
- `python3 scripts/sync_status.py`

Addresses #105 reviewer findings.