### PR TITLE
Harden AF7 selected-output metadata and Trae repair status

### DIFF
--- a/scripts/check_adapter_quality.py
+++ b/scripts/check_adapter_quality.py
@@ -241,8 +241,37 @@ def expected_skill_path(generated_root: Path, adapter_id: str, slug: str) -> Pat
     return generated_root / adapter_id / "skills" / slug / "SKILL.md"
 
 
-def check_generated_skill_artifacts(generated_root: Path, vault_root: Path) -> list[str]:
+def manifest_skill_artifacts(manifest: Path) -> list[dict[str, str]]:
+    artifacts: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    in_list = False
+    for raw in read(manifest).splitlines():
+        line = raw.rstrip()
+        if line.startswith("generated_skill_artifacts:"):
+            in_list = True
+            if line.split(":", 1)[1].strip() == "[]":
+                return []
+            continue
+        if in_list and line and not line.startswith(" "):
+            break
+        if not in_list:
+            continue
+        stripped = line.strip()
+        if stripped.startswith("- adapter:"):
+            if current:
+                artifacts.append(current)
+            current = {"adapter": stripped.split(":", 1)[1].strip().strip('"').strip("'")}
+        elif current is not None and stripped.startswith(("asset_id:", "slug:", "path:", "source_path:")):
+            key, value = stripped.split(":", 1)
+            current[key] = value.strip().strip('"').strip("'")
+    if current:
+        artifacts.append(current)
+    return artifacts
+
+
+def check_generated_skill_artifacts(generated_root: Path, vault_root: Path, manifest: Path) -> list[str]:
     errors: list[str] = []
+    manifest_artifacts = manifest_skill_artifacts(manifest)
     for record in active_skill_assets(vault_root):
         published_to = record.get("published_to", [])
         if not isinstance(published_to, list):
@@ -253,6 +282,27 @@ def check_generated_skill_artifacts(generated_root: Path, vault_root: Path) -> l
             ):
                 continue
             path = expected_skill_path(generated_root, adapter_id, str(record["slug"]))
