### PR TITLE
AF9 #174 validate advanced capability pack metadata

### DIFF
--- a/fixtures/capability-packs/optional-multi-agent/manifest.yaml
+++ b/fixtures/capability-packs/optional-multi-agent/manifest.yaml
@@ -15,13 +15,38 @@ review_state: accepted
 pack_contract:
   promised_use_case: "Help a project operate GitHub issues, PRs, labels, comments, and optional Project status as a lightweight multi-agent scheduler."
   deployment_role: "optional user-selected capability after bootstrap"
-  source_authority_after_deployment: "selected User Vault records and managed runtime/tool install receipts"
-  not_runtime_authority: "pack staging, product project evidence, and Core fixture paths"
+  source_authority_after_deployment: "selected User Vault records"
+  non_authority_boundaries: [generated adapters are downstream only, runtime installs are downstream only, pack staging is transfer evidence only, Core fixtures are schema and test evidence only]
 
 evidence_sources:
   - "Tiny IPA tools/agents helper suite"
   - "Tiny IPA role-generic agent helper design notes"
   - "Agent Foundry #53 executable helper boundary"
+
+export_policy:
+  exportability: review_required
+  privacy_class: sanitized
+  excluded_material: [private project ids, local runtime receipts, raw session history]
+  review_required: true
+
+runtime_projection:
+  downstream_only: true
+  generated_adapter_intent: generated_adapter_projection
+  runtime_install: review_required
+  authority: downstream_only
+
+lifecycle_policy:
+  split_behavior: review_required
+  merge_behavior: review_required
+  deprecation_behavior: review_required
+  update_behavior: reviewed_diff_required
+
+candidate_provenance:
+  review_only: true
+  candidate_ids: [AF9-optional-multi-agent]
+  canonical: false
+  activation_input: false
+  export_input: false
 
 candidate_contents:
   practices:

--- a/schemas/capability-pack-manifest.schema.yaml
+++ b/schemas/capability-pack-manifest.schema.yaml
@@ -52,12 +52,47 @@ executable_payload_fields:
   dependencies: "Declared runtime dependencies."
   runtime_impact: "Human-readable statement of affected runtime targets after managed install."
 
+advanced_metadata_sections:
+  pack_contract:
+    promised_use_case: "Human-readable capability promise for reviewers and deployers."
+    deployment_role: "How the reviewed pack is intended to be selected or deployed."
+    source_authority_after_deployment: "Must name selected User Vault records as canonical after deployment."
+    non_authority_boundaries: "Generated adapters, runtime installs, pack staging, Core fixtures, and local private evidence are downstream or non-authoritative."
+  evidence_sources:
+    description: "Public or sanitized evidence references only."
+    allowed_references: "Public Core paths, public GitHub issues/PRs, release notes, record ids, or sanitized aggregate summaries."
+    forbidden_references: "Absolute local paths, raw sessions, raw logs, secrets, local runtime manifests, private Vault evidence, or usage rows."
+  export_policy:
+    exportability: "not_exportable | review_required | exportable_after_review"
+    privacy_class: "public | internal | sanitized"
+    excluded_material: "Private/local/raw evidence that must stay outside the pack."
+    review_required: "Boolean. Must be true before exportable pack use."
+  runtime_projection:
+    downstream_only: "Boolean. Must be true when this section is present."
+    generated_adapter_intent: "none | generated_adapter_projection | review_required"
+    runtime_install: "false | review_required. Runtime apply is never implied by a manifest."
+    authority: "none | false | downstream_only"
+  lifecycle_policy:
+    split_behavior: "review_required | preserve_user_state | reviewed_diff_required | human_review_required | manual_review | not_supported"
+    merge_behavior: "review_required | preserve_user_state | reviewed_diff_required | human_review_required | manual_review | not_supported"
+    deprecation_behavior: "review_required | preserve_user_state | reviewed_diff_required | human_review_required | manual_review | not_supported"
+    update_behavior: "review_required | preserve_user_state | reviewed_diff_required | human_review_required | manual_review | not_supported"
+  candidate_provenance:
+    review_only: "Must be true. Candidate records remain review artifacts."
+    candidate_ids: "Candidate ids or issue references used as provenance only."
+    canonical: "Must not be true."
+    activation_input: "Must not be true."
+    export_input: "Must not be true."
+
 rules:
   - "A pack snapshot is a transfer and review artifact, not a live source of truth after deployment."
   - "After deployment, selected User Vault records own canonical practice, asset, membership, and provenance state."
   - "Do not package raw maintainer Vault evidence, local runtime manifests, secrets, or private User Vault content."
   - "All included files and executable payload sources must have checksums."
   - "Executable payloads must be declared but must not be executed from pack staging."
