### PR TITLE
[AF8 Task] Clarify runtime drift repair policy

### DIFF
--- a/scripts/adapter_install_receipt.py
+++ b/scripts/adapter_install_receipt.py
@@ -129,6 +129,14 @@ def receipt_status(receipt: dict[str, Any]) -> tuple[str, list[str]]:
     if not isinstance(files, list) or not files:
         return "selected-output-unknown", ["receipt has no installed files"]
     problems: list[str] = []
+    manifest_text = str(receipt.get("adapter_manifest", ""))
+    manifest_path = Path(manifest_text).expanduser()
+    manifest_sha256 = str(receipt.get("adapter_manifest_sha256", ""))
+    if manifest_text and manifest_sha256:
+        if not manifest_path.exists():
+            problems.append(f"missing adapter_manifest {manifest_path}")
+        elif file_sha256(manifest_path) != manifest_sha256:
+            problems.append(f"changed adapter_manifest {manifest_path}")
     for entry in files:
         if not isinstance(entry, dict):
             problems.append("receipt has invalid installed file entry")

--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -733,6 +733,26 @@ def check_runtime_import_script() -> list[str]:
     return output.splitlines()
 
 
+def check_runtime_drift_repair_script() -> list[str]:
+    script = ROOT / "scripts" / "test_runtime_drift_repair.py"
+    if not script.exists():
+        return ["Missing scripts/test_runtime_drift_repair.py"]
+    result = subprocess.run(
+        ["python3", str(script)],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode == 0:
+        return []
+    output = (result.stdout + result.stderr).strip()
+    if not output:
+        return ["Runtime drift repair fixture failed without output"]
+    return output.splitlines()
+
+
 def main() -> int:
     errors: list[str] = []
     errors += check_index_paths(VAULT_ROOT / "indexes" / "practice_index.yaml", VAULT_ROOT, "Practice")
@@ -760,6 +780,7 @@ def main() -> int:
     errors += check_capability_pack_lifecycle_script()
     errors += check_sync_status_report_script()
     errors += check_runtime_import_script()
+    errors += check_runtime_drift_repair_script()
 
     if errors:
         print("Consistency check failed:")

--- a/scripts/sync_status.py
+++ b/scripts/sync_status.py
@@ -309,7 +309,13 @@ def next_safe_actions(
 
 def setup_report(core_root: Path, vault_root: Path, adapter_root: Path, receipt_path: Path = RECEIPT_PATH) -> str:
     manifest_path = ROOT / "runtime" / "local" / "runtime_manifest.yaml"
-    targets = parse_runtime_manifest(manifest_path.read_text(encoding="utf-8")) if manifest_path.exists() else {}
+    template_path = ROOT / "runtime" / "templates" / "runtime_manifest.template.yaml"
+    if manifest_path.exists():
+        targets = parse_runtime_manifest(manifest_path.read_text(encoding="utf-8"))
+    elif template_path.exists():
+        targets = parse_runtime_manifest(template_path.read_text(encoding="utf-8"))
+    else:
+        targets = {}
     output_state, output_count = generated_output_status(adapter_root)
     packs = deployed_packs(vault_root)
     lines = [

--- a/scripts/sync_status.py
+++ b/scripts/sync_status.py
@@ -285,8 +285,15 @@ def next_safe_actions(
         actions.append("select or initialize a Vault before harvesting, refreshing, or applying packs")
     if output_state != "ready":
         actions.append("regenerate selected Vault adapter output before runtime install or refresh")
-    if read_receipt(receipt_path) is None:
+    receipt = read_receipt(receipt_path)
+    if receipt is None:
         actions.append("run runtime install only after generated output dry-run/review; receipt is currently missing")
+    else:
+        receipt_state, _ = receipt_status(receipt)
+        if receipt_state == "selected-output-drift":
+            actions.append("review selected-output drift, regenerate generated output if needed, then dry-run runtime install before apply")
+        elif receipt_state == "selected-output-unknown":
+            actions.append("repair or recreate runtime install receipt only through reviewed install apply after generated output is ready")
     actions.append("treat ChatGPT as manual import unless a future managed target is explicitly implemented")
     return actions
 

--- a/scripts/test_adapter_install_receipt.py
+++ b/scripts/test_adapter_install_receipt.py
@@ -48,6 +48,12 @@ def main() -> int:
         assert targets["codex"][0] == "selected-output-in-sync"
         assert targets["hermes"][0] == "selected-output-in-sync"
 
+        write(adapter / "adapter-publish-manifest.yaml", "active_assets:\n  - ASSET-CHANGED-001\n")
+        state, problems = receipt_status(loaded)
+        assert state == "selected-output-drift"
+        assert any("changed adapter_manifest" in problem for problem in problems)
+        write(adapter / "adapter-publish-manifest.yaml", "active_assets:\n  - ASSET-COLLAB-002\n")
+
         write(codex_dest / "role-automation-planner" / "SKILL.md", "changed\n")
         state, problems = receipt_status(loaded)
         assert state == "selected-output-drift"

--- a/scripts/test_runtime_drift_repair.py
+++ b/scripts/test_runtime_drift_repair.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Runtime drift and selected-output receipt repair policy tests."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import sync_status
+from adapter_install_receipt import write_receipt
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def make_core(root: Path) -> Path:
+    core = root / "core"
+    write(
+        core / "runtime" / "local" / "runtime_manifest.yaml",
+        "\n".join(
+            [
+                "targets:",
+                "  codex:",
+                "    status: disabled",
+                "    install_path: ~/.codex/skills",
+                "    ownership_mode: managed-directories",
+                "  chatgpt:",
+                "    status: manual",
+                '    install_path: ""',
+                "    ownership_mode: manual-import",
+                "",
+            ]
+        ),
+    )
+    return core
+
+
+def make_vault(root: Path) -> Path:
+    vault = root / "vault"
+    (vault / "practices").mkdir(parents=True)
+    return vault
+
+
+def make_generated(root: Path) -> Path:
+    generated = root / "generated"
+    write(generated / "adapter-publish-manifest.yaml", "active_assets:\n  - ASSET-COLLAB-002\n")
+    write(generated / "codex" / "skills" / "example" / "SKILL.md", "codex skill\n")
+    write(generated / "chatgpt" / "custom-instructions.md", "manual import\n")
+    return generated
+
+
+def assert_contains(text: str, snippets: tuple[str, ...]) -> None:
+    for snippet in snippets:
+        assert snippet in text, f"missing {snippet!r} in:\n{text}"
+
+
+def with_fake_root(core: Path, func) -> None:
+    original = sync_status.ROOT
+    try:
+        sync_status.ROOT = core
+        func()
+    finally:
+        sync_status.ROOT = original
+
+
+def assert_missing_receipt_guidance(base: Path) -> None:
+    core = make_core(base)
+    vault = make_vault(base)
+    generated = make_generated(base)
+
+    def check() -> None:
+        report = sync_status.setup_report(core, vault, generated, base / "missing-receipt.json")
+        assert_contains(
+            report,
+            (
+                "receipt: missing",
+                "run runtime install only after generated output dry-run/review; receipt is currently missing",
+                "- codex: skipped status=disabled",
+                "- chatgpt: manual import required",
+            ),
+        )
+
+    with_fake_root(core, check)
+
+
+def assert_generated_output_drift_guidance(base: Path) -> None:
+    core = make_core(base)
+    vault = make_vault(base)
+    generated = make_generated(base)
+    runtime = base / "runtime" / "codex"
+    receipt = base / "receipt.json"
+    write(runtime / "example" / "SKILL.md", "codex skill\n")
+    write_receipt(
+        core_root=core,
+        vault_root=vault,
+        adapter_root=generated,
+        installed_targets={"codex": runtime},
+        receipt_path=receipt,
+    )
+    write(generated / "adapter-publish-manifest.yaml", "active_assets:\n  - ASSET-CHANGED-001\n")
+
+    def check() -> None:
+        report = sync_status.setup_report(core, vault, generated, receipt)
+        assert_contains(
+            report,
+            (
+                "receipt: selected-output-drift",
+                "receipt detail: changed adapter_manifest",
+                "review selected-output drift, regenerate generated output if needed, then dry-run runtime install before apply",
+            ),
+        )
+
+    with_fake_root(core, check)
+
+
+def assert_stale_runtime_file_guidance(base: Path) -> None:
+    core = make_core(base)
+    vault = make_vault(base)
+    generated = make_generated(base)
+    runtime = base / "runtime" / "codex"
+    receipt = base / "receipt.json"
+    write(runtime / "example" / "SKILL.md", "codex skill\n")
+    write_receipt(
+        core_root=core,
+        vault_root=vault,
+        adapter_root=generated,
+        installed_targets={"codex": runtime},
+        receipt_path=receipt,
+    )
+    write(runtime / "example" / "SKILL.md", "stale runtime copy\n")
+
+    def check() -> None:
+        report = sync_status.setup_report(core, vault, generated, receipt)
+        assert_contains(
+            report,
+            (
+                "receipt: selected-output-drift",
+                "receipt target: codex selected-output-drift checked=1 problems=1",
+                "receipt detail: changed codex:",
+                "review selected-output drift, regenerate generated output if needed, then dry-run runtime install before apply",
+            ),
+        )
+
+    with_fake_root(core, check)
+
+
+def assert_unknown_receipt_guidance(base: Path) -> None:
+    core = make_core(base)
+    vault = make_vault(base)
+    generated = make_generated(base)
+    receipt = base / "receipt.json"
+    write(
+        receipt,
+        "{\n"
+        '  "schema_version": 1,\n'
+        f'  "adapter_root": "{generated}",\n'
+        '  "installed_files": []\n'
+        "}\n",
+    )
+
+    def check() -> None:
+        report = sync_status.setup_report(core, vault, generated, receipt)
+        assert_contains(
+            report,
+            (
+                "receipt: selected-output-unknown",
+                "receipt detail: receipt has no installed files",
+                "repair or recreate runtime install receipt only through reviewed install apply after generated output is ready",
+            ),
+        )
+
+    with_fake_root(core, check)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="agent-foundry-runtime-drift.") as raw:
+        base = Path(raw)
+        assert_missing_receipt_guidance(base / "missing-receipt")
+        assert_generated_output_drift_guidance(base / "generated-output-drift")
+        assert_stale_runtime_file_guidance(base / "runtime-file-drift")
+        assert_unknown_receipt_guidance(base / "unknown-receipt")
+    print("Runtime drift and receipt repair policy tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Treat changed or missing `adapter-publish-manifest.yaml` from an install receipt as selected-output drift.
- Adds safe repair guidance for selected-output drift and unknown receipts without implying automatic runtime writes.
- Adds temp-root runtime drift repair tests for missing receipt, generated-output drift, stale runtime files, unknown receipt, disabled targets, and ChatGPT manual boundary.

## Validation

- `python3 scripts/test_runtime_drift_repair.py`
- `python3 scripts/test_adapter_install_receipt.py`
- `python3 scripts/test_sync_status_report.py`
- `python3 scripts/check_consistency.py`
- `git diff --check`

Closes #122.