### PR TITLE
[AF8 Task] Add long-running sync freshness checks

### DIFF
--- a/scripts/sync_status.py
+++ b/scripts/sync_status.py
@@ -428,7 +428,13 @@ def next_safe_actions(
 
 def setup_report(core_root: Path, vault_root: Path, adapter_root: Path, receipt_path: Path = RECEIPT_PATH) -> str:
     manifest_path = ROOT / "runtime" / "local" / "runtime_manifest.yaml"
-    targets = parse_runtime_manifest(manifest_path.read_text(encoding="utf-8")) if manifest_path.exists() else {}
+    template_path = ROOT / "runtime" / "templates" / "runtime_manifest.template.yaml"
+    if manifest_path.exists():
+        targets = parse_runtime_manifest(manifest_path.read_text(encoding="utf-8"))
+    elif template_path.exists():
+        targets = parse_runtime_manifest(template_path.read_text(encoding="utf-8"))
+    else:
+        targets = {}
     output_state, output_count = generated_output_status(adapter_root)
     packs = deployed_packs(vault_root)
     lines = [

--- a/scripts/sync_status.py
+++ b/scripts/sync_status.py
@@ -35,6 +35,63 @@ def run_git(args: list[str]) -> str:
     return text or "none"
 
 
+def run_git_status(args: list[str]) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=ROOT,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        return subprocess.CompletedProcess(["git", *args], 127, "", "git unavailable")
+
+
+def repo_progress_status() -> str:
+    branch = run_git(["branch", "--show-current"])
+    upstream = run_git_status(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"])
+    if upstream.returncode != 0:
+        return "\n".join(
+            [
+                "repo: upstream-unknown",
+                f"branch: {branch}",
+                "repair: set or fetch the upstream branch before assuming remote Core progress is current",
+            ]
+        )
+    upstream_name = upstream.stdout.strip()
+    counts = run_git_status(["rev-list", "--left-right", "--count", f"{upstream_name}...HEAD"])
+    if counts.returncode != 0:
+        return "\n".join(
+            [
+                "repo: upstream-unavailable",
+                f"branch: {branch}",
+                f"upstream: {upstream_name}",
+                "repair: fetch remote Core progress before publishing or applying runtime changes",
+            ]
+        )
+    left, right = (counts.stdout.strip().split() + ["0", "0"])[:2]
+    behind = int(left)
+    ahead = int(right)
+    if behind and ahead:
+        state = "diverged"
+    elif behind:
+        state = "behind"
+    elif ahead:
+        state = "ahead"
+    else:
+        state = "current"
+    lines = [
+        f"repo: {state} ahead={ahead} behind={behind}",
+        f"branch: {branch}",
+        f"upstream: {upstream_name}",
+    ]
+    if behind:
+        lines.append("repair: fetch/pull remote Core progress before publishing generated output or applying runtime changes")
+    return "\n".join(lines)
+
+
 def latest_snapshot() -> Path | None:
     snapshots = sorted((ROOT / "sync" / "snapshots").glob("*.tar.gz"), key=lambda p: p.stat().st_mtime)
     return snapshots[-1] if snapshots else None
@@ -237,6 +294,70 @@ def generated_output_status(adapter_root: Path) -> tuple[str, int]:
     return "ready", len(files)
 
 
+def index_active_ids(path: Path, list_key: str) -> set[str]:
+    if not path.exists():
+        return set()
+    try:
+        data = parse_simple_yaml(path.read_text(encoding="utf-8"))
+    except ValueError:
+        return set()
+    entries = data.get(list_key, [])
+    if not isinstance(entries, list):
+        return set()
+    ids: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        status = str(entry.get("status", ""))
+        item_id = str(entry.get("id", ""))
+        if item_id and status in {"active", "revised"}:
+            ids.add(item_id)
+    return ids
+
+
+def manifest_list_ids(path: Path, list_key: str) -> set[str]:
+    if not path.exists():
+        return set()
+    try:
+        data = parse_simple_yaml(path.read_text(encoding="utf-8"))
+    except ValueError:
+        return set()
+    values = data.get(list_key, [])
+    if not isinstance(values, list):
+        return set()
+    return {str(value) for value in values if not isinstance(value, (dict, list))}
+
+
+def activation_freshness_lines(vault_root: Path, adapter_root: Path) -> list[str]:
+    manifest = adapter_root / "adapter-publish-manifest.yaml"
+    active_practices = index_active_ids(vault_root / "indexes" / "practice_index.yaml", "practices")
+    active_assets = index_active_ids(vault_root / "indexes" / "asset_index.yaml", "assets")
+    generated_practices = manifest_list_ids(manifest, "active_practices")
+    generated_assets = manifest_list_ids(manifest, "active_assets")
+    missing_practices = sorted(active_practices - generated_practices)
+    missing_assets = sorted(active_assets - generated_assets)
+    extra_practices = sorted(generated_practices - active_practices)
+    extra_assets = sorted(generated_assets - active_assets)
+    if not manifest.exists():
+        return [
+            "activation: generated-output-missing",
+            "activation repair: publish selected Vault generated output before runtime install or manual import",
+        ]
+    if missing_practices or missing_assets or extra_practices or extra_assets:
+        lines = [
+            "activation: stale-generated-output "
+            f"missing_active_practices={len(missing_practices)} missing_active_assets={len(missing_assets)} "
+            f"extra_generated_practices={len(extra_practices)} extra_generated_assets={len(extra_assets)}",
+        ]
+        for item_id in missing_practices[:5]:
+            lines.append(f"activation missing practice: {item_id}")
+        for item_id in missing_assets[:5]:
+            lines.append(f"activation missing asset: {item_id}")
+        lines.append("activation repair: publish selected Vault generated output, then dry-run runtime install before apply")
+        return lines
+    return ["activation: generated-output-current"]
+
+
 def default_adapter_root(core_root: Path, vault_root: Path, receipt_path: Path) -> Path:
     if core_root != vault_root:
         receipt = read_receipt(receipt_path)
@@ -321,6 +442,7 @@ def setup_report(core_root: Path, vault_root: Path, adapter_root: Path, receipt_
         *(f"- {pack}" for pack in packs),
         *(["- none detected"] if not packs else []),
         f"generated_output: {output_state} path={adapter_root} files={output_count}",
+        *activation_freshness_lines(vault_root, adapter_root),
         "runtime targets:",
     ]
     if not targets:
@@ -433,6 +555,8 @@ def main() -> int:
     print(run_git(["remote", "-v"]))
     print("git status:")
     print(run_git(["status", "--short"]))
+    print("repo progress:")
+    print(repo_progress_status())
     snapshot = latest_snapshot()
     print(f"latest snapshot: {snapshot_summary(snapshot) if snapshot else 'none'}")
     print("sync state:")

--- a/scripts/test_sync_status_report.py
+++ b/scripts/test_sync_status_report.py
@@ -3,12 +3,13 @@
 
 from __future__ import annotations
 
+import subprocess
 import tempfile
 from pathlib import Path
 
 import sync_status
 from adapter_install_receipt import file_sha256
-from sync_status import ROOT, DEFAULT_GENERATED_ROOT, default_adapter_root, deployed_packs, runtime_status, setup_report
+from sync_status import ROOT, DEFAULT_GENERATED_ROOT, default_adapter_root, deployed_packs, repo_progress_status, runtime_status, setup_report
 
 
 def write(path: Path, text: str) -> None:
@@ -16,15 +17,85 @@ def write(path: Path, text: str) -> None:
     path.write_text(text, encoding="utf-8")
 
 
+def git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=cwd, check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def assert_git(args: list[str], cwd: Path) -> None:
+    result = git(args, cwd)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def assert_repo_progress_behind(base: Path) -> None:
+    base.mkdir(parents=True)
+    remote = base / "remote.git"
+    work = base / "work"
+    other = base / "other"
+    assert_git(["init", "--bare", str(remote)], base)
+    assert_git(["init", "-b", "main", str(work)], base)
+    assert_git(["config", "user.email", "agent-foundry@example.com"], work)
+    assert_git(["config", "user.name", "Agent Foundry"], work)
+    write(work / "README.md", "one\n")
+    assert_git(["add", "README.md"], work)
+    assert_git(["commit", "-m", "initial"], work)
+    assert_git(["remote", "add", "origin", str(remote)], work)
+    assert_git(["push", "-u", "origin", "main"], work)
+
+    assert_git(["clone", str(remote), str(other)], base)
+    assert_git(["checkout", "main"], other)
+    assert_git(["config", "user.email", "agent-foundry@example.com"], other)
+    assert_git(["config", "user.name", "Agent Foundry"], other)
+    write(other / "README.md", "two\n")
+    assert_git(["commit", "-am", "remote progress"], other)
+    assert_git(["push"], other)
+    assert_git(["fetch"], work)
+
+    original_root = sync_status.ROOT
+    try:
+        sync_status.ROOT = work
+        report = repo_progress_status()
+        assert "repo: behind ahead=0 behind=1" in report, report
+        assert "repair: fetch/pull remote Core progress before publishing generated output or applying runtime changes" in report, report
+    finally:
+        sync_status.ROOT = original_root
+
+
 def main() -> int:
     with tempfile.TemporaryDirectory(prefix="agent-foundry-sync-status.") as raw:
         base = Path(raw)
+        assert_repo_progress_behind(base / "repo-progress")
         vault = base / "vault"
         generated = base / "generated-adapters"
         receipt = base / "adapter-install-receipt.json"
         (vault / "practices").mkdir(parents=True)
         (generated / "codex" / "skills").mkdir(parents=True)
         write(generated / "adapter-publish-manifest.yaml", "active_assets: []\n")
+        write(
+            vault / "indexes" / "practice_index.yaml",
+            "\n".join(
+                [
+                    "schema_version: 1",
+                    "practices:",
+                    "  - id: PRACTICE-ACTIVE-001",
+                    "    status: active",
+                    "    path: practices/example/PRACTICE-ACTIVE-001.md",
+                    "",
+                ]
+            ),
+        )
+        write(
+            vault / "indexes" / "asset_index.yaml",
+            "\n".join(
+                [
+                    "schema_version: 1",
+                    "assets:",
+                    "  - id: ASSET-ACTIVE-001",
+                    "    status: active",
+                    "    path: assets/skills/ASSET-ACTIVE-001.asset.yaml",
+                    "",
+                ]
+            ),
+        )
         write(
             receipt,
             "{\n"
@@ -75,6 +146,10 @@ def main() -> int:
             "deployed_packs:",
             "- pack.bootstrap.minimal (version=0.1.0, status=deployed, type=mandatory_bootstrap, source=local_path)",
             f"generated_output: ready path={generated} files=1",
+            "activation: stale-generated-output missing_active_practices=1 missing_active_assets=1",
+            "activation missing practice: PRACTICE-ACTIVE-001",
+            "activation missing asset: ASSET-ACTIVE-001",
+            "activation repair: publish selected Vault generated output, then dry-run runtime install before apply",
             "receipt: missing",
             "- chatgpt: manual import required",
             "next_safe_actions:",


### PR DESCRIPTION
## Summary

- Adds read-only repo progress reporting so agents can see when local Core is behind remote before publishing generated output or applying runtime changes.
- Adds activation freshness reporting that compares selected Vault active practice/asset IDs against generated adapter publish manifests.
- Extends sync status tests for remote-behind Core progress, stale generated output after Vault active ID changes, and stale runtime receipt drift for long-running agents.

## Validation

- `python3 scripts/test_sync_status_report.py`
- `python3 scripts/test_adapter_install_receipt.py`
- `python3 scripts/test_runtime_manifest.py`
- `python3 scripts/test_operation_context.py`
- `python3 scripts/check_consistency.py`
- `git diff --check`

Closes #127.