### PR TITLE
[AF7 Baseline] Runtime adapter framework and Trae support

### DIFF
--- a/adapters/adapter_profiles.yaml
+++ b/adapters/adapter_profiles.yaml
@@ -90,6 +90,33 @@ adapters:
       references: "Full operational references similar to Codex adapter."
       canonical_mapping_required: true
 
+  trae:
+    target: "Trae CN"
+    direct_programming_agent: true
+    fidelity: full
+    supports:
+      - skill_folder
+      - SKILL.md
+      - global_skills
+      - project_instruction_import
+      - progressive_disclosure
+    outputs:
+      - adapters/trae/skills/agent-foundry/
+    included_domains: [meta, governance, runtime, architecture, agent-collaboration, implementation, testing, debugging, product]
+    command_vocabulary:
+      harvest: ["harvest practices", "做一次 harvest practice", "提炼实践", "沉淀经验"]
+      discover_assets: ["discover assets", "发现可打包资产"]
+      import: ["import skill <source>", "导入这个 skill <source>"]
+      publish: ["publish practices", "发布 practices"]
+      review: ["review practices", "检查 skill rot"]
+      review_assets: ["review assets", "检查 asset rot"]
+      refresh: ["refresh practices and assets", "刷新practices和assets"]
+    transform_policy:
+      skill_body: "Global Trae Skill dispatcher that routes to Agent Foundry canonical practices and assets."
+      global_install_path: "~/.trae-cn/skills"
+      project_overlay: "Use project-level Trae output only when the project needs extra local contract text."
+      canonical_mapping_required: true
+
   chatgpt:
     target: "ChatGPT Projects or Custom GPT"
     direct_programming_agent: true

--- a/adapters/trae/skills/agent-foundry/.agent-foundry-managed
+++ b/adapters/trae/skills/agent-foundry/.agent-foundry-managed
@@ -1,0 +1,1 @@
+managed-by: agent-foundry

--- a/adapters/trae/skills/agent-foundry/SKILL.md
+++ b/adapters/trae/skills/agent-foundry/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: agent-foundry
+description: Use in Trae CN when working with Agent Foundry practices, assets, adapters, GitHub issue workflows, multi-agent roles, runtime refresh, or capability lifecycle checks.
+---
+
+# Agent Foundry
+
+Target runtime: Trae CN global Skill.
+
+Agent Foundry turns reviewed practices and assets into runtime-ready agent capabilities. In Trae, prefer this global Skill path before project-specific configuration. Project `AGENTS.md` and `CLAUDE.md` remain the project contract when Trae imports them.
+
+## Compact Preflight
+
+Before substantial changes, check:
+
+- Duplicate or derived truth source? Apply GOV-001.
+- New machinery, layer, script, workflow, or integration? Apply GOV-002 and ARCH-001.
+- Transient memory or chat summary used as fact? Apply GOV-003.
+- Writing into user-owned runtime or agent configuration? Apply GOV-004 and RUNTIME-001.
+- Syncing, publishing, or installing adapters? Apply RUNTIME-003.
+- Producing rendered or converted output? Apply TEST-001.
+
+## Commands
+
+- harvest practices
+- 做一次 harvest practice
+- 提炼实践
+- 沉淀经验
+- discover assets
+- 发现可打包资产
+- import skill
+- 导入这个 skill
+- publish practices
+- 发布 practices
+- review practices
+- 检查 skill rot
+- review assets
+- 检查 asset rot
+- refresh practices and assets
+- 刷新practices和assets
+
+## Role Routing
+
+- Architect: planning, architecture boundaries, Execution Contracts, and human-decision gates.
+- Implementer: scoped code or docs changes with verification.
+- Reviewer: bug/risk-first review against acceptance criteria.
+- Verifier: status, command, install, and runtime freshness checks.
+- Harvester: candidate extraction only; do not activate canonical records without review.
+
+## Runtime Rules
+
+- Treat canonical practices and assets in the selected User Vault as the source of truth.
+- Treat Trae files under `~/.trae-cn/skills` as downstream runtime copies.
+- Use global Trae Skills for reusable behavior.
+- Use project overlays only when a project needs additional local contract text.
+- Do not write Trae private application state or custom-agent database records.
+- Before runtime writes, use dry-run output and resolve unmanaged or drifted files.
+- Do not start memory-system work unless the user explicitly authorizes that separate stage.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -288,7 +288,7 @@ Use this after installing a new local agent or deciding to deploy Agent Foundry 
    python3 scripts/install_foundry.py --target <target> --apply
    ```
 
-Supported local targets: `codex`, `claude-code`, `hermes`. `chatgpt` is `manual`.
+Supported local targets: `codex`, `claude-code`, `hermes`, `trae`. `chatgpt` is `manual`.
 
 ## Remove Or Pause An Agent
 
@@ -432,6 +432,14 @@ Hermes:
 ```text
 adapter: adapters/hermes/skills/
 default runtime: ~/.hermes/skills/
+ownership: managed skill directories with .agent-foundry-managed
+```
+
+Trae CN:
+
+```text
+adapter: adapters/trae/skills/
+default runtime: ~/.trae-cn/skills/
 ownership: managed skill directories with .agent-foundry-managed
 ```
 

--- a/docs/lifecycle-compatibility.md
+++ b/docs/lifecycle-compatibility.md
@@ -1,6 +1,6 @@
 # End-to-End Lifecycle Compatibility
 
-This document defines how the Agent Foundry loop works across Codex, Claude Code, Hermes, and ChatGPT.
+This document defines how the Agent Foundry loop works across Codex, Claude Code, Hermes, Trae CN, and ChatGPT.
 
 It is a design contract, not a user prompt. Daily commands remain in `docs/commands.md` and `docs/usage.md`.
 
@@ -27,21 +27,21 @@ This loop must work across heterogeneous agents without pretending they have ide
 - Human approval is required before activating new or materially changed practices or assets.
 - After approval, adapter publishing should be automatic when the runtime supports it.
 - ChatGPT is manual-import by default; do not design local automation that ChatGPT cannot run.
-- Native agent capabilities must not be degraded. Agent Foundry should augment Codex, Claude Code, Hermes, and ChatGPT rather than replacing their memory, skills, project instructions, hooks, or self-improvement paths.
+- Native agent capabilities must not be degraded. Agent Foundry should augment Codex, Claude Code, Hermes, Trae CN, and ChatGPT rather than replacing their memory, skills, project instructions, hooks, or self-improvement paths.
 - Activation is soft by default. Only runtimes with hook support can add hard pre-tool checks, and those checks must remain optional and reversible.
 
 ## Agent Capability Matrix
 
-| Capability | Codex | Claude Code | Hermes | ChatGPT |
-|---|---|---|---|---|
-| Local repo editing | yes | yes | yes | no direct local runtime |
-| Skill/procedure packaging | `SKILL.md` folders | `CLAUDE.md` plus slash commands | `SKILL.md` folders and native skills | Project instructions plus files |
-| Progressive loading | skills and references | imports, commands, referenced files | skills and references | project files / knowledge |
-| Runtime install | managed copy to `~/.codex/skills` | managed block plus files under `~/.claude` | managed copy to `~/.hermes/skills` | manual import |
-| Local scripts | yes | yes | yes | no |
-| Hard pre-tool guard | no generic Foundry hook assumed | possible with Claude Code hooks | no generic Foundry hook assumed | no |
-| Evidence recording | local script | local script or optional hook | local script | manual/exported summary |
-| Best fit | full local loop | full local loop plus optional hook experiments | full local loop while preserving native learning | soft consumption and manual sync |
+| Capability | Codex | Claude Code | Hermes | Trae CN | ChatGPT |
+|---|---|---|---|---|---|
+| Local repo editing | yes | yes | yes | yes | no direct local runtime |
+| Skill/procedure packaging | `SKILL.md` folders | `CLAUDE.md` plus slash commands | `SKILL.md` folders and native skills | global `SKILL.md` folders plus project instructions | Project instructions plus files |
+| Progressive loading | skills and references | imports, commands, referenced files | skills and references | global skills plus project `AGENTS.md` / `CLAUDE.md` imports | project files / knowledge |
+| Runtime install | managed copy to `~/.codex/skills` | managed block plus files under `~/.claude` | managed copy to `~/.hermes/skills` | managed copy to `~/.trae-cn/skills` | manual import |
+| Local scripts | yes | yes | yes | yes | no |
+| Hard pre-tool guard | no generic Foundry hook assumed | possible with Claude Code hooks | no generic Foundry hook assumed | no generic Foundry hook assumed | no |
+| Evidence recording | local script | local script or optional hook | local script | local script | manual/exported summary |
+| Best fit | full local loop | full local loop plus optional hook experiments | full local loop while preserving native learning | global-skill local loop with optional project overlays | soft consumption and manual sync |
 
 ## Lifecycle Stages
 
@@ -64,6 +64,7 @@ After locating Agent Foundry, validate Core markers such as `workflows/harvest-p
 | Codex | Use `practice-harvester` skill with references. Can edit canonical repo and run scripts. |
 | Claude Code | Use `CLAUDE.md` routing and slash commands. Can edit canonical repo and run scripts. |
 | Hermes | Use managed `practice-harvester` skill. Native Hermes memory or generated skills are candidate inputs, not replacements for canonical records. |