+  - "AF-9 advanced metadata sections are optional and additive; manifest_schema_version: 1 fixtures without them remain valid."
+  - "Known AF-9 advanced metadata sections must fail closed when malformed, private/local, unsafe, or claiming runtime/generated/Core/pack authority."
+  - "Candidate records remain review-only provenance and must not be treated as active manifests, activation inputs, or export inputs."
   - "Same id, same version, different hash must fail closed and require review."
   - "Same id from unrelated provenance or incompatible kind must fail closed."
   - "Local Vault edits must be treated as canonical user state and handled through a reviewed merge proposal."

--- a/scripts/check_capability_pack_fixtures.py
+++ b/scripts/check_capability_pack_fixtures.py
@@ -13,6 +13,7 @@ import sys
 from pathlib import Path
 
 from check_foundry_roots import validate as validate_roots
+from plan_capability_pack import validate_advanced_metadata_text
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -150,6 +151,7 @@ def check_manifest(path: Path) -> list[str]:
     text = read(path)
     rel_manifest = path.relative_to(ROOT)
     errors.extend(check_no_forbidden_fixture_text(rel_manifest, path))
+    errors.extend(validate_advanced_metadata_text(text, str(rel_manifest)))
     manifest = top_level_scalars(text)
     missing = sorted(REQUIRED_MANIFEST_FIELDS - manifest.keys())
     for field in missing:

