### PR TITLE
AF9 #175 define capability pack lifecycle reporting

### DIFF
--- a/scripts/manage_capability_pack_lifecycle.py
+++ b/scripts/manage_capability_pack_lifecycle.py
@@ -390,6 +390,7 @@ def lifecycle(core_root: Path, vault_root: Path, pack_id: str, action: str, appl
         print("status: failed")
         for error in metadata_errors:
             print(f"- {error}")
+        print_followup_guidance(action)
         print("writes: none")
         return 1
     if start == -1:

--- a/scripts/manage_capability_pack_lifecycle.py
+++ b/scripts/manage_capability_pack_lifecycle.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Plan or apply disable/retire lifecycle transitions for deployed packs."""
+"""Plan or apply safe lifecycle transitions for deployed capability packs."""
 
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -11,11 +12,36 @@ from pathlib import Path
 from check_foundry_roots import validate
 from deploy_capability_pack import parse_simple_yaml
 from foundry_config import ROOT
-from plan_capability_pack import validate_deployed_pack_metadata
+from plan_capability_pack import scalar_texts, validate_deployed_pack_metadata
 
 
 PRACTICE_RETIRE_STATUS = "archived"
 ASSET_RETIRE_STATUS = "retired"
+LIFECYCLE_STATES = {
+    "detected",
+    "candidate",
+    "proposed",
+    "active",
+    "exportable",
+    "deprecated",
+    "split",
+    "merged",
+    "retired",
+    "blocked",
+}
+LEGACY_DEPLOYED_STATES = {"deployed", "disabled"}
+WRITE_ACTIONS = {"disable", "retire"}
+REVIEW_ONLY_ACTIONS = {"activate", "exportable", "deprecate", "split", "merge"}
+LOCAL_PRIVATE_RE = re.compile(
+    r"(^~|/Users/|\.agent-foundry|\.codex|\.trae|raw session|raw log|runtime manifest|"
+    r"local receipt|secret|token)",
+    re.IGNORECASE,
+)
+UNSAFE_CLAIM_RE = re.compile(
+    r"\b(runtime authority|generated authority|canonical runtime|memory-system|memory system|"
+    r"delete records|overwrite records|force merge|destructive)\b",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -51,6 +77,40 @@ def safe_vault_path(vault_root: Path, relative: str) -> Path:
     except ValueError as exc:
         raise SystemExit(f"Refusing Vault record path outside Vault: {relative}") from exc
     return target
+
+
+def lifecycle_metadata_errors(pack: dict[object, object], pack_id: str) -> list[str]:
+    errors = validate_deployed_pack_metadata(pack, pack_id)
+    lifecycle_status = str(pack.get("lifecycle_status", ""))
+    if lifecycle_status and lifecycle_status not in LIFECYCLE_STATES | LEGACY_DEPLOYED_STATES:
+        errors.append(f"deployed pack {pack_id} lifecycle_status is unsupported: {lifecycle_status}")
+
+    pack_records = pack.get("records", [])
+    if isinstance(pack_records, list):
+        for record in pack_records:
+            if not isinstance(record, dict):
+                continue
+            item_id = str(record.get("id", "<unknown>"))
+            if not record.get("deployed_sha256") and not record.get("imported_sha256"):
+                errors.append(f"deployed pack {pack_id} record {item_id} missing deployed/imported hash")
+
+    for section_name in [
+        "lifecycle_policy",
+        "lifecycle_transition",
+        "transition_plan",
+        "evidence_sources",
+        "export_policy",
+        "runtime_projection",
+    ]:
+        if section_name not in pack:
+            continue
+        section = pack.get(section_name)
+        for text in scalar_texts(section):
+            if LOCAL_PRIVATE_RE.search(text):
+                errors.append(f"deployed pack {pack_id} {section_name} contains local-private reference: {text}")
+            if UNSAFE_CLAIM_RE.search(text):
+                errors.append(f"deployed pack {pack_id} {section_name} contains unsafe lifecycle claim: {text}")
+    return errors
 
 
 def pack_block_bounds(lines: list[str], pack_id: str) -> tuple[int, int]:
@@ -89,7 +149,7 @@ def deployed_pack_records(vault_root: Path, pack_id: str) -> tuple[list[PackReco
     for pack in packs:
         if not isinstance(pack, dict) or pack.get("pack_id") != pack_id:
             continue
-        metadata_errors = validate_deployed_pack_metadata(pack, pack_id)
+        metadata_errors = lifecycle_metadata_errors(pack, pack_id)
         if metadata_errors:
             return [], lines, start, end, metadata_errors
         pack_records = pack.get("records", [])
@@ -212,6 +272,40 @@ def retire_status(kind: str) -> tuple[str, str]:
     raise SystemExit(f"Unsupported pack record kind: {kind}")
 
 
+def print_followup_guidance(action: str) -> None:
+    print("governance: practice and asset lifecycle changes still require review-practices/review-assets approval")
+    print("generated_followup: publish selected-Vault generated output only after reviewed Vault state changes")
+    print("runtime_followup: run install dry-run and sync_status; runtime writes require explicit approval")
+    print("rollback: keep selected Vault metadata canonical; revert reviewed metadata or restore from backup if an approved apply was wrong")
+    print("defer: leave pack in blocked/proposed state, gather missing evidence, or route to needs:human for private/destructive decisions")
+    if action in {"activate", "exportable"}:
+        print("review_gate: human approval required; this command does not activate or mark exportable")
+    if action in {"split", "merge"}:
+        print("review_gate: split/merge requires before-after membership diff, conflict handling, rollback plan, and human approval")
+    if action == "deprecate":
+        print("review_gate: deprecation requires replacement or rationale and user-visible warning")
+
+
+def report_review_only_action(records: list[PackRecord], action: str) -> int:
+    target_state = {
+        "activate": "active",
+        "exportable": "exportable",
+        "deprecate": "deprecated",
+        "split": "split",
+        "merge": "merged",
+    }[action]
+    print(f"target_state: {target_state}")
+    print("status: review_required")
+    print("records:")
+    if not records:
+        print("- none")
+    for record in records:
+        print(f"- {record.item_id} {record.kind}: {record.path}")
+    print_followup_guidance(action)
+    print("writes: none")
+    return 1
+
+
 def plan_lifecycle_writes(
     vault_root: Path,
     records: list[PackRecord],
@@ -302,6 +396,14 @@ def lifecycle(core_root: Path, vault_root: Path, pack_id: str, action: str, appl
         print("status: not_deployed")
         print("writes: none")
         return 1
+    if action in REVIEW_ONLY_ACTIONS:
+        if apply:
+            print("status: failed")
+            print(f"- {action} is review-only in #175 and cannot be applied")
+            print_followup_guidance(action)
+            print("writes: none")
+            return 1
+        return report_review_only_action(records, action)
     print("records:")
     if not records:
         print("- none")
@@ -324,10 +426,12 @@ def lifecycle(core_root: Path, vault_root: Path, pack_id: str, action: str, appl
         print("status: failed")
         for error in planning_errors:
             print(f"- {error}")
+        print_followup_guidance(action)
         print("writes: none")
         return 1
     for planned in planned_writes:
         write(planned.path, planned.text, apply)
+    print_followup_guidance(action)
     print("runtime_cleanup: use selected generated-output refresh and managed runtime receipt rollback; ChatGPT remains manual")
     print("restore: rebuild from public Core plus selected Vault; do not copy another machine's runtime files")
     print(f"writes: {'applied' if apply else 'none'}")
@@ -337,11 +441,11 @@ def lifecycle(core_root: Path, vault_root: Path, pack_id: str, action: str, appl
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Plan or apply deployed capability pack disable/retire transitions.")
+    parser = argparse.ArgumentParser(description="Plan or apply safe deployed capability pack lifecycle transitions.")
     parser.add_argument("--core-root", default=str(ROOT), help="Agent Foundry Core root.")
     parser.add_argument("--vault-root", required=True, help="Selected Agent Foundry Vault root.")
     parser.add_argument("--pack-id", required=True, help="Deployed capability pack id.")
-    parser.add_argument("--action", choices=["disable", "retire"], required=True)
+    parser.add_argument("--action", choices=sorted(WRITE_ACTIONS | REVIEW_ONLY_ACTIONS), required=True)
     parser.add_argument("--apply", action="store_true", help="Write lifecycle changes. Default is dry-run.")
     args = parser.parse_args()
     return lifecycle(

--- a/scripts/test_capability_pack_lifecycle.py
+++ b/scripts/test_capability_pack_lifecycle.py
@@ -88,6 +88,16 @@ def lifecycle(vault: Path, action: str, apply: bool) -> subprocess.CompletedProc
     return run(args)
 
 
+def add_metadata_section(vault: Path, lines: list[str]) -> None:
+    index = vault / "packs" / "deployed-pack-index.yaml"
+    text = index.read_text(encoding="utf-8")
+    marker = "    records:\n"
+    index.write_text(
+        text.replace(marker, "\n".join([*lines, "    records:", ""]), 1),
+        encoding="utf-8",
+    )
+
+
 def publish(vault: Path, generated: Path) -> subprocess.CompletedProcess[str]:
     return run(
         [
@@ -131,26 +141,15 @@ def status(vault: Path, generated: Path, receipt: Path) -> subprocess.CompletedP
 
 
 def add_deployed_pack_contract(vault: Path, source_authority: str) -> None:
-    index = vault / "packs" / "deployed-pack-index.yaml"
-    text = index.read_text(encoding="utf-8")
-    marker = "    records:\n"
-    index.write_text(
-        text.replace(
-            marker,
-            "\n".join(
-                [
-                    "    pack_contract:",
-                    "      promised_use_case: lifecycle fixture",
-                    "      deployment_role: optional user-selected capability",
-                    f"      source_authority_after_deployment: {source_authority}",
-                    "      non_authority_boundaries: [generated adapters are downstream only, runtime installs are downstream only]",
-                    "    records:",
-                    "",
-                ]
-            ),
-            1,
-        ),
-        encoding="utf-8",
+    add_metadata_section(
+        vault,
+        [
+            "    pack_contract:",
+            "      promised_use_case: lifecycle fixture",
+            "      deployment_role: optional user-selected capability",
+            f"      source_authority_after_deployment: {source_authority}",
+            "      non_authority_boundaries: [generated adapters are downstream only, runtime installs are downstream only]",
+        ],
     )
 
 
@@ -226,8 +225,33 @@ def main() -> int:
 
         dry_disable = lifecycle(vault, "disable", apply=False)
         errors.extend(expect("disable-dry-run", dry_disable, True, "writes: none"))
+        errors.extend(expect("disable-dry-run-rollback-guidance", dry_disable, True, "rollback:"))
+        errors.extend(expect("disable-dry-run-defer-guidance", dry_disable, True, "defer:"))
         if digest(metadata) != metadata_before:
             errors.append("disable-dry-run: metadata changed")
+
+        dry_retire = lifecycle(vault, "retire", apply=False)
+        errors.extend(expect("retire-dry-run", dry_retire, True, "writes: none"))
+        errors.extend(expect("retire-dry-run-reports-records", dry_retire, True, "COLLAB-PACK-001 practice -> archived"))
+
+        activate_plan = lifecycle(vault, "activate", apply=False)
+        errors.extend(expect("activate-review-only", activate_plan, False, "status: review_required"))
+        errors.extend(expect("activate-writes-none", activate_plan, False, "writes: none"))
+        activate_apply = lifecycle(vault, "activate", apply=True)
+        errors.extend(expect("activate-apply-refused", activate_apply, False, "cannot be applied"))
+
+        exportable_plan = lifecycle(vault, "exportable", apply=False)
+        errors.extend(expect("exportable-review-only", exportable_plan, False, "target_state: exportable"))
+        errors.extend(expect("exportable-no-runtime-authority", exportable_plan, False, "runtime_followup:"))
+
+        deprecate_plan = lifecycle(vault, "deprecate", apply=False)
+        errors.extend(expect("deprecate-review-only", deprecate_plan, False, "target_state: deprecated"))
+        errors.extend(expect("deprecate-reports-records", deprecate_plan, False, "ASSET-COLLAB-PACK-001 asset"))
+
+        split_plan = lifecycle(vault, "split", apply=False)
+        errors.extend(expect("split-review-only", split_plan, False, "before-after membership diff"))
+        merge_plan = lifecycle(vault, "merge", apply=False)
+        errors.extend(expect("merge-review-only", merge_plan, False, "split/merge requires"))
 
         metadata_with_valid_contract = metadata.read_text(encoding="utf-8")
         add_deployed_pack_contract(vault, "runtime generated adapter authority")
@@ -240,6 +264,38 @@ def main() -> int:
                 "must not claim runtime/generated/Core/pack authority",
             )
         )
+        metadata.write_text(metadata_with_valid_contract, encoding="utf-8")
+
+        add_metadata_section(
+            vault,
+            [
+                "    lifecycle_transition:",
+                "      evidence: /Users/example/private/raw-session.log",
+            ],
+        )
+        private_metadata = lifecycle(vault, "disable", apply=False)
+        errors.extend(expect("disable-local-private-metadata-fails", private_metadata, False, "local-private reference"))
+        metadata.write_text(metadata_with_valid_contract, encoding="utf-8")
+
+        add_metadata_section(
+            vault,
+            [
+                "    lifecycle_transition:",
+                "      notes: memory-system generated authority with destructive delete records",
+            ],
+        )
+        unsafe_claim = lifecycle(vault, "disable", apply=False)
+        errors.extend(expect("disable-memory-destructive-claim-fails", unsafe_claim, False, "unsafe lifecycle claim"))
+        metadata.write_text(metadata_with_valid_contract, encoding="utf-8")
+
+        missing_hash_text = "\n".join(
+            line
+            for line in metadata_with_valid_contract.splitlines()
+            if not line.strip().startswith(("imported_sha256:", "deployed_sha256:"))
+        ) + "\n"
+        metadata.write_text(missing_hash_text, encoding="utf-8")
+        missing_hash = lifecycle(vault, "disable", apply=False)
+        errors.extend(expect("disable-missing-record-hash-fails", missing_hash, False, "missing deployed/imported hash"))
         metadata.write_text(metadata_with_valid_contract, encoding="utf-8")
 
         apply_disable = lifecycle(vault, "disable", apply=True)

--- a/scripts/test_capability_pack_lifecycle.py
+++ b/scripts/test_capability_pack_lifecycle.py
@@ -275,6 +275,8 @@ def main() -> int:
         )
         private_metadata = lifecycle(vault, "disable", apply=False)
         errors.extend(expect("disable-local-private-metadata-fails", private_metadata, False, "local-private reference"))
+        for expected in ["generated_followup:", "runtime_followup:", "rollback:", "defer:", "writes: none"]:
+            errors.extend(expect(f"disable-local-private-metadata-guidance-{expected}", private_metadata, False, expected))
         metadata.write_text(metadata_with_valid_contract, encoding="utf-8")
 
         add_metadata_section(

--- a/workflows/manage-capability-pack-lifecycle.md
+++ b/workflows/manage-capability-pack-lifecycle.md
@@ -1,0 +1,146 @@
+# Manage Capability Pack Lifecycle Workflow
+
+Use this workflow when a capability pack needs lifecycle review after detection,
+deployment, update comparison, split/merge analysis, deprecation, retirement, or
+exportability discussion.
+
+This workflow plans and reports lifecycle transitions. It does not bypass
+practice review, asset review, runtime approval, export review, or human approval.
+
+## Invariants
+
+- Selected User Vault metadata owns canonical pack lifecycle state after
+  deployment.
+- Practice and asset records remain individually governed by
+  `workflows/review-practices.md` and `workflows/review-assets.md`.
+- Pack snapshots are transfer and comparison artifacts, not live authority.
+- Generated adapters and runtime installs are downstream projections only.
+- Local-private evidence, raw logs, runtime manifests, receipts, user paths,
+  secrets, and memory-system records are not pack lifecycle authority.
+
+## Lifecycle States
+
+| State | Meaning | Agent action | Required gate |
+| --- | --- | --- | --- |
+| `detected` | Evidence suggests a possible pack. | Gather public/sanitized evidence and score signals. | Privacy gate if private evidence is needed. |
+| `candidate` | Reviewable candidate output from discovery. | Prepare candidate packet and false-positive controls. | Reviewer/Architect review before promotion. |
+| `proposed` | Boundary accepted for possible deployment. | Produce dry-run plan, diff, and lifecycle impact. | Human approval before active use. |
+| `active` | Reviewed pack is deployed as an optional capability. | Report status and downstream follow-up. | Activation approval and record governance. |
+| `exportable` | Pack may be exported after privacy review. | Produce exportability status only. | Human privacy/export review; #176 owns mechanics. |
+| `deprecated` | Pack remains readable but is no longer preferred. | Warn, suggest replacement, avoid new activation. | Reviewed rationale and user-visible status. |
+| `split` | Pack boundary is divided into multiple packs. | Produce membership diff and conflict report. | Human approval with rollback/defer plan. |
+| `merged` | Pack boundary is merged into another pack. | Produce target-pack diff and conflict report. | Human approval with conflict handling. |
+| `retired` | Pack should no longer be used. | Dry-run/apply only after approval. | Human approval and practice/asset lifecycle review. |
+| `blocked` | Transition is unsafe or lacks evidence. | Explain blockers and write nothing. | Human correction or explicit hold. |
+
+## Transition Gates
+
+- `detected -> candidate`: requires passing discovery authority, privacy,
+  false-positive, and bootstrap-duplicate gates. No activation or export.
+- `candidate -> proposed`: requires Reviewer boundary review and Architect
+  acceptance.
+- `proposed -> active`: requires human approval of boundary, included records,
+  member lifecycle impact, generated/runtime impact, and rollback/defer plan.
+- `active -> exportable`: requires privacy/export review. #175 only reports this
+  state; #176 defines export/import mechanics.
+- `active -> deprecated`: requires reviewed replacement or rationale and a
+  user-visible warning/status report.
+- `deprecated -> retired`: requires dry-run report, affected records, generated
+  and runtime follow-up, and human approval.
+- `active/proposed -> split`: requires proposed new pack ids, before/after
+  membership diff, per-record hashes, conflicts, local-edit handling, generated
+  and runtime follow-up, rollback/defer plan, and human approval.
+- `active/proposed -> merged`: requires target pack id, membership diff,
+  duplicate/conflict handling, local-edit handling, generated and runtime
+  follow-up, rollback/defer plan, and human approval.
+- Any transition becomes `blocked` when metadata is malformed, hashes are
+  missing, local user edits conflict with deployed hashes, runtime/generated
+  authority is claimed, local-private evidence is required, destructive changes
+  are requested without approval, or memory-system work would be needed.
+
+## Safe Command Sequence
+
+1. Run lifecycle reports in dry-run mode first:
+
+   ```bash
+   python3 scripts/manage_capability_pack_lifecycle.py \
+     --vault-root <selected-vault> \
+     --pack-id <pack-id> \
+     --action <activate|exportable|deprecate|split|merge|disable|retire>
+   ```
+
+2. Read the report:
+   - current pack id and action;
+   - affected member records;
+   - review gate;
+   - generated output follow-up;
+   - runtime follow-up;
+   - rollback/defer guidance;
+   - `writes: none` for unsafe or review-only paths.
+
+3. Route to the correct reviewer:
+   - practice status, archive, activation tier, or broad adapter behavior:
+     `review-practices`;
+   - asset status, deprecation, retirement, merge, or published targets:
+     `review-assets`;
+   - private/exportability boundary: `needs:human` and #176 export/import review;
+   - runtime write: explicit runtime-write approval before apply.
+
+4. Apply only currently supported write actions after approval:
+
+   ```bash
+   python3 scripts/manage_capability_pack_lifecycle.py \
+     --vault-root <selected-vault> \
+     --pack-id <pack-id> \
+     --action retire \
+     --apply
+   ```
+
+   `activate`, `exportable`, `deprecate`, `split`, and `merge` are review-only
+   planning surfaces in #175. They must keep `writes: none`.
+
+5. After an approved Vault lifecycle change, publish and inspect downstream
+   state separately:
+
+   ```bash
+   python3 scripts/publish_adapters.py --vault-root <selected-vault> --output-root <generated-root> --apply
+   python3 scripts/install_foundry.py --vault-root <selected-vault> --adapter-root <generated-root>
+   python3 scripts/sync_status.py --vault-root <selected-vault> --adapter-root <generated-root>
+   ```
+
+   Apply runtime install only after explicit runtime-write approval. ChatGPT
+   remains manual import.
+
+## Rollback And Defer
+
+- Roll back approved metadata by restoring selected Vault metadata from a
+  reviewed backup or reversing the approved commit.
+- Rebuild generated output from Core plus selected Vault. Do not copy another
+  machine's runtime files.
+- Defer by leaving the pack in `blocked`, `candidate`, or `proposed` state and
+  recording missing evidence, conflicts, or human decisions.
+- When local user edits conflict with deployed hashes, preserve the selected
+  Vault and propose a merge. Do not overwrite.
+
+## Fail-Closed Conditions
+
+Lifecycle tooling must refuse writes and print `writes: none` when it sees:
+
+- malformed deployed-pack metadata;
+- unsupported lifecycle state;
+- missing deployed or imported hashes for member records;
+- unsafe lifecycle claims such as runtime authority, generated authority,
+  destructive deletion, forced overwrite, or automatic merge;
+- local-private evidence references in lifecycle, evidence, export, or runtime
+  projection sections;
+- memory-system references;
+- metadata paths that point at the wrong record id;
+- missing record files or missing/mismatched indexes;
+- generated/runtime evidence used as active or exportable authority.
+
+## #176 Boundary
+
+#175 may show `exportable` as a lifecycle status and report that export review is
+required. It must not implement export/import mechanics, produce export bundles,
+or mark a pack exportable from generated/runtime evidence alone. Privacy-safe
+export/import behavior belongs to #176.


### PR DESCRIPTION
## Scope

Implements #175 using the Architect implementation boundary in issue comment 4726885526.

- Adds `workflows/manage-capability-pack-lifecycle.md` with lifecycle states, transition gates, dry-run/apply/status sequencing, rollback/defer guidance, practice/asset governance preservation, Generated/Runtime downstream boundaries, and the #176 export/import boundary.
- Extends `scripts/manage_capability_pack_lifecycle.py` with safe lifecycle reporting for `activate`, `exportable`, `deprecate`, `split`, and `merge` as review-only actions.
- Preserves existing `disable`/`retire` behavior while adding rollback/defer/generated/runtime follow-up guidance to reports.
- Adds lifecycle metadata fail-closed checks for unsupported lifecycle states, missing deployed/imported member hashes, local-private lifecycle references, runtime/generated authority claims, memory-system references, and destructive claims.
- Extends lifecycle regression coverage for review-only transitions, dry-run reports, unsafe metadata, missing hashes, rollback/defer/status guidance, and existing AF5/AF6 disable/retire behavior.

## Verification

- `python3 -m py_compile scripts/manage_capability_pack_lifecycle.py scripts/test_capability_pack_lifecycle.py`
- `python3 scripts/test_capability_pack_lifecycle.py`
- `python3 scripts/test_capability_pack_plan.py`
- `python3 scripts/test_capability_pack_update.py`
- `python3 scripts/test_capability_pack_apply.py`
- `python3 scripts/check_capability_pack_fixtures.py`
- `python3 scripts/check_consistency.py`
- `git diff --check`

## Safety

- No live Vault records mutated.
- No runtime config, generated adapters, private state, or memory-system records changed.
- No runtime apply, activation automation, export automation, destructive data change, merge, or issue closure performed.

## Residual Risks

- `activate`, `exportable`, `deprecate`, `split`, and `merge` are review-only reporting surfaces in this PR; later issues must implement any approved write behavior explicitly.
- #176 still owns privacy-safe export/import mechanics.
- More detailed per-runtime lifecycle UX remains a likely #177 follow-up.

Reviewer target: transition-state review for #175.