### PR TITLE
Define AF9 capability candidate scoring protocol

### DIFF
--- a/schemas/capability-pack-candidate.schema.yaml
+++ b/schemas/capability-pack-candidate.schema.yaml
@@ -1,0 +1,134 @@
+# Capability pack candidate schema.
+# Human-readable AF-9 candidate format, not a strict machine validator yet.
+
+required_fields:
+  candidate_schema_version: "Integer schema version for this candidate format."
+  candidate_id: "Stable candidate id for review, such as candidate.pack.multi-agent.github-collaboration."
+  proposed_pack_id: "Proposed pack id if the candidate later becomes a pack, such as pack.multi-agent.github-collaboration."
+  title: "Short human-readable candidate title."
+  outcome: "candidate | baseline_control | extend_existing | deferred_overlap | deferred_insufficient_evidence | deferred_privacy_review | rejected_false_positive | rejected_too_broad | rejected_too_narrow | blocked_policy"
+  confidence: "high | medium | low"
+  summary: "One-paragraph explanation of the candidate and why this outcome was chosen."
+  authority_layers: "Evidence references grouped by Core, selected_vault, generated, runtime, and local_private treatment."
+  observed_facts: "Facts directly supported by evidence references."
+  inference: "Proposed boundary and reasoning derived from observed facts."
+  signal_scores: "Explainable 0-3 scores for required detection signals."
+  false_positive_controls: "Required controls for broad/narrow/overlap/private/stale/runtime/bootstrap failure modes."
+  privacy_and_exportability: "Privacy risk, excluded material, and exportability constraints."
+  runtime_and_generation_impact: "Generated adapter and runtime effects if this candidate later becomes a reviewed pack."
+  review_handoff: "Next review owner, required checks, and follow-up issue recommendations."
+
+authority_layer_fields:
+  core:
+    description: "Public Core docs, workflows, schemas, fixtures, scripts, issues, or PRs."
+    allowed_references: "Paths or public GitHub URLs."
+  selected_vault:
+    description: "Canonical selected Vault record metadata and sanitized summaries."
+    allowed_references: "Record IDs, asset IDs, practice IDs, sanitized aggregate summaries."
+    forbidden_references: "Raw usage rows, raw session history, secrets, private paths, local runtime manifests."
+  generated:
+    description: "Generated adapter outputs as downstream projection evidence only."
+    canonical_authority: false
+  runtime:
+    description: "Managed install receipts or status summaries as downstream operation evidence only."
+    canonical_authority: false
+  local_private:
+    description: "Private data is excluded by default."
+    allowed_references: "Only a statement that private evidence was excluded or needs private review."
+
+signal_score_fields:
+  shared_user_goal: "0-3 score for one recurring user goal across records or issues."
+  asset_or_practice_membership: "0-3 score for multiple coherent practices/assets."
+  workflow_recurrence: "0-3 score for repeated process or handoff shape."
+  usage_frequency: "0-3 score for sanitized aggregate or repeated issue evidence."
+  validation_path: "0-3 score for review, test, walkthrough, or acceptance route."
+  adapter_projection_breadth: "0-3 score for cross-runtime generated-adapter value."
+  fixture_or_provenance: "0-3 score for reviewed fixture, pack, issue, or provenance anchor."
+  authority_fit: "0-3 score for clean Core/Vault/Generated/Runtime/Local Private boundaries."
+  total_signal_score: "Sum of required signal scores. Maximum is 24."
+
+false_positive_control_fields:
+  overly_broad: "pass | fail | uncertain, with rationale."
+  overly_narrow: "pass | fail | uncertain, with rationale."
+  overlapping_pack: "pass | fail | uncertain, with split/merge/extend recommendation."
+  private_only: "pass | fail | uncertain, with privacy rationale."
+  stale_pack: "pass | fail | uncertain, with recent-evidence rationale."
+  runtime_wrapper: "pass | fail | uncertain, with Generated/Runtime authority rationale."
+  bootstrap_duplicate: "pass | fail | uncertain, with baseline-control rationale."
+
+rules:
+  - "Candidate records are review artifacts, not active pack manifests."
+  - "A candidate may propose outcome candidate, but only human-reviewed follow-up work may activate or export a pack."
+  - "Observed facts must cite evidence references; inference must be labeled separately."
+  - "Selected Vault evidence must use record IDs, metadata, or sanitized summaries, not raw private evidence."
+  - "Generated adapters and runtime installs are downstream evidence only and must not be treated as canonical pack contents."
+  - "Runtime adapters by themselves are a rejected false-positive fixture, not a capability pack."
+  - "Bootstrap/lifecycle baseline can be a control case without becoming a new emergent optional pack."
+  - "Memory-system storage is not required and must not be introduced by AF-9 candidate discovery."
+  - "Schema evolution for active pack metadata belongs to a later reviewed compatibility gate."
+
+example_candidate:
+  candidate_schema_version: 1
+  candidate_id: "candidate.pack.multi-agent.github-collaboration"
+  proposed_pack_id: "pack.multi-agent.github-collaboration"
+  title: "Multi-agent GitHub collaboration"
+  outcome: "candidate"
+  confidence: "medium"
+  summary: "Evidence supports a reviewable optional pack around durable GitHub scheduler state, role dispatch, and handoff packets."
+  authority_layers:
+    core:
+      - "fixtures/capability-packs/optional-multi-agent/manifest.yaml"
+      - "GitHub issue evidence from AF9 #172"
+    selected_vault:
+      - "ASSET-COLLAB-001"
+      - "ASSET-COLLAB-002"
+      - "sanitized usage aggregate summaries"
+    generated:
+      - "adapter target breadth only"
+    runtime:
+      - "excluded from candidate authority"
+    local_private:
+      - "raw sessions and private thread history excluded"
+  observed_facts:
+    - "Existing collaboration assets group multiple practices and publish to multiple runtimes."
+    - "AF9 #172 records repeated issue, handoff, and role-dispatch evidence."
+  inference:
+    boundary: "Reusable pack for GitHub issue/PR scheduler state, role dispatch packets, review handoff, and callback templates."
+    exclusions:
+      - "project-specific labels"
+      - "private thread IDs"
+      - "runtime-native dispatch state"
+  signal_scores:
+    shared_user_goal: 3
+    asset_or_practice_membership: 3
+    workflow_recurrence: 3
+    usage_frequency: 2
+    validation_path: 2
+    adapter_projection_breadth: 3
+    fixture_or_provenance: 3
+    authority_fit: 2
+    total_signal_score: 21
+  false_positive_controls:
+    overly_broad: "pass: centered on durable multi-agent GitHub collaboration."
+    overly_narrow: "pass: includes multiple assets, practices, workflows, and templates."
+    overlapping_pack: "uncertain: may split base collaboration from Coordinator automation add-on."
+    private_only: "pass: raw private sessions are excluded."
+    stale_pack: "pass: recent sanitized usage exists."
+    runtime_wrapper: "pass: generated/runtime outputs are downstream only."
+    bootstrap_duplicate: "pass: not mandatory bootstrap."
+  privacy_and_exportability:
+    risk: "medium"
+    excluded_material:
+      - "private thread IDs"
+      - "project-specific labels and Project IDs"
+      - "raw session history"
+    exportability: "template and record-id based export may be reviewed later."
+  runtime_and_generation_impact:
+    generated_adapters: "High guidance impact across several runtimes."
+    runtime_installs: "No direct runtime install from candidate discovery."
+  review_handoff:
+    next_owner: "Reviewer"
+    required_checks:
+      - "false-positive controls"
+      - "privacy boundary"
+      - "base versus Coordinator add-on split"