+            rel_path = str(path.relative_to(generated_root))
+            matching_artifact = next(
+                (
+                    artifact
+                    for artifact in manifest_artifacts
+                    if artifact.get("adapter") == adapter_id
+                    and artifact.get("asset_id") == str(record["id"])
+                    and artifact.get("slug") == str(record["slug"])
+                ),
+                None,
+            )
+            if matching_artifact is None:
+                errors.append(
+                    f"Selected output skill artifact: {adapter_id} manifest missing generated skill artifact "
+                    f"for active skill asset {record['id']}"
+                )
+            elif matching_artifact.get("path") != rel_path:
+                errors.append(
+                    f"Selected output skill artifact: {adapter_id} manifest path mismatch for {record['id']}: "
+                    f"expected {rel_path}, got {matching_artifact.get('path', '')}"
+                )
             if not path.exists():
                 errors.append(
                     f"Selected output skill artifact: {adapter_id} missing generated SKILL.md "
@@ -385,7 +435,7 @@ def check_selected_output_surface(core_root: Path, vault_root: Path, generated_r
                 phrase = phrase.split("<", 1)[0].strip()
             if phrase and phrase not in text:
                 errors.append(f"Selected output coverage: {name} generated output missing command phrase: {phrase}")
-    errors.extend(check_generated_skill_artifacts(generated_root, vault_root))
+    errors.extend(check_generated_skill_artifacts(generated_root, vault_root, manifest))
     return errors
 
 

--- a/scripts/publish_adapters.py
+++ b/scripts/publish_adapters.py
@@ -179,7 +179,36 @@ def parse_profiles(core_root: Path) -> dict[str, dict[str, object]]:
     return profiles
 
 
-def manifest_text(active_practices: list[dict[str, str]], active_assets: list[dict[str, str]]) -> str:
+def skill_artifact_records(output_root: Path, skill_assets: list[dict[str, object]]) -> list[dict[str, str]]:
+    records: list[dict[str, str]] = []
+    for record in skill_assets:
+        published_to = record.get("published_to", [])
+        if not isinstance(published_to, list):
+            continue
+        for adapter_id in sorted(SKILL_FOLDER_ADAPTERS):
+            if adapter_id not in published_to and not (
+                adapter_id == "trae" and TRAE_COMPATIBLE_SKILL_ADAPTERS.intersection(published_to)
+            ):
+                continue
+            path = output_root / adapter_id / "skills" / str(record["slug"]) / "SKILL.md"
+            source = str(record.get("source_path", ""))
+            records.append(
+                {
+                    "adapter": adapter_id,
+                    "asset_id": str(record["id"]),
+                    "slug": str(record["slug"]),
+                    "path": str(path.relative_to(output_root)),
+                    "source_path": source,
+                }
+            )
+    return records
+
+
+def manifest_text(
+    active_practices: list[dict[str, str]],
+    active_assets: list[dict[str, str]],
+    skill_artifacts: list[dict[str, str]],
+) -> str:
     lines = [
         "schema_version: 1",
         f"updated: {date.today().isoformat()}",
@@ -200,6 +229,17 @@ def manifest_text(active_practices: list[dict[str, str]], active_assets: list[di
             lines.append(f"  - {entry['id']}")
     else:
         lines.append("active_assets: []")
+    lines.append("")
+    if skill_artifacts:
+        lines.append("generated_skill_artifacts:")
+        for artifact in skill_artifacts:
+            lines.append(f"  - adapter: {artifact['adapter']}")
+            lines.append(f"    asset_id: {artifact['asset_id']}")
+            lines.append(f"    slug: {artifact['slug']}")
+            lines.append(f"    path: {artifact['path']}")
+            lines.append(f"    source_path: {artifact['source_path']}")
+    else:
+        lines.append("generated_skill_artifacts: []")
     lines.append("")
     return "\n".join(lines)
 
@@ -381,7 +421,7 @@ def publish(core_root: Path, vault_root: Path, output_root: Path, apply: bool) -
     active_assets = active_entries(vault_root, "indexes/asset_index.yaml", "assets")
     if not active_practices and not active_assets:
         print("Selected Vault has no active or revised practices/assets. Nothing to publish.")
-        write_manifest(output_root, manifest_text(active_practices, active_assets), apply)
+        write_manifest(output_root, manifest_text(active_practices, active_assets, []), apply)
         return 0
 
     if not (core_root / "adapters" / "adapter_profiles.yaml").exists():
@@ -392,9 +432,11 @@ def publish(core_root: Path, vault_root: Path, output_root: Path, apply: bool) -
         print("Refusing to overwrite Core adapter templates in place. Pass --output-root for generated outputs.")
         return 1
 
+    skill_assets = skill_asset_records(vault_root, active_assets)
+    skill_artifacts = skill_artifact_records(output_root, skill_assets)
     written = write_adapter_outputs(core_root, output_root, active_practices, active_assets, apply)
-    written.extend(write_generated_skill_outputs(output_root, skill_asset_records(vault_root, active_assets), apply))
-    write_manifest(output_root, manifest_text(active_practices, active_assets), apply)
+    written.extend(write_generated_skill_outputs(output_root, skill_assets, apply))
+    write_manifest(output_root, manifest_text(active_practices, active_assets, skill_artifacts), apply)
     print(f"Adapter publish {'wrote' if apply else 'planned'} {len(written)} files.")
     print(f"Active practices selected: {len(active_practices)}")
     print(f"Active assets selected: {len(active_assets)}")

--- a/scripts/sync_status.py
+++ b/scripts/sync_status.py
@@ -262,6 +262,12 @@ def receipt_summary(receipt_path: Path) -> list[str]:
     ]
     for target, (target_state, target_problems, checked) in sorted(receipt_target_statuses(receipt).items()):
         lines.append(f"receipt target: {target} {target_state} checked={checked} problems={len(target_problems)}")
+        if target_state == "selected-output-drift":
+            lines.append(
+                f"receipt repair: {target} review generated output, run install dry-run, then apply only with runtime-write approval"
+            )
+            if target == "trae":
+                lines.append("receipt repair: trae writes ~/.trae-cn/skills and requires durable human approval before --apply")
     for problem in problems[:10]:
         lines.append(f"receipt detail: {problem}")
     if len(problems) > 10:
@@ -288,6 +294,13 @@ def next_safe_actions(
         actions.append("regenerate selected Vault adapter output before runtime install or refresh")
     if read_receipt(receipt_path) is None:
         actions.append("run runtime install only after generated output dry-run/review; receipt is currently missing")
+    else:
+        receipt = read_receipt(receipt_path)
+        if isinstance(receipt, dict):
+            state, _ = receipt_status(receipt)
+            if state == "selected-output-drift":
+                actions.append("repair selected-output drift by regenerating output, reviewing install dry-run, then applying approved managed runtime sync")
+                actions.append("for Trae, do not write ~/.trae-cn/skills unless durable human approval explicitly authorizes that runtime apply")
     actions.append("treat ChatGPT as manual import unless a future managed target is explicitly implemented")
     return actions
 

--- a/scripts/test_adapter_quality_split.py
+++ b/scripts/test_adapter_quality_split.py
@@ -218,6 +218,48 @@ def main() -> int:
         generated_text = "\n".join(path.read_text(encoding="utf-8") for path in generated.rglob("*") if path.is_file())
         if "ASSET-COLLAB-002" not in generated_text:
             errors.append("selected-output-promoted-asset: generated output missing ASSET-COLLAB-002")
+        manifest_text = (generated / "adapter-publish-manifest.yaml").read_text(encoding="utf-8")
+        for expected in [
+            "generated_skill_artifacts:",
+            "adapter: codex",
+            "adapter: hermes",
+            "adapter: trae",
+            "asset_id: ASSET-COLLAB-002",
+            "path: trae/skills/role-automation-planner/SKILL.md",
+            "source_path: assets/skills/ASSET-COLLAB-002-role-automation-planner.asset.yaml",
+        ]:
+            if expected not in manifest_text:
+                errors.append(f"selected-output-promoted-asset: manifest missing {expected}")
+
+        manifest_path = generated / "adapter-publish-manifest.yaml"
+        manifest_without_artifact = "\n".join(
+            line
+            for line in manifest_text.splitlines()
+            if "role-automation-planner" not in line and "ASSET-COLLAB-002" not in line
+        )
+        manifest_path.write_text(manifest_without_artifact + "\n", encoding="utf-8")
+        missing_manifest_artifact_quality = run(
+            [
+                str(QUALITY),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(temp_vault),
+                "--surface",
+                "selected-output",
+                "--generated-root",
+                str(generated),
+            ]
+        )
+        errors.extend(
+            expect(
+                "selected-output-missing-manifest-skill-artifact",
+                missing_manifest_artifact_quality,
+                False,
+                "manifest missing generated skill artifact",
+            )
+        )
+        manifest_path.write_text(manifest_text, encoding="utf-8")
 
         codex_skill.unlink()
         missing_skill_quality = run(

--- a/scripts/test_sync_status_report.py
+++ b/scripts/test_sync_status_report.py
@@ -7,6 +7,7 @@ import tempfile
 from pathlib import Path
 
 import sync_status
+from adapter_install_receipt import file_sha256
 from sync_status import ROOT, DEFAULT_GENERATED_ROOT, default_adapter_root, deployed_packs, runtime_status, setup_report
 
 
@@ -83,6 +84,37 @@ def main() -> int:
         ]
         for text in expected:
             assert text in report, text
+
+        trae_dest = base / "runtime" / "trae"
+        write(generated / "trae" / "skills" / "role-automation-planner" / "SKILL.md", "generated trae skill\n")
+        write(trae_dest / "role-automation-planner" / "SKILL.md", "stale installed skill\n")
+        write(
+            receipt,
+            "{\n"
+            '  "schema_version": 1,\n'
+            f'  "adapter_root": "{generated}",\n'
+            '  "installed_targets": ["trae"],\n'
+            '  "installed_files": [\n'
+            "    {\n"
+            '      "target": "trae",\n'
+            '      "source": "trae/skills/role-automation-planner/SKILL.md",\n'
+            f'      "destination": "{trae_dest / "role-automation-planner" / "SKILL.md"}",\n'
+            f'      "sha256": "{file_sha256(generated / "trae" / "skills" / "role-automation-planner" / "SKILL.md")}"\n'
+            "    }\n"
+            "  ]\n"
+            "}\n",
+        )
+        drift_report = setup_report(ROOT, vault, generated, receipt)
+        drift_expected = [
+            "receipt: selected-output-drift",
+            "receipt target: trae selected-output-drift checked=1 problems=1",
+            "receipt repair: trae review generated output, run install dry-run, then apply only with runtime-write approval",
+            "receipt repair: trae writes ~/.trae-cn/skills and requires durable human approval before --apply",
+            "- repair selected-output drift by regenerating output, reviewing install dry-run, then applying approved managed runtime sync",
+            "- for Trae, do not write ~/.trae-cn/skills unless durable human approval explicitly authorizes that runtime apply",
+        ]
+        for text in drift_expected:
+            assert text in drift_report, text
 
         local_manifest = ROOT / "runtime" / "local" / "runtime_manifest.yaml"
         before = local_manifest.read_bytes() if local_manifest.exists() else None


### PR DESCRIPTION
## Scope

Implements the AF7 #141/#142 batch slice for runtime adapter selected-output contract hardening and Trae sync/status/repair UX.

- Adds explicit generated skill artifact metadata to `adapter-publish-manifest.yaml` for selected-output publishes.
- Extends selected-output adapter quality checks to validate generated skill artifact manifest coverage and path consistency.
- Keeps generated output downstream only; no Core adapter overwrite path is introduced.
- Improves sync status output for selected-output drift with Trae-specific repair/approval guidance.
- Adds focused regression coverage for ASSET-COLLAB-002 generated skill artifact manifest coverage and Trae receipt drift messaging.

## Verification

- `python3 -m py_compile scripts/publish_adapters.py scripts/check_adapter_quality.py scripts/sync_status.py scripts/test_adapter_quality_split.py scripts/test_sync_status_report.py`
- `python3 scripts/test_adapter_quality_split.py`
- `python3 scripts/test_sync_status_report.py`
- `python3 scripts/publish_adapters.py --output-root /private/tmp/af7-selected.O9dyN2 --apply`
- `python3 scripts/check_adapter_quality.py --surface selected-output --generated-root /private/tmp/af7-selected.O9dyN2`
- `python3 scripts/check_adapter_quality.py --surface core`
- `python3 scripts/check_activation.py`
- `python3 scripts/check_consistency.py`
- `git diff --check`

## Notes

- No live runtime sync was performed.
- No Trae private app state was written.
- No canonical Vault asset records or generated adapter Skill files were modified.
- #147 is intentionally excluded from this implementation PR because the latest operator rule requires AF asset modifications to go through the harvest workflow before implementation.

Reviewer target: AF7 batch Reviewer; #141 and #142 can be reviewed together.