### PR TITLE
[AF7] Validate collaboration rehydration gates

### DIFF
--- a/scripts/check_adapter_quality.py
+++ b/scripts/check_adapter_quality.py
@@ -272,6 +272,24 @@ def manifest_skill_artifacts(manifest: Path) -> list[dict[str, str]]:
 def check_generated_skill_artifacts(generated_root: Path, vault_root: Path, manifest: Path) -> list[str]:
     errors: list[str] = []
     manifest_artifacts = manifest_skill_artifacts(manifest)
+    asset_contract_phrases = {
+        "ASSET-COLLAB-001": [
+            "rehydration checkpoint",
+            "risky collaboration transitions",
+            "`needs:*` label changes are backed by transition gate evidence",
+            "reviewer handoff to `needs:reviewer` includes peer-session dispatch evidence",
+            "Human Decision Contract",
+            "explicit authorization phrase",
+            "delegated Architect or acceptance role",
+            "Epic closure",
+            "final `main` integration",
+        ],
+        "ASSET-COLLAB-002": [
+            "rehydration step from durable sources",
+            "transition gate it is satisfying",
+            "target role to rehydrate durable sources",
+        ],
+    }
     for record in active_skill_assets(vault_root):
         published_to = record.get("published_to", [])
         if not isinstance(published_to, list):
@@ -322,6 +340,12 @@ def check_generated_skill_artifacts(generated_root: Path, vault_root: Path, mani
                 if not ok:
                     errors.append(
                         f"Selected output skill artifact: {adapter_id} {record['id']} SKILL.md missing {label}: {path}"
+                    )
+            for phrase in asset_contract_phrases.get(str(record["id"]), []):
+                if phrase not in text:
+                    errors.append(
+                        f"Selected output skill artifact: {adapter_id} {record['id']} "
+                        f"SKILL.md missing contract phrase {phrase!r}: {path}"
                     )
     return errors
 

--- a/scripts/test_adapter_quality_split.py
+++ b/scripts/test_adapter_quality_split.py
@@ -194,6 +194,29 @@ def main() -> int:
             ]
         )
         errors.extend(expect("selected-output-promoted-asset", selected_quality, True, "selected-output surface"))
+        collaboration_paths = [
+            ("codex", generated / "codex" / "skills" / "agent-collaboration" / "SKILL.md"),
+            ("hermes", generated / "hermes" / "skills" / "agent-collaboration" / "SKILL.md"),
+            ("trae", generated / "trae" / "skills" / "agent-collaboration" / "SKILL.md"),
+        ]
+        for name, path in collaboration_paths:
+            if not path.exists():
+                errors.append(f"selected-output-transition-gates: {name} agent-collaboration SKILL.md missing: {path}")
+                continue
+            text = path.read_text(encoding="utf-8")
+            for expected in [
+                "rehydration checkpoint",
+                "risky collaboration transitions",
+                "`needs:*` label changes are backed by transition gate evidence",
+                "reviewer handoff to `needs:reviewer` includes peer-session dispatch evidence",
+                "Human Decision Contract",
+                "explicit authorization phrase",
+                "delegated Architect or acceptance role",
+                "Epic closure",
+                "final `main` integration",
+            ]:
+                if expected not in text:
+                    errors.append(f"selected-output-transition-gates: {name} agent-collaboration missing {expected}")
         codex_skill = generated / "codex" / "skills" / "role-automation-planner" / "SKILL.md"
         hermes_skill = generated / "hermes" / "skills" / "role-automation-planner" / "SKILL.md"
         trae_skill = generated / "trae" / "skills" / "role-automation-planner" / "SKILL.md"
@@ -215,6 +238,13 @@ def main() -> int:
                 ]:
                     if expected not in text:
                         errors.append(f"selected-output-promoted-asset: trae generated SKILL.md missing {expected}")
+            for expected in [
+                "rehydration step from durable sources",
+                "transition gate it is satisfying",
+                "target role to rehydrate durable sources",
+            ]:
+                if expected not in text:
+                    errors.append(f"selected-output-promoted-asset: {name} generated SKILL.md missing {expected}")
         generated_text = "\n".join(path.read_text(encoding="utf-8") for path in generated.rglob("*") if path.is_file())
         if "ASSET-COLLAB-002" not in generated_text:
             errors.append("selected-output-promoted-asset: generated output missing ASSET-COLLAB-002")


### PR DESCRIPTION
## Scope

Implements the Core validation portion of #147 after the approved harvest review list.

- Extends selected-output adapter quality checks for `ASSET-COLLAB-001` rehydration and `needs:*` transition gate contract phrases.
- Extends the split Core/Vault adapter fixture to assert generated Codex/Hermes/Trae `agent-collaboration` skills carry reviewer dispatch evidence, Human Decision Contract, child closure, Epic closure, and final-main boundary wording.
- Extends role automation planner generated-skill checks for target-role durable-source rehydration and transition gate wording.

Companion canonical Vault PR: pending/linked in #147.

## Verification

- `python3 scripts/check_adapter_quality.py --core-root "/Users/jinghuliu/Desktop/Code/Personal Projects/agent-foundry" --vault-root "/Users/jinghuliu/.agent-foundry/vault/agent-foundry-vault-farmerhunter" --surface selected-output --generated-root "/Users/jinghuliu/.agent-foundry/generated/agent-foundry-adapters"`
- `python3 scripts/check_consistency.py`
- `python3 scripts/test_adapter_quality_split.py`
- `python3 scripts/test_foundry_roots.py`
- `git diff --check`

## Boundaries

- No runtime install.
- No writes to `~/.codex`, `~/.trae-cn`, or private app state.
- No memory-system work.
- Final merge to `main` remains human-gated.