--- a/workflows/discover-capability-packs.md
+++ b/workflows/discover-capability-packs.md
@@ -1,0 +1,189 @@
+# Discover Capability Packs Workflow
+
+Use this workflow when an agent or human asks whether repeated practices,
+assets, workflows, templates, or adapter projections should become an advanced
+capability pack candidate.
+
+This workflow proposes candidates only. It does not activate, export, deploy,
+install, publish, or mutate any pack, Vault record, generated adapter, runtime
+copy, private state, or memory-system record.
+
+## Invariant
+
+Capability pack discovery outputs reviewable candidate records, not canonical
+pack state.
+
+A capability pack is a bounded reusable capability contract around a recurring
+user goal. It is not:
+
+- a single practice;
+- a single asset;
+- raw evidence;
+- generated adapter output;
+- an installed runtime copy;
+- a local-private workflow history;
+- a memory-system record.
+
+## 1. Gather Evidence
+
+Use evidence in this order:
+
+1. Public Core workflows, schemas, docs, fixtures, and issue or PR records.
+2. Selected Vault canonical record metadata: practice IDs, asset IDs, lifecycle
+   status, tags, triggers, membership, published targets, review cadence, and
+   sanitized evidence summaries.
+3. Sanitized usage aggregates.
+4. Generated adapter presence as downstream projection evidence only.
+5. Runtime state only through explicit status or receipt summaries when already
+   safe to reference.
+
+Do not copy raw session logs, private Vault history, secrets, local machine
+paths, provider credentials, production logs, screenshots with private data, or
+runtime manifests into public Core.
+
+Separate observed facts from inference. Observed facts name the evidence source
+and layer. Inference names the proposed boundary and why the evidence supports
+or rejects that boundary.
+
+## 2. Apply Authority Gates
+
+Reject or defer before scoring when any authority gate fails.
+
+| Gate | Pass condition | Failure result |
+| --- | --- | --- |
+| Canonical authority | Candidate is grounded in selected Vault canonical records, public Core workflows, or reviewed fixtures. | `rejected_false_positive` |
+| Layer boundary | Generated and Runtime artifacts are downstream projection or install evidence only. | `rejected_false_positive` |
+| Privacy | Candidate can be described without local-private evidence, secrets, raw logs, or personal history. | `deferred_privacy_review` or `blocked_policy` |
+| Pack size | Candidate is broader than one asset/practice but still centered on one user goal. | `rejected_too_narrow` or `rejected_too_broad` |
+| Activation safety | Candidate can be proposed without activation, export, runtime apply, or adapter publication. | `blocked_policy` |
+| Existing coverage | Candidate does not duplicate an already sufficient pack or baseline bootstrap role. | `baseline_control` or `extend_existing` |
+
+## 3. Score Explainable Signals
+
+Score each signal as `0`, `1`, `2`, or `3`.
+
+- `0`: absent or contradicted.
+- `1`: weak or inferred from one source.
+- `2`: supported by multiple sources or repeated use.
+- `3`: strong, repeated, and backed by canonical metadata plus workflow use.
+
+Required signals:
+
+| Signal | What to inspect |
+| --- | --- |
+| `shared_user_goal` | One recurring user goal is visible across records or issues. |
+| `asset_or_practice_membership` | Multiple practices/assets cohere into a bundle. |
+| `workflow_recurrence` | The same steps or handoff shape recur across work. |
+| `usage_frequency` | Sanitized usage aggregate or repeated issue history supports recurrence. |
+| `validation_path` | The candidate has a review, test, walkthrough, or acceptance route. |
+| `adapter_projection_breadth` | Generated adapter targets suggest cross-runtime value. |
+| `fixture_or_provenance` | Existing fixture, pack, issue, or reviewed source anchors the candidate. |
+| `authority_fit` | Core/Vault/Generated/Runtime/Local Private boundaries remain clear. |
+
+Compute:
+
+```text
+total_signal_score = sum(required signal scores)
+max_signal_score = 24
+```
+
+Then attach qualitative confidence:
+
+- `high`: gates pass, score >= 18, and no high residual privacy or overlap risk.
+- `medium`: gates pass, score 12-17, or score is high but residual risk remains.
+- `low`: gates pass but score < 12, or evidence is mostly inferred.
+
+Confidence is not an activation decision. A high-confidence candidate still
+requires review before activation or export.
+
+## 4. Classify Candidate Outcome
+
+Use the first matching outcome:
+
+| Outcome | Use when |
+| --- | --- |
+| `candidate` | Gates pass, confidence is medium or high, and the pack boundary is reviewable. |
+| `baseline_control` | Evidence is pack-shaped but represents mandatory bootstrap or stable baseline behavior rather than an emergent optional pack. |
+| `extend_existing` | Evidence supports changing an existing pack rather than creating a new one. |
+| `deferred_overlap` | Boundary overlaps another candidate and needs split/merge analysis. |
+| `deferred_insufficient_evidence` | Boundary is plausible but evidence is weak, new, or mostly inferred. |
+| `deferred_privacy_review` | Pack may be useful but export/import privacy rules are not ready. |
+| `rejected_false_positive` | Candidate is actually generated output, runtime state, raw evidence, private-only workflow, or another non-pack artifact. |
+| `rejected_too_broad` | Candidate combines unrelated user goals. |
+| `rejected_too_narrow` | Candidate is only one asset, practice, command, or helper. |
+| `blocked_policy` | Candidate would require forbidden activation, export, runtime apply, memory-system work, or private-state mutation. |
+
+## 5. False-Positive Controls
+
+Every candidate review must explicitly test these controls:
+
+- Overly broad: does the candidate mix unrelated user goals?
+- Overly narrow: is it only one reusable asset or practice?
+- Overlapping pack: should it split into base and advanced packs, or extend an
+  existing pack?
+- Private-only pack: does it depend on local history, secrets, private paths, or
+  user-specific state?
+- Stale pack: does it rely on outdated assets or low recent usage?
+- Runtime wrapper: is it merely generated adapter output, runtime install state,
+  or tool availability?
+- Bootstrap duplicate: is it already covered by mandatory bootstrap or a stable
+  lifecycle baseline?
+
+## 6. Output Candidate Record
+
+Write candidate records using `schemas/capability-pack-candidate.schema.yaml`.
+
+Each record must include:
+
+- proposed pack id and title;
+- outcome and confidence;
+- observed evidence references by authority layer;
+- inferred boundary;
+- likely included practices, assets, workflows, templates, or adapter projection
+  intent;
+- explicit exclusions;
+- signal scores and total;
+- false-positive control results;
+- privacy and exportability rationale;
+- runtime/generation impact;
+- review handoff.
+
+Use public issue/comment URLs when possible. For selected Vault evidence, cite
+record IDs and sanitized aggregate summaries rather than raw private content.
+
+## 7. Review Handoff
+
+Route candidates to Reviewer for false-positive and boundary review when the
+issue contract requires it.
+
+Reviewer should check:
+
+- evidence references exist and match the claimed layer;
+- observed facts and inference are separate;
+- score rationale is understandable to a human;
+- rejected/deferred outcomes are justified;
+- Generated and Runtime artifacts are not treated as canonical;
+- no private evidence is leaked;
+- harvest and asset-discovery workflows remain compatible.
+
+After review, Architect decides whether to:
+
+- keep the candidate as evidence only;
+- create a follow-up for schema evolution;
+- create a follow-up for lifecycle design;
+- create a follow-up for privacy-safe export/import;
+- create a follow-up for implementation;
+- close as rejected or deferred.
+
+## 8. AF9 Fixture Expectations
+
+Use these fixtures from AF9 #172 while validating the protocol:
+
+| Fixture | Expected treatment |
+| --- | --- |
+| Multi-agent GitHub collaboration / role dispatch | Positive candidate input. Consider split/merge analysis for base collaboration versus Coordinator automation add-on. |
+| Practice/asset lifecycle bootstrap | Baseline control. It is mandatory/stable, not a new optional emergent pack. |
+| Provider integration playbook | Plausible candidate with privacy-sensitive evidence. Keep activation/export deferred until privacy-safe evidence references exist. |
+| Architecture/frontend workflow design | Deferred overlap candidate. ASSET-UX-001 is newer and needs more usage evidence before exportable status. |
+| Runtime adapters as a capability pack | Negative false-positive fixture. Generated/runtime artifacts are downstream only. |
+| Document/format workflow | Deferred insufficient-evidence fixture until canonical asset/workflow evidence accumulates. |


### PR DESCRIPTION
## Summary

- Add `workflows/discover-capability-packs.md` for AF9 capability pack candidate discovery.
- Add `schemas/capability-pack-candidate.schema.yaml` as a human-readable candidate output format.
- Encode #172 fixture treatment for positive, baseline, privacy-sensitive, deferred, and false-positive candidates.

## Issue

Closes #173 after review/merge acceptance.

## Verification

- `python3 scripts/check_consistency.py`
- `git diff --check -- workflows/discover-capability-packs.md schemas/capability-pack-candidate.schema.yaml`
- `git diff --cached --check`

PyYAML was not installed in the local environment, so YAML parser validation was not run.

## Boundaries

- No pack activation/export.
- No runtime apply.
- No Vault/runtime/generated/private-state mutation.
- No memory-system work.
- No Epic closure.