+| Trae CN | Use managed global Skills under `~/.trae-cn/skills`; project `AGENTS.md` / `CLAUDE.md` imports supply project-specific contracts. |
 | ChatGPT | Use project instructions and knowledge files to produce candidates. A local agent or human must apply repo changes. |
 
 Invariant: candidates are not active records until the user approves them.
@@ -89,6 +90,7 @@ Publishing converts active canonical practices and assets into agent-specific do
 | Codex | `adapters/codex/skills/*` then managed copy to `~/.codex/skills`. |
 | Claude Code | `adapters/claude-code/CLAUDE.md` and commands, then managed block/files under `~/.claude`. |
 | Hermes | `adapters/hermes/skills/*` then managed copy to `~/.hermes/skills`. |
+| Trae CN | `adapters/trae/skills/*` then managed copy to `~/.trae-cn/skills`. |
 | ChatGPT | `adapters/chatgpt/custom-instructions.md` and `adapters/chatgpt/knowledge/*`; user manually imports into a Project or Custom GPT. |
 
 Publish checks include `scripts/check_consistency.py`, `scripts/check_adapter_quality.py`, and `scripts/check_activation.py`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 # Agent Foundry Roadmap
 
-Status: planning document  
+Status: planning document
 Updated: 2026-06-15
-Scope: Agent Foundry productization, capability-system hardening, repository hygiene, and memory-system readiness.
+Scope: Agent Foundry productization, runtime adapter framework, Trae support, capability-system hardening, repository hygiene, and memory-system readiness.
 
 ## Purpose
 
@@ -76,14 +76,15 @@ Agent Foundry should use maturity stages for planning and release versions for d
 | AF-4 | Current-User Deployment And Upgrade Migration | The only real user, `farmerhunter`, can use the split system reliably across all already-deployed machines and runtime types, and Agent Foundry has a repeatable migration discipline for future major data-schema or program-structure upgrades. | The User Vault has a private remote or equivalent reviewed sync substrate; every existing deployment can locate Core plus Vault, refresh from the selected Vault, run harvest/review/publish workflows, report sync/runtime state without stale combined-root assumptions, and pass a reusable upgrade readiness checklist covering version markers, dry-runs, backups, rollback, compatibility, and cross-machine verification. |
 | AF-5 | Onboarding Ready | New users can install Core, create a blank Vault, deploy the mandatory bootstrap capability pack, optionally deploy additional capability packs, and refresh adapters without confusing pack content with private user history. | Blank Vault creation, bootstrap pack deployment, optional pack selection, runtime-asset import, and first-run refresh are tested after the current user's multi-machine migration is proven. |
 | AF-6 | Existing Foundry Lifecycle Completion | AF-5 onboarding journeys become a coherent product lifecycle: complete install, blank-vault bootstrap, non-new-install pack status/update/apply, optional pack deployment, runtime refresh/install, and rollback/status reporting. | A user can install or restore Agent Foundry, deploy or update reviewed packs, refresh runtimes, inspect status, and recover from failure through documented commands and validation without mixing Core, Vault, Generated, Runtime, or product-project contexts. |
-| AF-7 | Capability System Hardening | The post-AF6 capability system is exercised against realistic multi-user, multi-machine, multi-runtime, long-running-agent, drift, restore, parser/schema, and lifecycle edge cases. | Capability-system boundary scenarios are validated or improved through temp fixtures, status/repair UX, Project scheduler state, and safe runtime/Vault boundaries. |
-| AF-8 | Advanced Capability Pack Discovery and Lifecycle | Capability packs can be recognized, maintained, exported, and optimized as higher-level reusable bundles after the basic pack lifecycle is stable and hardened. | Emergent capability-pack discovery and export/update automation can be designed without weakening Core/Vault authority, runtime freshness, or reviewed pack deployment. |
-| AF-9 | Memory-System Ready | Future memory-system records, evidence policy, routing, privacy, and MCP boundaries are designed but not necessarily implemented. | Memory-system implementation home can be chosen with clear tradeoffs. |
-| AF-10 | Memory Implementation Home Decision | The implementation home for memory-system work is chosen using evidence from completed Foundry lifecycle and capability-system hardening work. | Decision record names the chosen home, rejected alternatives, file/data boundaries, validation path, privacy policy, and rollback path. |
+| AF-7 | Runtime Adapter Framework And Trae Support | Adapter publishing becomes a runtime-aware distribution system, and Trae CN is supported through a verified global Skill path. | Canonical assets can project through a portable adapter model into generated runtime adapters with source metadata, freshness reporting, safe install behavior, and a Trae global Skill publisher validated against `~/.trae-cn/skills`. |
+| AF-8 | Capability System Hardening | The post-AF6 capability system is exercised against realistic multi-user, multi-machine, multi-runtime, long-running-agent, drift, restore, parser/schema, and lifecycle edge cases. | Capability-system boundary scenarios are validated or improved through temp fixtures, status/repair UX, Project scheduler state, and safe runtime/Vault boundaries. |
+| AF-9 | Advanced Capability Pack Discovery and Lifecycle | Capability packs can be recognized, maintained, exported, and optimized as higher-level reusable bundles after the basic pack lifecycle is stable and hardened. | Emergent capability-pack discovery and export/update automation can be designed without weakening Core/Vault authority, runtime freshness, or reviewed pack deployment. |
+| AF-10 | Memory-System Ready | Future memory-system records, evidence policy, routing, privacy, and MCP boundaries are designed but not necessarily implemented. | Memory-system implementation home can be chosen with clear tradeoffs. |
+| AF-11 | Memory Implementation Home Decision | The implementation home for memory-system work is chosen using evidence from completed Foundry lifecycle, runtime adapter framework, and capability-system hardening work. | Decision record names the chosen home, rejected alternatives, file/data boundaries, validation path, privacy policy, and rollback path. |
 
 Current planning stage: AF-7 / M7.
 
-AF-0 explains the existing mixed history. AF-1 starts the stricter planning and multi-agent coordination era. AF-2 designs the productization boundary. AF-3 executes the local Core/Vault split. AF-4 proves the split system works for the current real user across existing deployments and establishes the migration discipline needed for later major upgrades. AF-5 makes onboarding humane and reliable for new users. AF-6 closes the current Foundry product lifecycle so install, pack deployment, refresh, status, and rollback are usable beyond a one-off maintainer path. AF-7 hardens that capability system under realistic multi-user, multi-machine, multi-runtime, long-running-agent, and drift scenarios. AF-8 is later advanced capability-pack discovery and export lifecycle work. AF-9 is the decision gate for memory-system architecture. AF-10 chooses the memory implementation home. Memory-system implementation remains outside this current roadmap until explicitly authorized.
+AF-0 explains the existing mixed history. AF-1 starts the stricter planning and multi-agent coordination era. AF-2 designs the productization boundary. AF-3 executes the local Core/Vault split. AF-4 proves the split system works for the current real user across existing deployments and establishes the migration discipline needed for later major upgrades. AF-5 makes onboarding humane and reliable for new users. AF-6 closes the current Foundry product lifecycle so install, pack deployment, refresh, status, and rollback are usable beyond a one-off maintainer path. AF-7 upgrades runtime adapters and adds Trae CN support around a verified global Skill path. AF-8 hardens the capability system under realistic multi-user, multi-machine, multi-runtime, long-running-agent, and drift scenarios. AF-9 is later advanced capability-pack discovery and export lifecycle work. AF-10 is the decision gate for memory-system architecture. AF-11 chooses the memory implementation home. Memory-system implementation remains outside this current roadmap until explicitly authorized.
 
 ## Release Version Mapping
 
