### PR TITLE
[AF7] Sync roadmap issue states before final review

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1015,15 +1015,16 @@ Current GitHub records:
 | #134 | AF-7 Epic for runtime adapter framework and Trae support. | In Progress |
 | #135 | Historical baseline batch PR. This merged design, implementation, live Trae apply, and first validation before the child-issue plan was reconstructed. Do not use it as the AF-7 planning model. | Merged |
 | #136 | Evidence issue for real Trae global Skill discovery, role UX, project instruction interaction, and project-overlay need. | Done |
-| #138 | Corrective planning issue to reconstruct the AF-7 child issue plan and governance record. | Review |
+| #138 | Corrective planning issue to reconstruct the AF-7 child issue plan and governance record. | Done |
 | #139 | Review issue for auditing the merged #135 baseline scope and residual risks. | Done |
 | #140 | Accepted decision for the Trae user-facing role invocation and project-overlay contract. | Done |
-| #141 | Task issue for runtime adapter profile and selected-output contract hardening. | Inbox |
-| #142 | Task issue for Trae sync, refresh, and repair UX validation. | Ready |
+| #141 | Task issue for runtime adapter profile and selected-output contract hardening. | Done |
+| #142 | Task issue for Trae sync, refresh, and repair UX validation. | Done |
 | #143 | Task issue for project-overlay compatibility and multi-agent coordination scenarios. | Done |
 | #145 | Task issue for Trae SOLO mode and role automation planning output. | Done |
-| #147 | Task issue for idle/resume Skill rehydration and collaboration transition gates. | Planning |
-| #144 | Final AF-7 acceptance gate and Epic readiness review. | Inbox |
+| #147 | Task issue for idle/resume Skill rehydration and collaboration transition gates. | Done |
+| #150 | Follow-up issue for explicit Trae publication intent on `ASSET-COLLAB-001`. | Done |
+| #144 | Final AF-7 acceptance gate and Epic readiness review. | Review |
 
 Child issue dependency order:
 
@@ -1034,7 +1035,8 @@ Child issue dependency order:
 5. #142 and #143 follow #136 plus #140 for sync/repair UX and project-overlay/multi-agent scenarios.
 6. #145 follows #140 and #143 if Trae SOLO is accepted as the complex multi-role orchestration path.
 7. #147 follows the observed #145/#146 collaboration-state drift and hardens idle/resume rehydration plus `needs:*` transition gates before final readiness review.
-8. #144 reviews #136 and #138 through #143 plus #145 and #147 before any AF-7 completion or Epic closure decision.
+8. #150 resolves the non-blocking Trae publication-intent residual from #147.
+9. #144 reviews #136 and #138 through #143 plus #145, #147, and #150 before any AF-7 completion or Epic closure decision.
 
 Acceptance criteria:
 
@@ -1043,7 +1045,7 @@ Acceptance criteria:
 - Existing multi-agent assets can project into Trae without duplicating canonical logic.
 - Project overlays remain optional and separated from global setup.
 - Runtime status distinguishes canonical, generated, installed, project, unmanaged, stale, and conflict states.
-- #134 drives AF-7 runtime adapter framework and Trae support through child issues #136 and #138 through #145 plus #147.
+- #134 drives AF-7 runtime adapter framework and Trae support through child issues #136, #138 through #145, #147, and #150.
 - Existing former-AF7 capability-hardening records are renumbered to AF-8 and held until AF-7 completes.
 - No additional AF-7 implementation work starts from the Epic or the historical baseline PR alone; every new implementation, evidence, decision, or review step must enter through a scoped child issue.
 - No memory-system directories, schemas, storage, MCP tools, or design work are introduced.


### PR DESCRIPTION
## Summary

Syncs the AF7 roadmap status table with current durable GitHub state before #144 final readiness review.

Changes:

- marks #138, #141, #142, and #147 as Done;
- adds #150 as the completed Trae publication-intent follow-up;
- marks #144 as Review;
- updates dependency/acceptance text so #150 is included in the AF7 review scope.

## Verification

- `git diff --check`
- `python3 scripts/check_consistency.py`
- `python3 scripts/check_foundry_roots.py --core-root "/Users/jinghuliu/Desktop/Code/Personal Projects/agent-foundry" --vault-root "/Users/jinghuliu/.agent-foundry/vault/agent-foundry-vault-farmerhunter"`

## Scope Boundary

Docs-only state synchronization. No runtime install, no Vault mutation, no `~/.trae-cn` write, no private app-state write, and no memory-system work.

Refs #134, #144, #150.
