### PR TITLE
[AF7 #145] Add Trae SOLO mode to role automation planning

### DIFF
--- a/adapters/trae/skills/agent-foundry/SKILL.md
+++ b/adapters/trae/skills/agent-foundry/SKILL.md
@@ -47,6 +47,16 @@ Before substantial changes, check:
 - Verifier: status, command, install, and runtime freshness checks.
 - Harvester: candidate extraction only; do not activate canonical records without review.
 
+## Trae Multi-Agent Mode
+
+- Use SOLO Agent for planning-first multi-role orchestration when the task needs Architect -> Implementer -> Reviewer separation.
+- Prefer `.trae/subagents/*.md` for approved project-specific role prompts because they are selected per task.
+- Do not use separate `.trae/rules/architect.md`, `.trae/rules/implementor.md`, and `.trae/rules/reviewer.md` as the default role model; Trae treats project rules as always-applied workspace rules, so all roles can see all role contracts.
+- Use a single dispatcher or project contract reference in `.trae/rules` only when ambient project-wide wording is explicitly intended.
+- Keep Single Chat role dispatch as the fallback when SOLO/SubAgents are unavailable, too costly, or unreliable.
+- Keep durable coordination in GitHub issues, labels, comments, PRs, and explicit requested project artifacts.
+- Do not create summary `.md`, `.txt`, or `.docx` artifacts unless the user asks or the issue acceptance criteria requires a document deliverable.
+
 ## Runtime Rules
 
 - Treat canonical practices and assets in the selected User Vault as the source of truth.

--- a/docs/runtime-adapter-framework-and-trae.md
+++ b/docs/runtime-adapter-framework-and-trae.md
@@ -1,7 +1,7 @@
 # Runtime Adapter Framework And Trae Support
 
 Status: proposed AF-7 design  
-Updated: 2026-06-15
+Updated: 2026-06-16
 
 ## Purpose
 
@@ -28,6 +28,13 @@ Local experiments on 2026-06-15 verified:
 - Trae CN also scans `.agents/skills` style skill locations, making a portable shared skill layer plausible.
 - Trae CN imports project instruction files such as `AGENTS.md` and `CLAUDE.md` when that feature is enabled.
 - Trae custom agent definitions appear to live in private application state, not a stable public file schema.
+
+Follow-up validation on 2026-06-16 verified:
+
+- Trae SOLO Agent can consume a planning-only Agent Foundry prompt and return a useful Orchestrator -> role-subagent flow without file edits when explicitly constrained.
+- Trae recognizes Agent Foundry global Skill concepts such as `role-automation-planner` and `agent-collaboration`.
+- Trae project `.trae/rules/*.md` files behave as always-applied workspace rules; separate role rule files expose all role contracts to all agents and create authority-mixing risk.
+- `.trae/subagents/*.md` is the better project-specific overlay candidate for isolated role prompts selected per task.
 
 Implication: Agent Foundry should publish Trae support primarily as generated global Skills plus optional project overlays, and should not write Trae private application state until Trae exposes a supported import/export contract.
 
@@ -91,6 +98,8 @@ Trae currently works best as a coordinator runtime rather than as a fully file-b
 
 If Trae later exposes a stable custom-agent file schema or CLI import path, Agent Foundry can add a custom-agent publisher. Until then, generated Skills are the safer integration point.
 
+For complex multi-role work, prefer a SOLO Agent plan that dispatches isolated role prompts from `.trae/subagents` when a project overlay is explicitly approved. Do not generate multiple default `.trae/rules/<role>.md` files. Use `.trae/rules` only for a single dispatcher or project-wide contract reference when ambient always-applied wording is safe and intentional.
+
 ## Asset Compatibility
 
 Existing runtime-neutral multi-agent assets remain useful if they avoid Codex-only assumptions. The Trae adapter should add only the runtime-specific layer needed to activate those assets:
@@ -99,6 +108,7 @@ Existing runtime-neutral multi-agent assets remain useful if they avoid Codex-on
 - launcher instructions that call existing helper scripts;
 - status and repair guidance that names Trae install paths;
 - role-specific prompt packaging for Trae's interaction model.
+- anti-summary-document instructions so Trae does not create summary files unless requested or required by acceptance criteria.
 
 Trae-specific assets are justified only when Trae has unique behavior that cannot be represented by the portable adapter layer, such as Skill discovery, UI activation wording, or future custom-agent import formats.
 

--- a/scripts/test_adapter_quality_split.py
+++ b/scripts/test_adapter_quality_split.py
@@ -84,6 +84,29 @@ def promote_asset_collab_002(vault_root: Path) -> None:
     asset_text = asset.read_text(encoding="utf-8")
     asset_text = asset_text.replace("status: proposed\n", "status: active\n", 1)
     asset_text = asset_text.replace("published_to: []\n", "published_to: [codex, claude-code, hermes, chatgpt]\n", 1)
+    asset_text = asset_text.replace(
+        "  - hermes\n  - chatgpt\n",
+        "  - hermes\n  - trae\n  - chatgpt\n",
+        1,
+    )
+    if "Trae SOLO orchestration prompt" not in asset_text:
+        asset_text = asset_text.replace(
+            "  - portable fallback prompt for runtimes without live thread APIs\n",
+            "  - portable fallback prompt for runtimes without live thread APIs\n"
+            "  - Trae SOLO orchestration prompt with Orchestrator, Architect, Implementer, Reviewer, Verifier, or Harvester role boundaries\n"
+            "  - Trae .trae/subagents project overlay guidance when explicitly approved\n"
+            "  - Trae Single Chat dispatcher fallback prompt\n",
+            1,
+        )
+        asset_text = asset_text.replace(
+            "  - generated prompts require helper fast paths when repo-local helpers exist\n",
+            "  - generated prompts require helper fast paths when repo-local helpers exist\n"
+            "  - Trae SOLO output keeps global Skills as the default substrate and uses .trae/subagents only for approved project-specific overlays\n"
+            "  - Trae output avoids default multi-role .trae/rules files and explains the always-applied workspace rule conflict\n"
+            "  - Trae output includes no-private-state and anti-summary-document constraints\n"
+            "  - Trae output names GitHub issues, comments, labels, PRs, and explicit requested project artifacts as durable state\n",
+            1,
+        )
     asset.write_text(asset_text, encoding="utf-8")
 
 
@@ -182,6 +205,16 @@ def main() -> int:
             for expected in ["ASSET-COLLAB-002", "Role Dispatch and Automation Planner", "## Responsibility", "## Process"]:
                 if expected not in text:
                     errors.append(f"selected-output-promoted-asset: {name} generated SKILL.md missing {expected}")
+            if name == "trae":
+                for expected in [
+                    "Trae SOLO orchestration prompt",
+                    ".trae/subagents",
+                    ".trae/rules",
+                    "always-applied workspace rule conflict",
+                    "anti-summary-document",
+                ]:
+                    if expected not in text:
+                        errors.append(f"selected-output-promoted-asset: trae generated SKILL.md missing {expected}")
         generated_text = "\n".join(path.read_text(encoding="utf-8") for path in generated.rglob("*") if path.is_file())
         if "ASSET-COLLAB-002" not in generated_text:
             errors.append("selected-output-promoted-asset: generated output missing ASSET-COLLAB-002")


### PR DESCRIPTION
## Summary

Refs #145 and uses validation evidence from #143.

This PR adds Trae SOLO role-planning support to the AF7 adapter path:

- documents Trae SOLO multi-role orchestration in the Trae global Agent Foundry Skill;
- records the 2026-06-16 validation findings in the runtime adapter design doc;
- extends adapter quality split coverage so generated Trae `role-automation-planner` output must include SOLO/subagents/rules-conflict/no-summary guidance.

## Validation

- `python3 scripts/test_adapter_quality_split.py` passed.
- `python3 scripts/check_adapter_quality.py --surface core` passed.
- `git diff --check` passed.

Previously completed during the same task branch work:

- temp `publish_adapters.py --apply` output included Trae SOLO role-planning guidance;
- `python3 scripts/sync_status.py --adapter-root ~/.agent-foundry/generated/agent-foundry-adapters` completed;
- `python3 scripts/sync_adapters.py --adapter-root ~/.agent-foundry/generated/agent-foundry-adapters --target trae` was dry-run only and showed runtime copies would be needed;
- `python3 scripts/check_consistency.py` passed;
- `python3 scripts/test_runtime_manifest.py && python3 scripts/test_sync_status_report.py` passed.

## External State

The selected User Vault was updated locally outside this Core PR:

- `ASSET-COLLAB-002-role-automation-planner.asset.yaml` was advanced to include Trae SOLO orchestration guidance and `published_to: trae`;
- `indexes/asset_index.yaml` was updated accordingly;
- selected generated adapters under `~/.agent-foundry/generated/agent-foundry-adapters` were refreshed.

No runtime install was applied to `~/.trae-cn/skills`. The dry run indicates that runtime sync is still pending and should be applied only with explicit approval.

## Residual Risks

- `sync_status.py` still reports selected output as in sync by receipt while `sync_adapters.py --target trae` dry-run reports would-copy runtime files. This looks like a status/receipt visibility gap and should remain in AF7 hardening follow-up scope rather than expanding #145.
- Canonical Vault edits are local workspace state, not part of this Core repository PR.