@@ -99,10 +100,11 @@ Suggested mapping:
 | AF-4 | `v0.4.0`: current-user deployment and upgrade migration baseline. |
 | AF-5 | `v0.5.0`: external-user onboarding baseline. |
 | AF-6 | `v0.6.0`: complete Foundry install and basic pack lifecycle baseline. |
-| AF-7 | `v0.7.0`: capability-system hardening baseline. |
-| AF-8 | `v0.8.0`: advanced capability-pack discovery and lifecycle design baseline. |
-| AF-9 | `v0.9.0`: memory-system-ready design baseline. |
-| AF-10 | `v0.10.0`: memory implementation-home decision baseline. |
+| AF-7 | `v0.7.0`: runtime adapter framework and Trae support baseline. |
+| AF-8 | `v0.8.0`: capability-system hardening baseline. |
+| AF-9 | `v0.9.0`: advanced capability-pack discovery and lifecycle design baseline. |
+| AF-10 | `v0.10.0`: memory-system-ready design baseline. |
+| AF-11 | `v0.11.0`: memory implementation-home decision baseline. |
 
 `v1.0` should wait until the reusable core, user vault story, generated artifact policy, and runtime adapter behavior are stable enough that external users can rely on them without understanding this repository's personal history.
 
@@ -121,7 +123,7 @@ Minimal fields:
 | Field | Values | Purpose |
 | --- | --- | --- |
 | Status | Inbox, Ready, In Progress, Review, Done, Blocked | Human-visible work state. |
-| Stage | AF-1 through AF-10 | Maturity stage the item serves. |
+| Stage | AF-1 through AF-11 | Maturity stage the item serves. |
 | Epic | Free text or single-select | Groups issues by roadmap epic. |
 | Owner Role | Architect, Implementer, Reviewer, Harvester | Clarifies expected agent/human role. |
 | Depends On | Issue or PR references | Prevents ready queues from bypassing dependencies. |
@@ -139,7 +141,7 @@ Issue types:
 
 Recommended labels:
 
-- `stage:AF-1` through `stage:AF-10`
+- `stage:AF-1` through `stage:AF-11`
 - `type:epic`, `type:task`, `type:decision`, `type:review`, `type:evidence`
 - `area:core`, `area:vault`, `area:generated`, `area:runtime`, `area:privacy`, `area:memory-readiness`, `area:adapters`
 - `needs:architect`, `needs:implementer`, `needs:reviewer`, `needs:harvester`
@@ -152,7 +154,7 @@ Multi-agent rule:
 - Reviewer checks against the Epic exit criteria and relevant practices.
 - Harvester extracts reusable practices or asset candidates after meaningful work, using the harvest workflow.
 
-For now, create GitHub Project/Epic items for the active stage and its immediate successor. After AF-6 lifecycle completion, prioritize AF-7 capability-system hardening before advanced capability-pack discovery or any memory-system planning. Memory-system issues should remain placeholders until the user explicitly authorizes that work.
+For now, create GitHub Project/Epic items for the active stage and its immediate successor. After AF-6 lifecycle completion, prioritize AF-7 runtime adapter framework and Trae support, then AF-8 capability-system hardening, before advanced capability-pack discovery or any memory-system planning. Memory-system issues should remain placeholders until the user explicitly authorizes that work.
 
 ## Milestones
 
@@ -462,7 +464,7 @@ Stop conditions:
 - Vault validation depends on Core-owned `workflows/` files as Vault markers.
 - Generated adapters include personal paths, raw evidence, inactive records, or future memory-system paths.
 - The current context cannot distinguish product project, Foundry Vault operation, and Foundry Core maintenance.
-- A proposed change collapses AF-3 split migration with AF-4 current-user deployment/upgrade migration, AF-5 onboarding, AF-7 capability-system hardening, or later memory-system planning.
+- A proposed change collapses AF-3 split migration with AF-4 current-user deployment/upgrade migration, AF-5 onboarding, AF-7 runtime adapter framework work, AF-8 capability-system hardening, or later memory-system planning.
 
 Minimum verification matrix:
 
@@ -832,7 +834,7 @@ Residual gaps and explicit deferrals:
 - ChatGPT manual import and cleanup remain manual by design; no live ChatGPT project update was attempted.
 - Optional pack deployment beyond the MVP candidate fixture remains later work; #79 validates the candidate boundary, not real optional-pack rollout.
 - Real capability-owned helper install remains deferred until a reviewed helper install path is selected; helper payloads stay declared/inert in pack fixtures.
-- Advanced capability discovery, marketplace behavior, broad pack registry, automatic update management, and AF-8-style discovery remain future work.
+- Advanced capability discovery, marketplace behavior, broad pack registry, automatic update management, and AF-9-style discovery remain future work.
 - Memory-system implementation remains out of scope for AF-5 and should not be introduced by AF-5 close.
 - Current maintainer Vault bootstrap deployment state is not evidence of new-user onboarding success; temp blank-Vault fixtures are the acceptance evidence for that journey.
 
@@ -973,11 +975,55 @@ Suggested AF-6 issue order:
 | 9 | #104 Disable/retire/rollback pack lifecycle | Task | Implementer | High | #100, #101, and #102 | Reviewer + Architect acceptance |
 | 10 | #105 AF-6 end-to-end validation and close review | Review | Reviewer | High | all AF-6 child issues | Human close/main-integration decision |
 
-### AF-7 / M7: Capability System Hardening
+### AF-7 / M7: Runtime Adapter Framework And Trae Support
+
+Goal: make Agent Foundry adapter publishing runtime-aware and support Trae CN through a verified global Skill path that keeps the user's day-to-day Trae setup simple.
+
+AF-7 is adapter and runtime UX work. It does not start memory-system design or implementation. See `docs/runtime-adapter-framework-and-trae.md` for the current design.
+
+Design areas:
+
+- **Runtime adapter framework**
+  - Define a portable adapter model between canonical practices/assets and runtime-specific outputs.
+  - Track source canonical ids, versions, generator versions, target runtime, activation scope, human gates, and managed-file ownership.
+  - Make generated output and installed runtime state comparable through status, dry-run, diff, and apply flows.
+
+- **Trae CN global-first UX**
+  - Publish Trae global Skills under `~/.trae-cn/skills` as the preferred reusable setup path.
+  - Keep `.agents/skills` as a portable shared-skill option where compatible.
+  - Use project overlays only when behavior is genuinely project-specific.
+  - Do not write Trae private application state without a supported public import/export contract and explicit human approval.
+
+- **Multi-agent role projection**
+  - Project Architect, Implementer, Reviewer, Verifier, and Harvester behavior into Trae Skills or role instructions usable by SOLO Agent.
+  - Keep canonical multi-agent assets runtime-neutral where possible.
+  - Add Trae-specific wrappers only for activation, install path, UI wording, or future public Trae schemas.
+
+- **Canonical update compatibility**
+  - Ensure future canonical asset updates can refresh Trae outputs without forking practice logic.
+  - Detect fresh, stale, drifted, unmanaged, missing, blocked, and unknown runtime states before writes.
+  - Preserve fail-closed behavior for malformed or ambiguous metadata.
+
+- **Long-running use and sync UX**
+  - Show whether canonical records, generated adapters, installed Trae files, and project overlays are fresh.
+  - Provide repair actions in user terms: pull, publish adapters, dry-run install, apply install, manual import, or reopen Trae.
+
+Acceptance criteria:
+
+- Trae is represented as a target runtime in profiles, docs, validation, and status.
+- A generated Trae global Skill can be dry-run, installed, detected, refreshed, and repaired.
+- Existing multi-agent assets can project into Trae without duplicating canonical logic.
+- Project overlays remain optional and separated from global setup.
+- Runtime status distinguishes canonical, generated, installed, project, unmanaged, stale, and conflict states.
+- #134 drives AF-7 runtime adapter framework and Trae support.
+- Existing former-AF7 capability-hardening records are renumbered to AF-8 and held until AF-7 completes.
+- No memory-system directories, schemas, storage, MCP tools, or design work are introduced.
+
+### AF-8 / M8: Capability System Hardening
 
 Goal: harden the AF-6 capability system under realistic long-running, multi-user, multi-machine, multi-runtime, drift, restore, parser/schema, lifecycle, and scheduler-state scenarios.
 