--- a/scripts/compare_capability_pack_update.py
+++ b/scripts/compare_capability_pack_update.py
@@ -24,6 +24,9 @@ def deployed_pack_metadata(vault_root: Path, pack_id: str) -> tuple[dict[str, ob
         return {}, "deployed-pack-index.yaml deployed_packs must be a list"
     for pack in packs:
         if isinstance(pack, dict) and pack.get("pack_id") == pack_id:
+            metadata_errors = planner.validate_deployed_pack_metadata(pack, pack_id)
+            if metadata_errors:
+                return {}, "; ".join(metadata_errors)
             return pack, ""
     return {}, ""
 

--- a/scripts/manage_capability_pack_lifecycle.py
+++ b/scripts/manage_capability_pack_lifecycle.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from check_foundry_roots import validate
 from deploy_capability_pack import parse_simple_yaml
 from foundry_config import ROOT
+from plan_capability_pack import validate_deployed_pack_metadata
 
 
 PRACTICE_RETIRE_STATUS = "archived"
@@ -88,6 +89,9 @@ def deployed_pack_records(vault_root: Path, pack_id: str) -> tuple[list[PackReco
     for pack in packs:
         if not isinstance(pack, dict) or pack.get("pack_id") != pack_id:
             continue
+        metadata_errors = validate_deployed_pack_metadata(pack, pack_id)
+        if metadata_errors:
+            return [], lines, start, end, metadata_errors
         pack_records = pack.get("records", [])
         if pack_records in ({}, None):
             return [], lines, start, end, []

--- a/scripts/plan_capability_pack.py
+++ b/scripts/plan_capability_pack.py
@@ -68,6 +68,37 @@ REQUIRED_INTEGRITY_FIELDS = {
     "private_vault_content",
 }
 REQUIRED_DEPLOYED_PACK_FIELDS = {"pack_id", "version", "source"}
+ADVANCED_METADATA_SECTIONS = {
+    "pack_contract",
+    "evidence_sources",
+    "export_policy",
+    "runtime_projection",
+    "lifecycle_policy",
+    "candidate_provenance",
+}
+ADVANCED_AUTHORITY_REJECT_RE = re.compile(
+    r"\b(runtime|generated|adapter|pack snapshot|pack staging|core fixture|local private|private vault|"
+    r"canonical authority|source of truth)\b",
+    re.IGNORECASE,
+)
+PRIVATE_REFERENCE_RE = re.compile(
+    r"(^/|~|/Users/|\.agent-foundry|\.codex|\.trae|private|secret|token|session|transcript|"
+    r"raw log|usage row|runtime manifest|local receipt)",
+    re.IGNORECASE,
+)
+UNSAFE_LIFECYCLE_RE = re.compile(r"\b(automatic|auto|force|overwrite|delete|destructive|runtime apply|install)\b", re.IGNORECASE)
+
+ALLOWED_EXPORTABILITY = {"not_exportable", "review_required", "exportable_after_review"}
+ALLOWED_PRIVACY_CLASSES = {"public", "internal", "sanitized"}
+ALLOWED_RUNTIME_INTENT = {"none", "generated_adapter_projection", "review_required"}
+ALLOWED_LIFECYCLE_VALUES = {
+    "review_required",
+    "preserve_user_state",
+    "reviewed_diff_required",
+    "human_review_required",
+    "manual_review",
+    "not_supported",
+}
 
 
 @dataclass(frozen=True)
@@ -173,6 +204,174 @@ def deployed_pack_records(vault_root: Path, pack_id: str) -> tuple[dict[str, dic
     return {}, []
 
 
+def object_to_scalar_text(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, list):
+        return " ".join(object_to_scalar_text(item) for item in value)
+    return ""
+
+
+def scalar_texts(value: object) -> list[str]:
+    texts: list[str] = []
+    if isinstance(value, dict):
+        for nested in value.values():
+            texts.extend(scalar_texts(nested))
+        return texts
+    if isinstance(value, list):
+        for item in value:
+            texts.extend(scalar_texts(item))
+        return texts
+    text = object_to_scalar_text(value)
+    return [text] if text else []
+
+
+def require_mapping(section: object, section_name: str, label: str) -> tuple[dict[str, object], list[str]]:
+    if section == {}:
+        return {}, [f"{label}: {section_name} must be a mapping with explicit fields"]
+    if not isinstance(section, dict):
+        return {}, [f"{label}: {section_name} must be a mapping"]
+    return section, []
+
+
+def reject_private_references(section_name: str, value: object, label: str) -> list[str]:
+    errors: list[str] = []
+    for text in scalar_texts(value):
+        if PRIVATE_REFERENCE_RE.search(text):
+            errors.append(f"{label}: {section_name} contains private/local evidence reference: {text}")
+    return errors
+
+
+def validate_pack_contract(section: object, label: str) -> list[str]:
+    contract, errors = require_mapping(section, "pack_contract", label)
+    for field in ["promised_use_case", "deployment_role", "source_authority_after_deployment", "non_authority_boundaries"]:
+        if field not in contract:
+            errors.append(f"{label}: pack_contract missing {field}")
+    authority = object_to_scalar_text(contract.get("source_authority_after_deployment", ""))
+    if "selected" not in authority.lower() or "vault" not in authority.lower():
+        errors.append(f"{label}: pack_contract source_authority_after_deployment must name selected Vault authority")
+    if ADVANCED_AUTHORITY_REJECT_RE.search(authority):
+        errors.append(
+            f"{label}: pack_contract source_authority_after_deployment must not claim runtime/generated/Core/pack authority"
+        )
+    boundaries = contract.get("non_authority_boundaries", [])
+    boundary_text = " ".join(scalar_texts(boundaries)).lower()
+    if not boundary_text:
+        errors.append(f"{label}: pack_contract non_authority_boundaries must name excluded authority surfaces")
+    if "runtime" not in boundary_text or "generated" not in boundary_text:
+        errors.append(f"{label}: pack_contract non_authority_boundaries must include generated and runtime as downstream only")
+    return errors
+
+
+def validate_evidence_sources(section: object, label: str) -> list[str]:
+    errors: list[str] = []
+    if section in ({}, None):
+        return [f"{label}: evidence_sources must be a non-empty list"]
+    if not isinstance(section, list):
+        return [f"{label}: evidence_sources must be a list"]
+    for index, source in enumerate(section, start=1):
+        if isinstance(source, dict):
+            ref = object_to_scalar_text(source.get("ref", "")) or object_to_scalar_text(source.get("url", ""))
+            if not ref:
+                errors.append(f"{label}: evidence_sources item {index} missing ref or url")
+        elif not isinstance(source, str) or not source.strip():
+            errors.append(f"{label}: evidence_sources item {index} must be a non-empty string or mapping")
+        errors.extend(reject_private_references(f"evidence_sources item {index}", source, label))
+    return errors
+
+
+def validate_export_policy(section: object, label: str) -> list[str]:
+    policy, errors = require_mapping(section, "export_policy", label)
+    exportability = object_to_scalar_text(policy.get("exportability", ""))
+    privacy_class = object_to_scalar_text(policy.get("privacy_class", ""))
+    review_required = object_to_scalar_text(policy.get("review_required", "")).lower()
+    if exportability not in ALLOWED_EXPORTABILITY:
+        errors.append(f"{label}: export_policy exportability must be one of {sorted(ALLOWED_EXPORTABILITY)}")
+    if privacy_class not in ALLOWED_PRIVACY_CLASSES:
+        errors.append(f"{label}: export_policy privacy_class must be one of {sorted(ALLOWED_PRIVACY_CLASSES)}")
+    if exportability != "not_exportable" and review_required != "true":
+        errors.append(f"{label}: export_policy review_required must be true before exportable pack use")
+    reference_fields = {key: value for key, value in policy.items() if str(key) not in {"excluded_material", "exclusions"}}
+    errors.extend(reject_private_references("export_policy", reference_fields, label))
+    return errors
+
+
+def validate_runtime_projection(section: object, label: str) -> list[str]:
+    projection, errors = require_mapping(section, "runtime_projection", label)
+    downstream_only = object_to_scalar_text(projection.get("downstream_only", "")).lower()
+    runtime_install = object_to_scalar_text(projection.get("runtime_install", "")).lower()
+    intent = object_to_scalar_text(projection.get("generated_adapter_intent", ""))
+    if downstream_only != "true":
+        errors.append(f"{label}: runtime_projection downstream_only must be true")
+    if runtime_install not in {"false", "review_required"}:
+        errors.append(f"{label}: runtime_projection runtime_install must be false or review_required")
+    if intent and intent not in ALLOWED_RUNTIME_INTENT:
+        errors.append(f"{label}: runtime_projection generated_adapter_intent must be one of {sorted(ALLOWED_RUNTIME_INTENT)}")
+    for field in ["authority", "canonical_authority", "source_authority"]:
+        claim = object_to_scalar_text(projection.get(field, ""))
+        if claim and claim.lower() not in {"none", "false", "downstream_only"}:
+            errors.append(f"{label}: runtime_projection {field} must not claim authority")
+    errors.extend(reject_private_references("runtime_projection", projection, label))
+    return errors
+
+
+def validate_lifecycle_policy(section: object, label: str) -> list[str]:
+    policy, errors = require_mapping(section, "lifecycle_policy", label)
+    for field, value in policy.items():
+        text = object_to_scalar_text(value)
+        if text and text not in ALLOWED_LIFECYCLE_VALUES:
+            errors.append(f"{label}: lifecycle_policy {field} must be review-only; got {text}")
+        if UNSAFE_LIFECYCLE_RE.search(text):
+            errors.append(f"{label}: lifecycle_policy {field} contains unsafe lifecycle claim: {text}")
+    return errors
+
+
+def validate_candidate_provenance(section: object, label: str) -> list[str]:
+    provenance, errors = require_mapping(section, "candidate_provenance", label)
+    if object_to_scalar_text(provenance.get("review_only", "")).lower() != "true":
+        errors.append(f"{label}: candidate_provenance review_only must be true")
+    for field in ["canonical", "activation_input", "export_input"]:
+        if object_to_scalar_text(provenance.get(field, "")).lower() == "true":
+            errors.append(f"{label}: candidate_provenance {field} must not be true")
+    errors.extend(reject_private_references("candidate_provenance", provenance, label))
+    return errors
+
+
+def validate_advanced_metadata_text(text: str, label: str) -> list[str]:
+    try:
+        parsed = parse_simple_yaml(text)
+    except ValueError as exc:
+        return [f"{label}: parse error: {exc}"]
+    if not isinstance(parsed, dict):
+        return [f"{label}: manifest metadata must be a mapping"]
+    return validate_advanced_metadata(parsed, label)
+
+
+def validate_advanced_metadata(parsed: dict[object, object], label: str) -> list[str]:
+    errors: list[str] = []
+    if "candidate_schema_version" in parsed and "manifest_schema_version" not in parsed:
+        errors.append(f"{label}: candidate schema records are review-only and cannot be used as active pack manifests")
+    for section_name in ADVANCED_METADATA_SECTIONS & {str(key) for key in parsed}:
+        section = parsed.get(section_name)
+        if section_name == "pack_contract":
+            errors.extend(validate_pack_contract(section, label))
+        elif section_name == "evidence_sources":
+            errors.extend(validate_evidence_sources(section, label))
+        elif section_name == "export_policy":
+            errors.extend(validate_export_policy(section, label))
+        elif section_name == "runtime_projection":
+            errors.extend(validate_runtime_projection(section, label))
+        elif section_name == "lifecycle_policy":
+            errors.extend(validate_lifecycle_policy(section, label))
+        elif section_name == "candidate_provenance":
+            errors.extend(validate_candidate_provenance(section, label))
+    return errors
+
+
 def validate_deployed_pack_metadata(pack: dict[object, object], pack_id: str) -> list[str]:
     errors: list[str] = []
     for field in sorted(REQUIRED_DEPLOYED_PACK_FIELDS - {str(key) for key in pack}):
@@ -184,6 +383,7 @@ def validate_deployed_pack_metadata(pack: dict[object, object], pack_id: str) ->
         manifest_sha = str(source.get("manifest_sha256", ""))
         if not SHA256_RE.match(manifest_sha):
             errors.append(f"deployed pack {pack_id} source.manifest_sha256 must be sha256")
+    errors.extend(validate_advanced_metadata(pack, f"deployed pack {pack_id}"))
     return errors
 
 
@@ -230,6 +430,7 @@ def validate_manifest(core_root: Path, vault_root: Path, pack_root: Path) -> tup
     manifest_text = read(manifest_path)
     manifest = top_level_scalars(manifest_text)
     errors: list[str] = []
+    errors.extend(validate_advanced_metadata_text(manifest_text, str(manifest_path)))
     for field in sorted(REQUIRED_PLAN_MANIFEST_FIELDS - manifest.keys()):
         errors.append(f"manifest missing {field}")
     if manifest.get("manifest_schema_version", "") != SUPPORTED_MANIFEST_SCHEMA_VERSION:

--- a/scripts/plan_capability_pack.py
+++ b/scripts/plan_capability_pack.py
@@ -353,7 +353,7 @@ def validate_advanced_metadata_text(text: str, label: str) -> list[str]:
 
 def validate_advanced_metadata(parsed: dict[object, object], label: str) -> list[str]:
     errors: list[str] = []
-    if "candidate_schema_version" in parsed and "manifest_schema_version" not in parsed:
+    if "candidate_schema_version" in parsed:
         errors.append(f"{label}: candidate schema records are review-only and cannot be used as active pack manifests")
     for section_name in ADVANCED_METADATA_SECTIONS & {str(key) for key in parsed}:
         section = parsed.get(section_name)

--- a/scripts/test_capability_pack_lifecycle.py
+++ b/scripts/test_capability_pack_lifecycle.py
@@ -130,6 +130,30 @@ def status(vault: Path, generated: Path, receipt: Path) -> subprocess.CompletedP
     )
 
 
+def add_deployed_pack_contract(vault: Path, source_authority: str) -> None:
+    index = vault / "packs" / "deployed-pack-index.yaml"
+    text = index.read_text(encoding="utf-8")
+    marker = "    records:\n"
+    index.write_text(
+        text.replace(
+            marker,
+            "\n".join(
+                [
+                    "    pack_contract:",
+                    "      promised_use_case: lifecycle fixture",
+                    "      deployment_role: optional user-selected capability",
+                    f"      source_authority_after_deployment: {source_authority}",
+                    "      non_authority_boundaries: [generated adapters are downstream only, runtime installs are downstream only]",
+                    "    records:",
+                    "",
+                ]
+            ),
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+
 def main() -> int:
     errors: list[str] = []
     with tempfile.TemporaryDirectory(prefix="agent-foundry-pack-lifecycle-") as tmp:
@@ -204,6 +228,19 @@ def main() -> int:
         errors.extend(expect("disable-dry-run", dry_disable, True, "writes: none"))
         if digest(metadata) != metadata_before:
             errors.append("disable-dry-run: metadata changed")
+
+        metadata_with_valid_contract = metadata.read_text(encoding="utf-8")
+        add_deployed_pack_contract(vault, "runtime generated adapter authority")
+        unsafe_lifecycle_metadata = lifecycle(vault, "disable", apply=False)
+        errors.extend(
+            expect(
+                "disable-unsafe-deployed-metadata-fails",
+                unsafe_lifecycle_metadata,
+                False,
+                "must not claim runtime/generated/Core/pack authority",
+            )
+        )
+        metadata.write_text(metadata_with_valid_contract, encoding="utf-8")
 
         apply_disable = lifecycle(vault, "disable", apply=True)
         errors.extend(expect("disable-apply", apply_disable, True, "writes: applied"))

--- a/scripts/test_capability_pack_plan.py
+++ b/scripts/test_capability_pack_plan.py
@@ -88,6 +88,7 @@ def write_probe_pack(
     include_integrity: bool = True,
     core_schema_min: str = "1",
     core_schema_max: str = "1",
+    advanced_metadata: list[str] | None = None,
 ) -> Path:
     pack = base / name
     pack.mkdir(parents=True, exist_ok=True)
@@ -115,6 +116,9 @@ def write_probe_pack(
     ]
     if include_source_provenance:
         lines.insert(8, "source_provenance: test fixture")
+    if advanced_metadata:
+        compatibility_index = lines.index("compatibility:")
+        lines[compatibility_index:compatibility_index] = ["", *advanced_metadata, ""]
     for record in records:
         kind = record.get("kind", "practice")
         lines.extend(
@@ -249,6 +253,36 @@ def write_reordered_deployed_index(
                 f"        path: practices/meta/BOOT-001-bootstrap-orientation.md",
                 f"        deployed_sha256: \"{record_hash}\"",
                 f"        id: \"{record_id}\"",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def write_advanced_deployed_index(
+    vault: Path, pack_id: str, version: str, manifest_hash: str, record_id: str, record_hash: str
+) -> None:
+    packs = vault / "packs"
+    packs.mkdir(parents=True, exist_ok=True)
+    (packs / "deployed-pack-index.yaml").write_text(
+        "\n".join(
+            [
+                "schema_version: 1",
+                "updated: 2026-06-12",
+                "deployed_packs:",
+                f"  - pack_id: {pack_id}",
+                f"    version: {version}",
+                "    source:",
+                f"      manifest_sha256: {manifest_hash}",
+                "    pack_contract:",
+                "      promised_use_case: reviewed deployed metadata fixture",
+                "      deployment_role: optional user-selected capability",
+                "      source_authority_after_deployment: selected User Vault records",
+                "      non_authority_boundaries: [generated adapters are downstream only, runtime installs are downstream only]",
+                "    records:",
+                f"      - id: {record_id}",
+                f"        deployed_sha256: {record_hash}",
                 "",
             ]
         ),
@@ -407,6 +441,118 @@ def main() -> int:
         errors.extend(expect("plan-optional-adds-records", optional_after_bootstrap, True, "add: 2"))
         errors.extend(expect("plan-optional-no-executable-block", optional_after_bootstrap, True, "blocked_executable_install: 0"))
 
+        advanced_record = base / "advanced-metadata" / "records" / "ADV.md"
+        advanced_record.parent.mkdir(parents=True, exist_ok=True)
+        advanced_record.write_text(practice_text("ADV-001"), encoding="utf-8")
+        advanced_pack = write_probe_pack(
+            base,
+            "advanced-metadata",
+            [{"id": "ADV-001", "path": "records/ADV.md", "sha": sha256(advanced_record)}],
+            advanced_metadata=[
+                "pack_contract:",
+                "  promised_use_case: reviewed optional capability fixture",
+                "  deployment_role: optional user-selected capability",
+                "  source_authority_after_deployment: selected User Vault records",
+                "  non_authority_boundaries: [generated adapters are downstream only, runtime installs are downstream only]",
+                "export_policy:",
+                "  exportability: review_required",
+                "  privacy_class: sanitized",
+                "  excluded_material: [private evidence, raw logs]",
+                "  review_required: true",
+                "runtime_projection:",
+                "  downstream_only: true",
+                "  generated_adapter_intent: generated_adapter_projection",
+                "  runtime_install: review_required",
+                "  authority: downstream_only",
+                "lifecycle_policy:",
+                "  split_behavior: review_required",
+                "  merge_behavior: review_required",
+                "  deprecation_behavior: review_required",
+                "  update_behavior: reviewed_diff_required",
+                "candidate_provenance:",
+                "  review_only: true",
+                "  candidate_ids: [candidate.probe.advanced]",
+                "  canonical: false",
+                "  activation_input: false",
+                "  export_input: false",
+            ],
+        )
+        advanced_metadata = plan_pack(advanced_pack, vault)
+        errors.extend(expect("plan-advanced-metadata-valid", advanced_metadata, True, "add: 1"))
+
+        bad_authority_record = base / "bad-advanced-authority" / "records" / "BAD.md"
+        bad_authority_record.parent.mkdir(parents=True, exist_ok=True)
+        bad_authority_record.write_text(practice_text("BAD-AUTH-001"), encoding="utf-8")
+        bad_authority_pack = write_probe_pack(
+            base,
+            "bad-advanced-authority",
+            [{"id": "BAD-AUTH-001", "path": "records/BAD.md", "sha": sha256(bad_authority_record)}],
+            advanced_metadata=[
+                "pack_contract:",
+                "  promised_use_case: unsafe authority fixture",
+                "  deployment_role: optional user-selected capability",
+                "  source_authority_after_deployment: runtime generated adapter is canonical authority",
+                "  non_authority_boundaries: [generated adapters are downstream only, runtime installs are downstream only]",
+            ],
+        )
+        bad_authority = plan_pack(bad_authority_pack, vault)
+        errors.extend(
+            expect(
+                "plan-advanced-runtime-authority-fails-closed",
+                bad_authority,
+                False,
+                "must not claim runtime/generated/Core/pack authority",
+            )
+        )
+
+        bad_evidence_record = base / "bad-advanced-evidence" / "records" / "BAD.md"
+        bad_evidence_record.parent.mkdir(parents=True, exist_ok=True)
+        bad_evidence_record.write_text(practice_text("BAD-EVIDENCE-001"), encoding="utf-8")
+        bad_evidence_pack = write_probe_pack(
+            base,
+            "bad-advanced-evidence",
+            [{"id": "BAD-EVIDENCE-001", "path": "records/BAD.md", "sha": sha256(bad_evidence_record)}],
+            advanced_metadata=[
+                "evidence_sources:",
+                "  - /Users/example/private/raw-session.log",
+            ],
+        )
+        bad_evidence = plan_pack(bad_evidence_pack, vault)
+        errors.extend(
+            expect(
+                "plan-private-evidence-fails-closed",
+                bad_evidence,
+                False,
+                "private/local evidence reference",
+            )
+        )
+
+        candidate_manifest = base / "candidate-schema-as-pack" / "manifest.yaml"
+        candidate_manifest.parent.mkdir(parents=True, exist_ok=True)
+        candidate_manifest.write_text(
+            "\n".join(
+                [
+                    "candidate_schema_version: 1",
+                    "candidate_id: candidate.probe.review-only",
+                    "proposed_pack_id: pack.probe.review-only",
+                    "title: Review-only candidate",
+                    "outcome: candidate",
+                    "confidence: medium",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        candidate_as_manifest = plan_pack(candidate_manifest.parent, vault)
+        errors.extend(
+            expect(
+                "plan-candidate-schema-review-only",
+                candidate_as_manifest,
+                False,
+                "candidate schema records are review-only",
+            )
+        )
+
         write_deployed_index(
             vault,
             "pack.multi-agent.optional",
@@ -443,6 +589,17 @@ def main() -> int:
         )
         reordered = plan_pack(BOOTSTRAP_PACK, vault)
         errors.extend(expect("plan-reordered-metadata-parses", reordered, True, "skip: 24"))
+
+        write_advanced_deployed_index(
+            vault,
+            "pack.bootstrap.minimal",
+            "0.2.0",
+            sha256(BOOTSTRAP_PACK / "manifest.yaml"),
+            "BOOT-001",
+            sha256(target),
+        )
+        advanced_deployed_index = plan_pack(BOOTSTRAP_PACK, vault)
+        errors.extend(expect("plan-advanced-deployed-index-parses", advanced_deployed_index, True, "skip: 24"))
 
         write_malformed_deployed_index(vault)
         malformed_metadata = plan_pack(BOOTSTRAP_PACK, vault)

--- a/scripts/test_capability_pack_plan.py
+++ b/scripts/test_capability_pack_plan.py
@@ -553,6 +553,29 @@ def main() -> int:
             )
         )
 
+        hybrid_record = base / "hybrid-candidate-manifest" / "records" / "HYBRID.md"
+        hybrid_record.parent.mkdir(parents=True, exist_ok=True)
+        hybrid_record.write_text(practice_text("HYBRID-001"), encoding="utf-8")
+        hybrid_pack = write_probe_pack(
+            base,
+            "hybrid-candidate-manifest",
+            [{"id": "HYBRID-001", "path": "records/HYBRID.md", "sha": sha256(hybrid_record)}],
+        )
+        hybrid_manifest = hybrid_pack / "manifest.yaml"
+        hybrid_manifest.write_text(
+            "candidate_schema_version: 1\n" + hybrid_manifest.read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+        hybrid_candidate_as_manifest = plan_pack(hybrid_pack, vault)
+        errors.extend(
+            expect(
+                "plan-hybrid-candidate-manifest-review-only",
+                hybrid_candidate_as_manifest,
+                False,
+                "candidate schema records are review-only",
+            )
+        )
+
         write_deployed_index(
             vault,
             "pack.multi-agent.optional",

--- a/scripts/test_capability_pack_update.py
+++ b/scripts/test_capability_pack_update.py
@@ -166,6 +166,30 @@ def compare_pack(pack_root: Path, vault_root: Path) -> subprocess.CompletedProce
     return run([str(COMPARE), str(pack_root), "--core-root", str(ROOT), "--vault-root", str(vault_root)])
 
 
+def add_deployed_pack_contract(vault_root: Path, source_authority: str) -> None:
+    index = vault_root / "packs" / "deployed-pack-index.yaml"
+    text = index.read_text(encoding="utf-8")
+    marker = "    records:\n"
+    index.write_text(
+        text.replace(
+            marker,
+            "\n".join(
+                [
+                    "    pack_contract:",
+                    "      promised_use_case: update comparison fixture",
+                    "      deployment_role: optional user-selected capability",
+                    f"      source_authority_after_deployment: {source_authority}",
+                    "      non_authority_boundaries: [generated adapters are downstream only, runtime installs are downstream only]",
+                    "    records:",
+                    "",
+                ]
+            ),
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+
 def main() -> int:
     errors: list[str] = []
     with tempfile.TemporaryDirectory(prefix="agent-foundry-pack-update-") as tmp:
@@ -187,7 +211,21 @@ def main() -> int:
 
         errors.extend(expect("init-blank-vault", init_blank(vault), True, "Blank Vault initialized and validated."))
         errors.extend(expect("apply-v1", apply_pack(v1, vault), True, "metadata: written"))
+        index_after_apply = (vault / "packs" / "deployed-pack-index.yaml").read_text(encoding="utf-8")
         errors.extend(expect("compare-unchanged", compare_pack(v1, vault), True, "status: unchanged"))
+        add_deployed_pack_contract(vault, "selected User Vault records")
+        errors.extend(expect("compare-advanced-deployed-metadata", compare_pack(v1, vault), True, "status: unchanged"))
+        (vault / "packs" / "deployed-pack-index.yaml").write_text(index_after_apply, encoding="utf-8")
+        add_deployed_pack_contract(vault, "runtime generated adapter authority")
+        errors.extend(
+            expect(
+                "compare-unsafe-deployed-metadata-fails",
+                compare_pack(v1, vault),
+                False,
+                "must not claim runtime/generated/Core/pack authority",
+            )
+        )
+        (vault / "packs" / "deployed-pack-index.yaml").write_text(index_after_apply, encoding="utf-8")
         errors.extend(expect("compare-same-version-mismatch", compare_pack(v1_same_version_changed, vault), False, "same pack id and version"))
         errors.extend(expect("compare-clean-update", compare_pack(v2, vault), True, "status: clean_update_available"))
         errors.extend(expect("compare-clean-update-count", compare_pack(v2, vault), True, "clean_update: 1"))


### PR DESCRIPTION
## Scope

Implements #174 using the accepted Architect packet in issue comment 4726560118.

- Extends the human-readable capability pack manifest schema with optional AF9 advanced metadata sections.
- Adds fail-closed validation for known advanced sections in `plan_capability_pack.py`, reused by fixture checks, update comparison, apply planning, and lifecycle metadata reads.
- Preserves `manifest_schema_version: 1` compatibility for existing fixtures without advanced sections.
- Keeps candidate schema records review-only; candidate records are rejected as active pack manifests.
- Adds regression coverage for valid advanced metadata, malformed/runtime-authority claims, private/local evidence references, candidate-as-manifest rejection, and mixed deployed-pack index metadata.

## Verification

- `python3 -m py_compile scripts/plan_capability_pack.py scripts/check_capability_pack_fixtures.py scripts/compare_capability_pack_update.py scripts/manage_capability_pack_lifecycle.py scripts/test_capability_pack_plan.py scripts/test_capability_pack_update.py scripts/test_capability_pack_lifecycle.py`
- `python3 scripts/check_capability_pack_fixtures.py`
- `python3 scripts/test_capability_pack_plan.py`
- `python3 scripts/test_capability_pack_apply.py`
- `python3 scripts/test_capability_pack_update.py`
- `python3 scripts/test_capability_pack_lifecycle.py`
- `python3 scripts/check_consistency.py`
- `git diff --check`

## Safety

- No live Vault records mutated.
- No runtime config, generated adapters, private state, or memory-system records changed.
- No runtime apply, activation, export, merge, or issue closure performed.

## Residual Risks

- Advanced section parsing remains aligned with the repository's current dependency-free YAML subset parser; richer future manifest shapes may need a stricter structured validator.
- The validation enumerates currently accepted AF9 metadata values conservatively; future lifecycle/export semantics in #175/#176 may need additive enum expansion.

Reviewer target: compatibility and failure-mode review for #174.