### PR TITLE
[AF8 Task] Harden capability pack lifecycle scenarios

### DIFF
--- a/scripts/sync_status.py
+++ b/scripts/sync_status.py
@@ -307,7 +307,13 @@ def next_safe_actions(
 
 def setup_report(core_root: Path, vault_root: Path, adapter_root: Path, receipt_path: Path = RECEIPT_PATH) -> str:
     manifest_path = ROOT / "runtime" / "local" / "runtime_manifest.yaml"
-    targets = parse_runtime_manifest(manifest_path.read_text(encoding="utf-8")) if manifest_path.exists() else {}
+    template_path = ROOT / "runtime" / "templates" / "runtime_manifest.template.yaml"
+    if manifest_path.exists():
+        targets = parse_runtime_manifest(manifest_path.read_text(encoding="utf-8"))
+    elif template_path.exists():
+        targets = parse_runtime_manifest(template_path.read_text(encoding="utf-8"))
+    else:
+        targets = {}
     output_state, output_count = generated_output_status(adapter_root)
     packs = deployed_packs(vault_root)
     lines = [

--- a/scripts/test_capability_pack_lifecycle.py
+++ b/scripts/test_capability_pack_lifecycle.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import hashlib
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -66,6 +67,10 @@ def apply_optional(vault: Path) -> subprocess.CompletedProcess[str]:
     return run([str(APPLY), str(OPTIONAL_PACK), "--core-root", str(ROOT), "--vault-root", str(vault), "--apply"])
 
 
+def apply_pack(vault: Path, pack: Path) -> subprocess.CompletedProcess[str]:
+    return run([str(APPLY), str(pack), "--core-root", str(ROOT), "--vault-root", str(vault), "--apply"])
+
+
 def lifecycle(vault: Path, action: str, apply: bool) -> subprocess.CompletedProcess[str]:
     args = [
         str(LIFECYCLE),
@@ -98,6 +103,17 @@ def publish(vault: Path, generated: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
+def copy_optional_variant(base: Path, name: str, replacements: dict[str, str]) -> Path:
+    target = base / name
+    shutil.copytree(OPTIONAL_PACK, target)
+    manifest = target / "manifest.yaml"
+    text = manifest.read_text(encoding="utf-8")
+    for old, new in replacements.items():
+        text = text.replace(old, new)
+    manifest.write_text(text, encoding="utf-8")
+    return target
+
+
 def status(vault: Path, generated: Path, receipt: Path) -> subprocess.CompletedProcess[str]:
     return run(
         [
@@ -123,6 +139,43 @@ def main() -> int:
         errors.extend(expect("init-blank-vault", init_blank(vault), True, "Blank Vault initialized and validated."))
         errors.extend(expect("deploy-bootstrap", deploy_bootstrap(vault), True, "selected Vault validated"))
         errors.extend(expect("apply-optional", apply_optional(vault), True, "metadata: written"))
+        repeat_metadata_before = digest(vault / "packs" / "deployed-pack-index.yaml")
+        errors.extend(expect("apply-optional-repeat", apply_optional(vault), True, "pack metadata already present"))
+        repeat_metadata_after = digest(vault / "packs" / "deployed-pack-index.yaml")
+        if repeat_metadata_after != repeat_metadata_before:
+            errors.append("apply-optional-repeat: same-version same-hash metadata changed")
+
+        same_version_mismatch = copy_optional_variant(
+            base,
+            "same-version-mismatch-pack",
+            {"title: Optional Multi-Agent Collaboration Pack": "title: Optional Multi-Agent Collaboration Pack Changed"},
+        )
+        errors.extend(
+            expect(
+                "apply-same-version-hash-mismatch",
+                apply_pack(vault, same_version_mismatch),
+                False,
+                "different manifest_sha256",
+            )
+        )
+        if digest(vault / "packs" / "deployed-pack-index.yaml") != repeat_metadata_before:
+            errors.append("apply-same-version-hash-mismatch: metadata changed after refusal")
+
+        newer_version = copy_optional_variant(
+            base,
+            "newer-version-pack",
+            {"version: 0.2.0": "version: 0.3.0"},
+        )
+        errors.extend(
+            expect(
+                "apply-newer-version-requires-update-flow",
+                apply_pack(vault, newer_version),
+                False,
+                "blocking record outcome update",
+            )
+        )
+        if digest(vault / "packs" / "deployed-pack-index.yaml") != repeat_metadata_before:
+            errors.append("apply-newer-version-requires-update-flow: metadata changed after refusal")
 
         user_record = vault / "practices" / "user" / "USER-LOCAL-001.md"
         write(


### PR DESCRIPTION
## Summary

- Extends the capability pack lifecycle fixture with explicit same-version same-hash idempotence coverage.
- Adds fail-closed tests for same-version manifest hash mismatch and newer-version reviewed-update-required behavior.
- Verifies refused lifecycle/update paths leave deployed pack metadata unchanged.

## Validation

- `python3 scripts/test_capability_pack_lifecycle.py`
- `python3 scripts/test_capability_pack_apply.py`
- `python3 scripts/test_capability_pack_plan.py`
- `python3 scripts/check_consistency.py`
- `git diff --check`

Closes #126.