-AF-7 is capability-system work. It does not start memory-system design or implementation.
+AF-8 is capability-system work. It does not start memory-system design or implementation. Existing GitHub records #119 through #127 were originally created as AF-7 work and are held as AF-8 records after the AF-7 Trae/runtime adapter reorder.
 
 Hardening areas:
 
@@ -1009,17 +1055,17 @@ Hardening areas:
 
 Acceptance criteria:
 
-- #119 through #127 or their successors cover practical boundary scenarios and are synchronized in the GitHub Project.
+- #119 through #127 or their successors cover practical boundary scenarios and are synchronized in the GitHub Project as AF-8 records.
 - Status/install/publish/lifecycle flows distinguish Core, Vault, Generated, Runtime, Local Private, manual target, and Project scheduler state.
 - Temp-root tests or evidence cover stale runtime after remote update, stale generated output after Core/Vault change, second-machine onboarding, receipt drift, manual ChatGPT boundary, and lifecycle rollback behavior.
 - Repair guidance is explicit and safe: fetch/pull, publish generated output, dry-run install, reviewed apply, manual import, or route to human review.
 - No memory-system directories, schemas, storage, MCP tools, or design work are introduced.
 
-### AF-8 / M8: Advanced Capability Pack Discovery and Lifecycle
+### AF-9 / M9: Advanced Capability Pack Discovery and Lifecycle
 
 Goal: improve whether Agent Foundry can recognize, maintain, and export higher-level capability packs that emerge from repeated work after the basic AF-6 pack lifecycle exists.
 
-This is intentionally later than repository hygiene, productization, physical split migration, current-user deployment and upgrade migration, onboarding, lifecycle completion, and capability-system hardening. Do not use this milestone to delay AF-1 through AF-7. AF-6 owns the complete install experience, basic pack status/plan/apply/update/disable lifecycle, and first optional multi-agent collaboration pack deployment path. AF-7 hardens the actual capability system in realistic user/runtime scenarios. AF-8 is for automatic discovery, advanced lifecycle optimization, export polish, and maintenance of emergent packs.
+This is intentionally later than repository hygiene, productization, physical split migration, current-user deployment and upgrade migration, onboarding, lifecycle completion, runtime adapter framework work, and capability-system hardening. Do not use this milestone to delay AF-1 through AF-8. AF-6 owns the complete install experience, basic pack status/plan/apply/update/disable lifecycle, and first optional multi-agent collaboration pack deployment path. AF-7 makes adapters runtime-aware and adds Trae support. AF-8 hardens the actual capability system in realistic user/runtime scenarios. AF-9 is for automatic discovery, advanced lifecycle optimization, export polish, and maintenance of emergent packs.
 
 Capability packs are not the same as individual assets. A future capability pack may bundle practices, assets, workflows, templates, adapter snippets, examples, configuration profiles, dependency metadata, and export/install behavior around a recurring user goal such as multi-agent collaboration or technical documentation writing.
 
@@ -1050,11 +1096,11 @@ Acceptance criteria:
 - Exportable packs do not include local-private evidence, personal vault content, or future architecture concepts as current substrate.
 - The design proves at least one existing capability cluster could be packaged without weakening Core/Vault boundaries.
 
-### AF-9 / M9: Memory-System Readiness Design
+### AF-10 / M10: Memory-System Readiness Design
 
 Goal: define memory as an adjacent future capability without implementing storage yet.
 
-AF-9 does not begin until explicitly authorized. It is intentionally after capability-system hardening and advanced capability-pack lifecycle planning.
+AF-10 does not begin until explicitly authorized. It is intentionally after runtime adapter framework work, capability-system hardening, and advanced capability-pack lifecycle planning.
 
 Epics:
 
@@ -1087,11 +1133,11 @@ Acceptance criteria:
 - Open questions remain visible.
 - No automatic memory writing exists.
 
-### AF-10 / M10: Memory Implementation Home Decision
+### AF-11 / M11: Memory Implementation Home Decision
 
-Goal: decide the implementation home for memory-system work using evidence from AF-1 through AF-9.
+Goal: decide the implementation home for memory-system work using evidence from AF-1 through AF-10.
 
-AF-10 is a decision stage, not implementation. It does not authorize creating memory directories, schemas, MCP write tools, or storage.
+AF-11 is a decision stage, not implementation. It does not authorize creating memory directories, schemas, MCP write tools, or storage.
 
 Decision options:
 
@@ -1131,9 +1177,9 @@ Acceptance criteria:
 
 ## Future Memory-System Implementation
 
-Goal: implement a reviewed memory/knowledge MVP only after Foundry lifecycle, capability-system hardening, memory readiness, and implementation-home decisions are complete, and only after explicit user authorization.
+Goal: implement a reviewed memory/knowledge MVP only after Foundry lifecycle, runtime adapter framework work, capability-system hardening, memory readiness, and implementation-home decisions are complete, and only after explicit user authorization.
 
-Expected scope will be defined by AF-9 and AF-10. Until then, memory-system implementation is a future placeholder, not a license to create memory directories, schemas, or MCP write tools now.
+Expected scope will be defined by AF-10 and AF-11. Until then, memory-system implementation is a future placeholder, not a license to create memory directories, schemas, or MCP write tools now.
 
 ## Work Not To Do Yet
 
@@ -1143,14 +1189,14 @@ Expected scope will be defined by AF-9 and AF-10. Until then, memory-system impl
 - Do not add MCP write tools.
 - Do not import raw ChatGPT exports.
 - Do not implement memory-system design or implementation before explicit user authorization.
-- Do not refactor adapters or runtime install behavior until repository hygiene policy exists.
+- Do not refactor adapters or runtime install behavior outside reviewed AF-7 adapter framework scope.
 
 ## Immediate Next Planning Tasks
 
 1. Treat AF-6 as merged and complete through #116 and #105.
-2. Use #119 as the AF-7 capability-system hardening Epic.
-3. Start #120 first as the scenario matrix and acceptance-gate pass.
-4. Release #121, #122, #125, #126, and #127 against the scenario matrix where possible.
-5. Let #123 and #124 proceed independently when scoped to parser/schema robustness and manual-target policy.
-6. Keep AF-8 advanced capability-pack discovery out of implementation until AF-7 hardening evidence is accepted.
-7. Do not begin AF-9/AF-10 memory-system readiness or implementation-home work until explicitly authorized by the user.
+2. Treat the Trae/runtime adapter framework work as the active AF-7 stage.
+3. Use #134 as the AF-7 runtime adapter framework and Trae support Epic.
+4. Rename and hold #119 through #127 as AF-8 capability-system hardening records.
+5. Keep the existing AF-8 implementation PRs held until AF-7 is complete or the user explicitly resumes them.
+6. Keep AF-9 advanced capability-pack discovery out of implementation until AF-8 hardening evidence is accepted.
+7. Do not begin AF-10/AF-11 memory-system readiness or implementation-home work until explicitly authorized by the user.

