### PR TITLE
[AF8 Task] Enforce ChatGPT manual import boundary

### DIFF
--- a/scripts/sync_adapters.py
+++ b/scripts/sync_adapters.py
@@ -164,12 +164,14 @@ def sync_chatgpt(adapter_root: Path, dest: Path | None, apply: bool) -> list[tup
     src = adapter_root / "chatgpt"
     if not src.exists():
         raise SystemExit(f"Adapter source missing: {src}")
-    if dest is None:
-        print("ChatGPT has no default local runtime. Use these files manually:")
-        print(f"- {src / 'custom-instructions.md'}")
-        print(f"- {src / 'knowledge'}")
-        return []
-    return copytree_contents(src, dest, apply)
+    print("ChatGPT has no managed local runtime. Import these generated files manually:")
+    print(f"- {src / 'custom-instructions.md'}")
+    print(f"- {src / 'knowledge'}")
+    if dest is not None:
+        print(f"manual target destination ignored: {dest}")
+    if apply and dest is not None:
+        raise SystemExit("Refusing managed ChatGPT runtime write; ChatGPT remains manual-import only.")
+    return []
 
 
 def main() -> int:

--- a/scripts/sync_status.py
+++ b/scripts/sync_status.py
@@ -307,7 +307,13 @@ def next_safe_actions(
 
 def setup_report(core_root: Path, vault_root: Path, adapter_root: Path, receipt_path: Path = RECEIPT_PATH) -> str:
     manifest_path = ROOT / "runtime" / "local" / "runtime_manifest.yaml"
-    targets = parse_runtime_manifest(manifest_path.read_text(encoding="utf-8")) if manifest_path.exists() else {}
+    template_path = ROOT / "runtime" / "templates" / "runtime_manifest.template.yaml"
+    if manifest_path.exists():
+        targets = parse_runtime_manifest(manifest_path.read_text(encoding="utf-8"))
+    elif template_path.exists():
+        targets = parse_runtime_manifest(template_path.read_text(encoding="utf-8"))
+    else:
+        targets = {}
     output_state, output_count = generated_output_status(adapter_root)
     packs = deployed_packs(vault_root)
     lines = [

--- a/scripts/test_sync_status_report.py
+++ b/scripts/test_sync_status_report.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import tempfile
+import subprocess
+import sys
 from pathlib import Path
 
 import sync_status
@@ -13,6 +15,17 @@ from sync_status import ROOT, DEFAULT_GENERATED_ROOT, default_adapter_root, depl
 def write(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
+
+
+def run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, *args],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
 
 
 def main() -> int:
@@ -116,6 +129,43 @@ def main() -> int:
             assert not local_manifest.exists()
         else:
             assert local_manifest.read_bytes() == before
+
+        chatgpt_generated = base / "chatgpt-generated"
+        chatgpt_dest = base / "chatgpt-runtime"
+        write(chatgpt_generated / "chatgpt" / "custom-instructions.md", "# Manual instructions\n")
+        write(chatgpt_generated / "chatgpt" / "knowledge" / "commands.md", "# Commands\n")
+        dry_run = run(
+            [
+                str(ROOT / "scripts" / "sync_adapters.py"),
+                "--target",
+                "chatgpt",
+                "--adapter-root",
+                str(chatgpt_generated),
+                "--dest",
+                str(chatgpt_dest),
+                "--dry-run",
+            ]
+        )
+        assert dry_run.returncode == 0, dry_run.stdout + dry_run.stderr
+        assert "ChatGPT has no managed local runtime" in dry_run.stdout
+        assert "manual target destination ignored" in dry_run.stdout
+        assert not chatgpt_dest.exists()
+
+        apply = run(
+            [
+                str(ROOT / "scripts" / "sync_adapters.py"),
+                "--target",
+                "chatgpt",
+                "--adapter-root",
+                str(chatgpt_generated),
+                "--dest",
+                str(chatgpt_dest),
+                "--apply",
+            ]
+        )
+        assert apply.returncode != 0
+        assert "Refusing managed ChatGPT runtime write" in apply.stdout + apply.stderr
+        assert not chatgpt_dest.exists()
 
     print("Sync status report tests passed.")
     return 0


### PR DESCRIPTION
## Summary

- Keeps ChatGPT as a manual-import target even when `sync_adapters.py --target chatgpt --dest ...` is used.
- Makes ChatGPT dry-run output explain generated files are for manual import and ignores managed destinations.
- Refuses `--apply --dest` for ChatGPT so future flows cannot accidentally create a managed ChatGPT runtime write path.

## Validation

- `python3 scripts/test_sync_status_report.py`
- `python3 scripts/test_import_runtime_assets.py`
- `python3 scripts/test_operation_context.py`
- `python3 scripts/check_consistency.py`
- `git diff --check`

Closes #124.