--- a/docs/runtime-adapter-framework-and-trae.md
+++ b/docs/runtime-adapter-framework-and-trae.md
@@ -1,0 +1,159 @@
+# Runtime Adapter Framework And Trae Support
+
+Status: proposed AF-7 design  
+Updated: 2026-06-15
+
+## Purpose
+
+AF-7 makes Agent Foundry runtime adapters more explicit and adds first-class Trae CN support. The user experience goal is that Trae can use reviewed Agent Foundry practices and assets with minimal manual setup, while Core and the selected User Vault remain the source of truth.
+
+This stage does not start memory-system work.
+
+## Design Goals
+
+- Make runtime setup simple: publish once, then refresh or repair with clear status.
+- Prefer global runtime configuration when the runtime supports it.
+- Preserve project-level contracts through `AGENTS.md`, `CLAUDE.md`, and project overlays when needed.
+- Support multi-agent role behavior without requiring users to hand-maintain runtime-specific prompts.
+- Keep canonical practices and assets compatible with future updates.
+- Make stale, drifted, unmanaged, or partially installed runtime state visible before writes.
+
+## Verified Trae CN Facts
+
+Local experiments on 2026-06-15 verified:
+
+- Trae CN uses `~/.trae-cn` as a global configuration root.
+- Trae CN discovers global skills from `~/.trae-cn/skills`.
+- A global Skill placed at `~/.trae-cn/skills/<skill-id>/SKILL.md` was loaded by Trae SOLO Agent and executed successfully.
+- Trae CN also scans `.agents/skills` style skill locations, making a portable shared skill layer plausible.
+- Trae CN imports project instruction files such as `AGENTS.md` and `CLAUDE.md` when that feature is enabled.
+- Trae custom agent definitions appear to live in private application state, not a stable public file schema.
+
+Implication: Agent Foundry should publish Trae support primarily as generated global Skills plus optional project overlays, and should not write Trae private application state until Trae exposes a supported import/export contract.
+
+## User Experience Model
+
+The normal Trae flow should be:
+
+1. User installs or updates Agent Foundry Core and selects a User Vault.
+2. Agent Foundry publishes generated adapters from active canonical practices and assets.
+3. Agent Foundry installs or refreshes Trae global Skills under `~/.trae-cn/skills` after a dry-run shows planned writes.
+4. In a project, Trae reads project contracts from `AGENTS.md` and `CLAUDE.md`.
+5. The user works through Trae SOLO Agent or a Trae custom agent that invokes the installed Agent Foundry Skills.
+6. Agent Foundry status reports whether canonical records, generated adapters, installed Trae files, and project overlays are fresh.
+
+The user should not need to copy large prompts into every Trae project. Project-level setup should be limited to contracts that are genuinely project-specific.
+
+## Architecture
+
+Agent Foundry should treat adapters as runtime projections with four layers:
+
+```text
+canonical practice or asset
+  -> portable adapter intermediate representation
+  -> runtime-specific generated adapter
+  -> machine-local installed runtime copy
+```
+
+The portable adapter intermediate representation should describe:
+
+- source canonical ids and versions;
+- target capability type, such as instruction, skill, command, role prompt, helper script, or project overlay;
+- activation semantics, such as global, project, manual import, or runtime-managed;
+- required human review gates;
+- privacy and local-write constraints;
+- generated file ownership markers;
+- compatibility and migration metadata.
+
+Runtime publishers then map that representation into Codex, Claude Code, Hermes, ChatGPT/manual import, Trae, or future targets.
+
+## Trae Adapter Shape
+
+Trae should have three output scopes:
+
+- **Global native scope**: generated Trae Skills under `~/.trae-cn/skills`. This is the preferred path for reusable Agent Foundry behavior.
+- **Portable shared scope**: generated `.agents/skills` output when a skill should remain usable across runtimes that understand the shared skill convention.
+- **Project overlay scope**: generated `.trae/` or project contract snippets only for project-specific behavior that cannot safely live globally.
+
+Trae global Skills should be thin wrappers around canonical Agent Foundry content. They can include Trae-specific activation text, examples, and command wiring, but they should not fork canonical practice logic.
+
+## Multi-Agent Role Mapping
+
+Trae currently works best as a coordinator runtime rather than as a fully file-backed multi-agent registry. Agent Foundry should map roles this way:
+
+| Agent Foundry role | Trae mapping |
+| --- | --- |
+| Architect | Trae Skill or role instruction invoked by SOLO Agent for planning, contracts, issue shaping, and human-decision gates. |
+| Implementer | Trae Skill or task prompt for scoped implementation with validation expectations. |
+| Reviewer | Trae Skill for bug/risk-first review and acceptance-gate checking. |
+| Verifier | Trae Skill for local command, UI, and runtime freshness verification. |
+| Harvester | Trae Skill for proposing candidates, never directly activating canonical records. |
+
+If Trae later exposes a stable custom-agent file schema or CLI import path, Agent Foundry can add a custom-agent publisher. Until then, generated Skills are the safer integration point.
+
+## Asset Compatibility
+
+Existing runtime-neutral multi-agent assets remain useful if they avoid Codex-only assumptions. The Trae adapter should add only the runtime-specific layer needed to activate those assets:
+
+- Trae-facing `SKILL.md` wrappers;
+- launcher instructions that call existing helper scripts;
+- status and repair guidance that names Trae install paths;
+- role-specific prompt packaging for Trae's interaction model.
+
+Trae-specific assets are justified only when Trae has unique behavior that cannot be represented by the portable adapter layer, such as Skill discovery, UI activation wording, or future custom-agent import formats.
+
+## Canonical Update Compatibility
+
+Generated Trae files must stay compatible with future canonical asset updates:
+
+- Every generated file should include a managed marker, source canonical ids, source version or hash, generator version, and target runtime.
+- Status should distinguish fresh, stale, drifted, unmanaged, missing, blocked, and unknown states.
+- Refresh should support dry-run, diff, and apply.
+- Local edits to managed files should be detected before overwrite.
+- Adapter generation should tolerate additive canonical metadata changes and fail closed on ambiguous or malformed metadata.
+
+Canonical content remains authoritative. Runtime copies are replaceable projections.
+
+## Sync And Long-Running Use
+
+Trae support must handle long-running agent usage where Core, Vault, generated output, or runtime installs changed elsewhere:
+
+- report whether the local repo is behind remote progress when that evidence is available;
+- report whether generated adapters are stale relative to canonical records;
+- report whether installed Trae files are stale relative to generated output;
+- separate project overlay freshness from global Skill freshness;
+- give repair actions in user terms: pull, publish adapters, dry-run install, apply install, or reopen Trae.
+
+This is part of capability-system hardening, not memory-system work.
+
+## Human Decision Points
+
+AF-7 requires human decisions for:
+
+- approving writes to `~/.trae-cn/skills` on the current machine;
+- approving any project-specific `.trae/` output;
+- accepting unmanaged-file overwrite or local-edit conflict resolution;
+- approving any future attempt to write Trae private application state;
+- approving activation of new or changed canonical practices/assets before publishing;
+- deciding whether a Trae-specific asset is warranted instead of a portable wrapper.
+
+## Risks
+
+- Trae's public extension surface may change without a stable schema.
+- Trae custom-agent state may remain private and unsafe to automate.
+- Global Skills may not cover every desired multi-agent UX.
+- `.agents/skills` portability is promising but still needs cross-runtime compatibility checks.
+- Runtime hot reload behavior may require user-visible restart or refresh guidance.
+- Generated wrappers can drift from canonical assets if source metadata and receipt checks are weak.
+
+## AF-7 Acceptance Model
+
+AF-7 is complete when:
+
+- the adapter framework has a documented portable intermediate model;
+- Trae is represented as a target runtime in profiles, docs, validation, and status;
+- a generated Trae global Skill can be dry-run, installed, detected, refreshed, and repaired;
+- project overlays are optional and clearly separated from global setup;
+- existing multi-agent assets can be projected into Trae without duplicating canonical logic;
+- runtime status distinguishes canonical, generated, installed, project, unmanaged, stale, and conflict states;
+- the old capability-system hardening Epic is renumbered and held for AF-8.

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -137,7 +137,7 @@ Current repository mapping:
 | `indexes/` | User Vault | Registry for the current vault's records. |
 | `usage/usage-aggregate.yaml` | User Vault shared aggregate | Sanitized, but still specific to this vault. |
 | `imports/` | User Vault staging machinery plus tracked instructions | Directory convention may become Core; staged content is Vault/evidence. |
-| `adapters/codex/`, `adapters/claude-code/`, `adapters/hermes/`, `adapters/chatgpt/` | Generated distribution outputs | Tracked for install/manual import; regenerate from Core plus target Vault. |
+| `adapters/codex/`, `adapters/claude-code/`, `adapters/hermes/`, `adapters/trae/`, `adapters/chatgpt/` | Generated distribution outputs | Tracked for install/manual import; regenerate from Core plus target Vault. |
 | `runtime/local/`, `sync/local/`, `usage/local/` | Local Private | Gitignored machine-local state. |
 | `Agent Foundry.md` | User Vault navigation | Maintainer hub, not required for external users. |
 | `.claude/settings.json` | Maintainer/runtime-specific setting | Boundary-sensitive; should not be product setup guidance without review. |
@@ -1039,8 +1039,8 @@ Use these categories:
 | --- | --- | --- | --- |
 | Core source | `workflows/`, `schemas/`, `templates/`, source scripts, `adapters/adapter_profiles.yaml`, adapter quality rules, product docs | Tracked in public Core | Source-maintained tooling and operating rules |
 | User Vault canonical records | `practices/`, `assets/`, `indexes/`, reviewed imports, `usage/usage-aggregate.yaml` | Tracked in the selected User Vault, not public Core by default | Human-reviewed canonical records and sanitized Vault metadata |
-| Tracked generated distribution output | `adapters/codex/`, `adapters/hermes/`, `adapters/claude-code/`, `adapters/chatgpt/` | Tracked when needed for runtime install, manual import, review, or distribution | Canonical practices/assets plus adapter profiles |
-| Runtime copy | Installed files under `~/.codex`, `~/.claude`, `~/.hermes`, and manual ChatGPT imports | Not tracked here | Regenerated or installed from `adapters/` |
+| Tracked generated distribution output | `adapters/codex/`, `adapters/hermes/`, `adapters/trae/`, `adapters/claude-code/`, `adapters/chatgpt/` | Tracked when needed for runtime install, manual import, review, or distribution | Canonical practices/assets plus adapter profiles |
+| Runtime copy | Installed files under `~/.codex`, `~/.claude`, `~/.hermes`, `~/.trae-cn`, and manual ChatGPT imports | Not tracked here | Regenerated or installed from `adapters/` |
 | Local private/generated operational state | `runtime/local/`, `usage/local/`, `usage/adoption-log.yaml`, `sync/local/`, `sync/imported/`, `sync/pending/`, `sync/applied/`, `sync/conflicts/`, `sync/snapshots/` | Gitignored by default | Local runtime, sync, or evidence workflows |
 | Shared aggregate or derived metadata | Future Core-owned derived indexes if approved | Tracked only when sanitized, reviewable, and Core-owned | Derived metadata, not raw local evidence |
 
@@ -1086,7 +1086,7 @@ Default classifications:
 | Offline sync operational state | `sync/local/`, `sync/imported/`, `sync/pending/`, `sync/applied/`, `sync/conflicts/`, `sync/snapshots/` | Ignored |
 | External skill staging instructions | `imports/*/INSTRUCTIONS.md` in the selected User Vault or future Core templates | Tracked only in the owning layer |
 | Raw external imports or exports | downloaded skills, raw chat exports, transcripts, source dumps, sensitive review packets | Not committed by default; stage only after explicit review |
-| Runtime adapter outputs | `adapters/codex/`, `adapters/claude-code/`, `adapters/hermes/`, `adapters/chatgpt/` | Tracked distribution/manual-import outputs |
+| Runtime adapter outputs | `adapters/codex/`, `adapters/claude-code/`, `adapters/hermes/`, `adapters/trae/`, `adapters/chatgpt/` | Tracked distribution/manual-import outputs |
 | User workspace affordances | `Agent Foundry.md`, Obsidian-oriented metadata, local agent settings | Treat as User Vault or maintainer-local unless promoted into Core by review |
 
 Rules:

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -16,7 +16,7 @@ discover repeated work and reusable lessons
   -> review and improve
 ```
 
-See docs/lifecycle-compatibility.md for how this loop adapts across Codex, Claude Code, Hermes, and ChatGPT from harvest through activation, evidence, and review.
+See docs/lifecycle-compatibility.md for how this loop adapts across Codex, Claude Code, Hermes, and ChatGPT from harvest through activation, evidence, and review. See docs/runtime-adapter-framework-and-trae.md for the proposed AF-7 runtime adapter framework and Trae support model.
 
 ## Core Principle
 
@@ -354,7 +354,7 @@ Standard upgrade checklist:
 - run at least one real workflow smoke test;
 - verify another deployment can pull/sync the result;
 - record residual risks and intentionally deferred deployments;
-- keep AF-5 onboarding, AF-7 capability-system hardening, and later memory-system planning out of the upgrade unless explicitly scoped.
+- keep AF-5 onboarding, AF-7 runtime adapter framework work, AF-8 capability-system hardening, and later memory-system planning out of the upgrade unless explicitly scoped.
 
 Future split options:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,7 +8,7 @@ This guide is for day-to-day use. You do not need to remember the internal workf
 
 ## How It Works
 
-Agent Foundry is a **local-first** system with separate Core, User Vault, and runtime layers. The public Core checkout contains workflows, schemas, scripts, templates, docs, and adapter profiles. Canonical practices, assets, indexes, imports, and shared usage aggregates live in the selected User Vault. Installed agent files under `~/.claude`, `~/.codex`, and `~/.hermes` are downstream copies.
+Agent Foundry is a **local-first** system with separate Core, User Vault, and runtime layers. The public Core checkout contains workflows, schemas, scripts, templates, docs, and adapter profiles. Canonical practices, assets, indexes, imports, and shared usage aggregates live in the selected User Vault. Installed agent files under `~/.claude`, `~/.codex`, `~/.hermes`, and `~/.trae-cn` are downstream copies.
 
 ```text
 work session or external skill
@@ -20,7 +20,7 @@ work session or external skill
   -> use short commands to invoke assets
 ```
 
-工作方式：Agent Foundry 是本地优先的系统，并区分 Core、User Vault、runtime 三层。public Core checkout 保存 workflows、schemas、scripts、templates、docs 和 adapter profiles。canonical practices、assets、indexes、imports 和共享 usage aggregate 存在选中的 User Vault。`~/.claude`、`~/.codex`、`~/.hermes` 下的文件是下游副本。
+工作方式：Agent Foundry 是本地优先的系统，并区分 Core、User Vault、runtime 三层。public Core checkout 保存 workflows、schemas、scripts、templates、docs 和 adapter profiles。canonical practices、assets、indexes、imports 和共享 usage aggregate 存在选中的 User Vault。`~/.claude`、`~/.codex`、`~/.hermes`、`~/.trae-cn` 下的文件是下游副本。
 
 ---
 
@@ -72,7 +72,7 @@ python3 scripts/foundry_config.py write --core-root . --vault-root ~/.agent-foun
 python3 scripts/foundry_config.py status
 python3 scripts/runtime_manifest.py init
 python3 scripts/runtime_manifest.py detect
-python3 scripts/runtime_manifest.py enable claude-code   # or codex, hermes
+python3 scripts/runtime_manifest.py enable claude-code   # or codex, hermes, trae
 python3 scripts/install_foundry.py --apply
 ```
 

--- a/runtime/templates/runtime_manifest.template.yaml
+++ b/runtime/templates/runtime_manifest.template.yaml
@@ -48,6 +48,19 @@ targets:
         - ~/.hermes/skills
     notes: "Hermes native memory and self-growth remain enabled; Agent Foundry skills are managed runtime copies."
 
+  trae:
+    adapter: trae
+    status: disabled
+    install_path: ~/.trae-cn/skills
+    ownership_mode: managed-directories
+    conflict_policy: refuse-unmanaged
+    backup_policy: none
+    detection:
+      default_path: ~/.trae-cn/skills
+      marker_paths:
+        - ~/.trae-cn/skills
+    notes: "Trae CN global Skills are installed as managed skill directories. Project overlays remain optional."
+
   chatgpt:
     adapter: chatgpt
     status: manual

--- a/scripts/adapter_install_receipt.py
+++ b/scripts/adapter_install_receipt.py
@@ -13,6 +13,7 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 RECEIPT_PATH = ROOT / "runtime" / "local" / "adapter-install-receipt.yaml"
+SKILL_FOLDER_TARGETS = {"codex", "hermes", "trae"}
 
 
 def file_sha256(path: Path) -> str:
@@ -36,7 +37,7 @@ def git_commit(root: Path) -> str:
 
 
 def source_files_for_target(adapter_root: Path, target: str) -> list[tuple[Path, Path]]:
-    if target in {"codex", "hermes"}:
+    if target in SKILL_FOLDER_TARGETS:
         src = adapter_root / target / "skills"
         return [(path, path.relative_to(adapter_root)) for path in sorted(src.rglob("*")) if path.is_file()] if src.exists() else []
     if target == "claude-code":
@@ -53,7 +54,7 @@ def source_files_for_target(adapter_root: Path, target: str) -> list[tuple[Path,
 
 
 def destination_for_source(target: str, source_rel: Path, install_path: Path) -> Path | None:
-    if target in {"codex", "hermes"}:
+    if target in SKILL_FOLDER_TARGETS:
         prefix = Path(target) / "skills"
         rel = source_rel.relative_to(prefix)
         return install_path / rel

--- a/scripts/check_adapter_quality.py
+++ b/scripts/check_adapter_quality.py
@@ -16,6 +16,8 @@ from foundry_config import CONFIG_PATH, parse_config
 
 DEFAULT_ROOT = Path(__file__).resolve().parents[1]
 ACTIVE_STATUSES = {"active", "revised"}
+SKILL_FOLDER_ADAPTERS = {"codex", "hermes", "trae"}
+TRAE_COMPATIBLE_SKILL_ADAPTERS = {"codex", "hermes"}
 
 
 def configured_vault_root() -> Path:
@@ -245,8 +247,10 @@ def check_generated_skill_artifacts(generated_root: Path, vault_root: Path) -> l
         published_to = record.get("published_to", [])
         if not isinstance(published_to, list):
             continue
-        for adapter_id in ("codex", "hermes"):
-            if adapter_id not in published_to:
+        for adapter_id in sorted(SKILL_FOLDER_ADAPTERS):
+            if adapter_id not in published_to and not (
+                adapter_id == "trae" and TRAE_COMPATIBLE_SKILL_ADAPTERS.intersection(published_to)
+            ):
                 continue
             path = expected_skill_path(generated_root, adapter_id, str(record["slug"]))
             if not path.exists():

--- a/scripts/publish_adapters.py
+++ b/scripts/publish_adapters.py
@@ -14,6 +14,8 @@ from operation_context import configured_roots, print_operation_context
 
 
 ACTIVE_STATUSES = {"active", "revised"}
+SKILL_FOLDER_ADAPTERS = {"codex", "hermes", "trae"}
+TRAE_COMPATIBLE_SKILL_ADAPTERS = {"codex", "hermes"}
 
 
 def read(path: Path) -> str:
@@ -352,8 +354,10 @@ def write_generated_skill_outputs(
         published_to = record.get("published_to", [])
         if not isinstance(published_to, list):
             continue
-        for adapter_id in ("codex", "hermes"):
-            if adapter_id not in published_to:
+        for adapter_id in sorted(SKILL_FOLDER_ADAPTERS):
+            if adapter_id not in published_to and not (
+                adapter_id == "trae" and TRAE_COMPATIBLE_SKILL_ADAPTERS.intersection(published_to)
+            ):
                 continue
             target = output_root / adapter_id / "skills" / str(record["slug"]) / "SKILL.md"
             written.append(target)

--- a/scripts/runtime_manifest.py
+++ b/scripts/runtime_manifest.py
@@ -27,7 +27,53 @@ def ensure_local_manifest() -> None:
 
 def read_manifest() -> list[str]:
     ensure_local_manifest()
-    return LOCAL_MANIFEST.read_text(encoding="utf-8").splitlines()
+    lines = LOCAL_MANIFEST.read_text(encoding="utf-8").splitlines()
+    if TEMPLATE_MANIFEST.exists():
+        return merge_template_targets(lines, TEMPLATE_MANIFEST.read_text(encoding="utf-8").splitlines())
+    return lines
+
+
+def target_blocks(lines: list[str]) -> dict[str, list[str]]:
+    blocks: dict[str, list[str]] = {}
+    current: str | None = None
+    current_lines: list[str] = []
+    in_targets = False
+    for line in lines:
+        if line == "targets:":
+            in_targets = True
+            continue
+        if not in_targets:
+            continue
+        if line.startswith("  ") and not line.startswith("    ") and line.rstrip().endswith(":"):
+            if current is not None:
+                blocks[current] = current_lines
+            current = line.strip().removesuffix(":")
+            current_lines = [line]
+            continue
+        if current is not None:
+            current_lines.append(line)
+    if current is not None:
+        blocks[current] = current_lines
+    return blocks
+
+
+def merge_template_targets(local_lines: list[str], template_lines: list[str]) -> list[str]:
+    if "targets:" not in local_lines:
+        return local_lines
+    local_targets = parse_targets(local_lines)
+    additions = [block for name, block in target_blocks(template_lines).items() if name not in local_targets]
+    if not additions:
+        return local_lines
+    merged = list(local_lines)
+    if merged and merged[-1].strip():
+        merged.append("")
+    for block in additions:
+        merged.extend(block)
+        if merged[-1].strip():
+            merged.append("")
+    while merged and not merged[-1].strip():
+        merged.pop()
+    return merged
 
 
 def write_manifest(lines: list[str]) -> None:

--- a/scripts/sync_adapters.py
+++ b/scripts/sync_adapters.py
@@ -21,6 +21,7 @@ DEFAULT_DESTS = {
     "codex": HOME / ".codex" / "skills",
     "claude-code": HOME / ".claude",
     "hermes": HOME / ".hermes" / "skills",
+    "trae": HOME / ".trae-cn" / "skills",
 }
 
 MANAGED_MARKER = ".agent-foundry-managed"
@@ -138,6 +139,11 @@ def sync_hermes(adapter_root: Path, dest: Path, apply: bool, adopt: bool) -> lis
     return copy_skill_dirs(src, dest, apply, adopt)
 
 
+def sync_trae(adapter_root: Path, dest: Path, apply: bool, adopt: bool) -> list[tuple[Action, Path, Path]]:
+    src = adapter_root / "trae" / "skills"
+    return copy_skill_dirs(src, dest, apply, adopt)
+
+
 def sync_claude(adapter_root: Path, dest: Path, apply: bool, backup: bool) -> list[tuple[Action, Path, Path]]:
     copied: list[tuple[Action, Path, Path]] = []
     src_root = adapter_root / "claude-code"
@@ -176,7 +182,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Sync Agent Foundry adapters.")
     parser.add_argument(
         "--target",
-        choices=["all", "codex", "claude-code", "hermes", "chatgpt"],
+        choices=["all", "codex", "claude-code", "hermes", "trae", "chatgpt"],
         default="all",
     )
     parser.add_argument("--dest", help="Override destination for a single target.")
@@ -192,7 +198,7 @@ def main() -> int:
     if args.dry_run:
         apply = False
 
-    targets = ["codex", "claude-code", "hermes", "chatgpt"] if args.target == "all" else [args.target]
+    targets = ["codex", "claude-code", "hermes", "trae", "chatgpt"] if args.target == "all" else [args.target]
     if args.dest and len(targets) != 1:
         raise SystemExit("--dest can only be used with a single --target")
 
@@ -206,6 +212,8 @@ def main() -> int:
             all_copied.extend(sync_claude(adapter_root, dest, apply, not args.no_backup))
         elif target == "hermes":
             all_copied.extend(sync_hermes(adapter_root, dest, apply, args.adopt))
+        elif target == "trae":
+            all_copied.extend(sync_trae(adapter_root, dest, apply, args.adopt))
         elif target == "chatgpt":
             all_copied.extend(sync_chatgpt(adapter_root, Path(args.dest).expanduser() if args.dest else None, apply))
 

--- a/scripts/sync_status.py
+++ b/scripts/sync_status.py
@@ -16,6 +16,7 @@ from operation_context import text_report, build_context
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_GENERATED_ROOT = Path.home() / ".agent-foundry" / "generated" / "agent-foundry-adapters"
+SKILL_FOLDER_TARGETS = {"codex", "hermes", "trae"}
 
 
 def run_git(args: list[str]) -> str:
@@ -368,10 +369,8 @@ def runtime_drift_status(receipt_path: Path = RECEIPT_PATH) -> str:
             lines.append(f"{name}: skipped status={config.get('status')}")
             continue
         dest = Path(config.get("install_path", "")).expanduser()
-        if name == "codex":
-            checked, missing, changed = compare_tree(ROOT / "adapters" / "codex" / "skills", dest)
-        elif name == "hermes":
-            checked, missing, changed = compare_tree(ROOT / "adapters" / "hermes" / "skills", dest)
+        if name in SKILL_FOLDER_TARGETS:
+            checked, missing, changed = compare_tree(ROOT / "adapters" / name / "skills", dest)
         elif name == "claude-code":
             managed = dest / "agent-foundry" / "CLAUDE.md"
             commands = dest / "commands" / "agent-foundry"

--- a/scripts/test_adapter_install_receipt.py
+++ b/scripts/test_adapter_install_receipt.py
@@ -22,6 +22,7 @@ def main() -> int:
         adapter = root / "generated"
         codex_dest = root / "runtime" / "codex"
         hermes_dest = root / "runtime" / "hermes"
+        trae_dest = root / "runtime" / "trae"
         receipt = root / "receipt.yaml"
         for repo in (core, vault):
             (repo / ".git").mkdir(parents=True)
@@ -29,14 +30,16 @@ def main() -> int:
         write(adapter / "adapter-publish-manifest.yaml", "active_assets:\n  - ASSET-COLLAB-002\n")
         write(adapter / "codex" / "skills" / "role-automation-planner" / "SKILL.md", "codex skill\n")
         write(adapter / "hermes" / "skills" / "role-automation-planner" / "SKILL.md", "hermes skill\n")
+        write(adapter / "trae" / "skills" / "role-automation-planner" / "SKILL.md", "trae skill\n")
         write(codex_dest / "role-automation-planner" / "SKILL.md", "codex skill\n")
         write(hermes_dest / "role-automation-planner" / "SKILL.md", "hermes skill\n")
+        write(trae_dest / "role-automation-planner" / "SKILL.md", "trae skill\n")
 
         write_receipt(
             core_root=core,
             vault_root=vault,
             adapter_root=adapter,
-            installed_targets={"codex": codex_dest, "hermes": hermes_dest},
+            installed_targets={"codex": codex_dest, "hermes": hermes_dest, "trae": trae_dest},
             receipt_path=receipt,
         )
 
@@ -47,6 +50,7 @@ def main() -> int:
         targets = receipt_target_statuses(loaded)
         assert targets["codex"][0] == "selected-output-in-sync"
         assert targets["hermes"][0] == "selected-output-in-sync"
+        assert targets["trae"][0] == "selected-output-in-sync"
 
         write(codex_dest / "role-automation-planner" / "SKILL.md", "changed\n")
         state, problems = receipt_status(loaded)
@@ -55,6 +59,7 @@ def main() -> int:
         targets = receipt_target_statuses(loaded)
         assert targets["codex"][0] == "selected-output-drift"
         assert targets["hermes"][0] == "selected-output-in-sync"
+        assert targets["trae"][0] == "selected-output-in-sync"
 
     print("Adapter install receipt tests passed.")
     return 0

--- a/scripts/test_adapter_quality_split.py
+++ b/scripts/test_adapter_quality_split.py
@@ -173,7 +173,8 @@ def main() -> int:
         errors.extend(expect("selected-output-promoted-asset", selected_quality, True, "selected-output surface"))
         codex_skill = generated / "codex" / "skills" / "role-automation-planner" / "SKILL.md"
         hermes_skill = generated / "hermes" / "skills" / "role-automation-planner" / "SKILL.md"
-        for name, path in [("codex", codex_skill), ("hermes", hermes_skill)]:
+        trae_skill = generated / "trae" / "skills" / "role-automation-planner" / "SKILL.md"
+        for name, path in [("codex", codex_skill), ("hermes", hermes_skill), ("trae", trae_skill)]:
             if not path.exists():
                 errors.append(f"selected-output-promoted-asset: {name} generated SKILL.md missing: {path}")
                 continue

--- a/scripts/test_runtime_manifest.py
+++ b/scripts/test_runtime_manifest.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Regression tests for runtime manifest template upgrades."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import runtime_manifest
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="agent-foundry-runtime-manifest.") as raw:
+        base = Path(raw)
+        local = base / "runtime" / "local" / "runtime_manifest.yaml"
+        template = base / "runtime" / "templates" / "runtime_manifest.template.yaml"
+        write(
+            local,
+            "\n".join(
+                [
+                    "schema_version: 1",
+                    "updated: 2026-06-01",
+                    "",
+                    "targets:",
+                    "  codex:",
+                    "    status: disabled",
+                    "    install_path: ~/.codex/skills",
+                    "    ownership_mode: managed-directories",
+                    "",
+                ]
+            ),
+        )
+        write(
+            template,
+            "\n".join(
+                [
+                    "schema_version: 1",
+                    "updated: 2026-06-15",
+                    "",
+                    "targets:",
+                    "  codex:",
+                    "    status: disabled",
+                    "    install_path: ~/.codex/skills",
+                    "    ownership_mode: managed-directories",
+                    "  trae:",
+                    "    status: disabled",
+                    "    install_path: ~/.trae-cn/skills",
+                    "    ownership_mode: managed-directories",
+                    "",
+                ]
+            ),
+        )
+
+        original_local = runtime_manifest.LOCAL_MANIFEST
+        original_template = runtime_manifest.TEMPLATE_MANIFEST
+        try:
+            runtime_manifest.LOCAL_MANIFEST = local
+            runtime_manifest.TEMPLATE_MANIFEST = template
+            before = local.read_text(encoding="utf-8")
+
+            targets = runtime_manifest.parse_targets(runtime_manifest.read_manifest())
+            assert "trae" in targets, targets
+            assert local.read_text(encoding="utf-8") == before
+
+            runtime_manifest.set_target_status("trae", "enabled")
+            written = local.read_text(encoding="utf-8")
+            assert "  trae:" in written, written
+            assert "    status: enabled" in written, written
+        finally:
+            runtime_manifest.LOCAL_MANIFEST = original_local
+            runtime_manifest.TEMPLATE_MANIFEST = original_template
+
+    print("Runtime manifest tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_sync_status_report.py
+++ b/scripts/test_sync_status_report.py
@@ -102,6 +102,10 @@ def main() -> int:
                         "    status: manual",
                         "    install_path: \"\"",
                         "    ownership_mode: manual-import",
+                        "  trae:",
+                        "    status: disabled",
+                        "    install_path: ~/.trae-cn/skills",
+                        "    ownership_mode: managed-directories",
                         "",
                     ]
                 ),
@@ -109,6 +113,7 @@ def main() -> int:
             sync_status.ROOT = fake_core
             text = runtime_status()
             assert "manifest_source: template-read-only" in text, text
+            assert "trae: status=disabled path=~/.trae-cn/skills exists=" in text, text
             assert not (fake_core / "runtime" / "local" / "runtime_manifest.yaml").exists()
         finally:
             sync_status.ROOT = original_root


### PR DESCRIPTION
## Correction Note

This merged PR is a historical AF7 baseline batch, not the AF7 planning artifact.

It combined design, implementation, verification, live Trae apply, and first runtime validation before the AF7 child issue plan was reconstructed. That violated the intended Epic -> child issue -> scoped PR/evidence workflow. The corrected planning surface now lives in #134, with remaining AF7 work split across #136 and #138 through #144.

## Summary

- adds the AF7 runtime adapter framework and Trae support design document
- updates the roadmap so new AF7 is Trae/runtime adapter work, old AF7 becomes AF8, and later stages shift to AF9-AF11
- adds Trae CN as a runtime adapter target with a global Skill dispatcher under `adapters/trae/skills/agent-foundry/`
- adds Trae selected-output generation, sync dry-run/install support, receipt/drift handling, runtime manifest template support, and docs
- keeps memory-system work explicitly out of scope

## GitHub Sync

- Opened #134 as the new `[AF7 Epic] Runtime adapter framework and Trae support`
- Renamed #119-#127 to `[AF8 ...]` and marked them held
- Renamed open former-AF7 PRs #129-#133 to `[AF8 ...]` and marked them held

This PR established a baseline batch. It did not complete #134. The remaining work is governed by #134, #136, and #138 through #144.

## Verification

- `git diff --check`
- `python3 scripts/check_consistency.py`
- `python3 scripts/check_adapter_quality.py --surface core`
- `python3 scripts/test_adapter_quality_split.py`
- `python3 scripts/test_adapter_install_receipt.py`
- `python3 scripts/test_sync_status_report.py`
- `python3 scripts/test_runtime_manifest.py`
- `for t in scripts/test_*.py; do python3 "$t"; done`
- temp selected-output publish plus Trae sync dry-run:
  - `python3 scripts/publish_adapters.py --output-root <tmp> --apply`
  - `python3 scripts/check_adapter_quality.py --surface selected-output --generated-root <tmp>`
  - `python3 scripts/sync_adapters.py --target trae --adapter-root <tmp> --dest <tmp>/runtime-trae --dry-run`
- local old-manifest behavior:
  - `python3 scripts/install_foundry.py --target trae --adapter-root adapters --skip-check` reports `## trae: skipped status=disabled`, with no runtime writes.
