### PR TITLE
AF9 #176 privacy-safe capability pack transfer planning

### DIFF
--- a/scripts/plan_capability_pack_transfer.py
+++ b/scripts/plan_capability_pack_transfer.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Report-only privacy validation for capability pack export/import transfer."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from foundry_config import ROOT
+from plan_capability_pack import (
+    plan_records,
+    rel,
+    validate_manifest,
+    validate_payloads,
+    validate_records,
+)
+
+
+TRANSFER_STATES = {"preview", "dry-run", "proposed", "accepted", "rejected", "blocked"}
+PRIVATE_TEXT_RE = re.compile(
+    r"(^~|/Users/|\.agent-foundry|\.codex|\.trae|secret|token|password|raw session|session transcript|"
+    r"raw log|runtime/local|usage/local|sync/local|local receipt|runtime manifest|private vault|memory-system|"
+    r"memory system)",
+    re.IGNORECASE,
+)
+PRIVATE_PATH_RE = re.compile(
+    r"(^|/)(runtime/local|usage/local|sync/local|memory|knowledge|research_memos|project_memory)(/|$)|"
+    r"(^|/)(\.codex|\.trae|\.agent-foundry)(/|$)",
+    re.IGNORECASE,
+)
+GENERATED_AUTHORITY_RE = re.compile(
+    r"\b(generated adapter authority|runtime authority|canonical runtime|generated output is canonical|"
+    r"runtime install is canonical|activate automatically|auto activate|execute on import)\b",
+    re.IGNORECASE,
+)
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def files_under(root: Path) -> list[Path]:
+    if not root.exists():
+        return []
+    return sorted(path for path in root.rglob("*") if path.is_file())
+
+
+def transfer_privacy_errors(pack_root: Path) -> list[str]:
+    errors: list[str] = []
+    for path in files_under(pack_root):
+        relative = rel(path, pack_root)
+        if PRIVATE_PATH_RE.search(relative):
+            errors.append(f"{relative}: private/local path is not allowed in a capability pack transfer")
+            continue
+        try:
+            text = read(path)
+        except UnicodeDecodeError:
+            errors.append(f"{relative}: binary or non-UTF-8 transfer payload requires separate review")
+            continue
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            if line.strip().startswith(("excluded_material:", "exclusions:", "forbidden_references:")):
+                continue
+            if PRIVATE_TEXT_RE.search(line):
+                errors.append(f"{relative}:{line_no}: private/local reference is not exportable")
+            if GENERATED_AUTHORITY_RE.search(line):
+                errors.append(f"{relative}:{line_no}: generated/runtime output must not claim transfer authority")
+    return errors
+
+
+def transfer_state_errors(state: str) -> list[str]:
+    if state not in TRANSFER_STATES:
+        return [f"import_state must be one of {sorted(TRANSFER_STATES)}"]
+    if state == "accepted":
+        return ["accepted import state still requires reviewed apply handoff; this planner writes nothing"]
+    return []
+
+
+def export_policy_errors(manifest_text: str) -> list[str]:
+    if "export_policy:" not in manifest_text:
+        return ["export_policy is required before capability pack export/import transfer review"]
+    if "review_required: true" not in manifest_text:
+        return ["export_policy review_required must be true for transfer review"]
+    if "private_vault_content: excluded" not in manifest_text:
+        return ["integrity private_vault_content must be excluded"]
+    return []
+
+
+def report(
+    *,
+    action: str,
+    import_state: str,
+    pack_root: Path,
+    vault_root: Path,
+    manifest: dict[str, str],
+    errors: list[str],
+    diff_rows: list[str],
+) -> None:
+    print("Capability pack export/import transfer report")
+    print(f"action: {action}")
+    print(f"import_state: {import_state if action.startswith('import') else 'n/a'}")
+    print(f"pack_root: {pack_root}")
+    print(f"vault_root: {vault_root}")
+    if manifest:
+        print(f"pack_id: {manifest.get('pack_id', '')}")
+        print(f"version: {manifest.get('version', '')}")
+        print(f"review_state: {manifest.get('review_state', '')}")
+    print("allowed_export_contents:")
+    print("- manifest and reviewed metadata")
+    print("- sanitized included records with checksums")
+    print("- public Core references, examples, fixtures, and validation metadata")
+    print("excluded_material:")
+    print("- private Vault history, raw evidence, sessions, secrets, local paths")
+    print("- runtime receipts, user settings, generated/runtime files as authority")
+    print("- memory-system records or references")
+    print("diff_before_write:")
+    if diff_rows:
+        for row in diff_rows:
+            print(f"- {row}")
+    else:
+        print("- none")
+    print("validation:")
+    if errors:
+        print("status: blocked")
+        for error in errors:
+            print(f"- {error}")
+    else:
+        print("status: review_required")
+        print("- privacy review required before export sharing or import acceptance")
+        print("- dry-run diff required before any selected Vault write")
+    print("rollback:")
+    print("- discard staged transfer material or revert the reviewed Vault change")
+    print("- rebuild generated output from Core plus selected Vault after approved changes")
+    print("handoff:")
+    print("- route privacy/export review to human or Reviewer before sharing")
+    print("- route accepted import material through existing practice/asset review gates")
+    print("writes: none")
+
+
+def plan_transfer(core_root: Path, vault_root: Path, pack_root: Path, action: str, import_state: str) -> int:
+    manifest, manifest_errors, manifest_text = validate_manifest(core_root, vault_root, pack_root)
+    records_raw, record_errors = validate_records(pack_root, manifest_text) if manifest_text else ([], [])
+    payloads, payload_errors = validate_payloads(pack_root, manifest_text) if manifest_text else ([], [])
+    records, planning_errors = plan_records(vault_root, pack_root, manifest, records_raw) if manifest else ([], [])
+    errors = (
+        manifest_errors
+        + record_errors
+        + payload_errors
+        + planning_errors
+        + transfer_privacy_errors(pack_root)
+        + export_policy_errors(manifest_text)
+    )
+    if action.startswith("import"):
+        errors.extend(transfer_state_errors(import_state))
+    for payload in payloads:
+        if payload.outcome == "blocked_executable_install":
+            errors.append(f"executable_payload {payload.payload_id} cannot install or execute during transfer")
+    diff_rows = [f"{record.item_id} {record.kind} {record.outcome}: {record.detail}" for record in records]
+    report(
+        action=action,
+        import_state=import_state,
+        pack_root=pack_root,
+        vault_root=vault_root,
+        manifest=manifest,
+        errors=errors,
+        diff_rows=diff_rows,
+    )
+    return 1 if errors else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate capability pack export/import transfer without writes.")
+    parser.add_argument("pack_root", help="Capability pack directory containing manifest.yaml.")
+    parser.add_argument("--core-root", default=str(ROOT), help="Agent Foundry Core root.")
+    parser.add_argument("--vault-root", required=True, help="Selected Agent Foundry Vault root.")
+    parser.add_argument(
+        "--action",
+        choices=["export-preview", "import-preview", "import-dry-run"],
+        default="import-preview",
+        help="Report-only transfer action.",
+    )
+    parser.add_argument("--import-state", default="preview", help="Import state to validate for import actions.")
+    args = parser.parse_args()
+    return plan_transfer(
+        Path(args.core_root).expanduser().resolve(),
+        Path(args.vault_root).expanduser().resolve(),
+        Path(args.pack_root).expanduser().resolve(),
+        args.action,
+        args.import_state,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_capability_pack_transfer.py
+++ b/scripts/test_capability_pack_transfer.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Regression tests for privacy-safe capability pack transfer planning."""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INIT = ROOT / "scripts" / "init_vault.py"
+TRANSFER = ROOT / "scripts" / "plan_capability_pack_transfer.py"
+
+
+def run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, *args],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def expect(name: str, result: subprocess.CompletedProcess[str], should_pass: bool, expected_text: str = "") -> list[str]:
+    output = result.stdout + result.stderr
+    if (result.returncode == 0) == should_pass and (not expected_text or expected_text in output):
+        print(f"{name}: ok")
+        return []
+    return [
+        f"{name}: expected {'pass' if should_pass else 'failure'}"
+        + (f" containing {expected_text!r}" if expected_text else "")
+        + f", got exit {result.returncode}\n{output.strip()}"
+    ]
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def practice_text(item_id: str) -> str:
+    return "\n".join(
+        [
+            "---",
+            f'id: "{item_id}"',
+            f'title: "{item_id}"',
+            'domain: "meta"',
+            'status: "candidate"',
+            "---",
+            "",
+            "Sanitized practice fixture.",
+            "",
+        ]
+    )
+
+
+def write_pack(
+    base: Path,
+    name: str,
+    *,
+    private_text: str = "",
+    executable: bool = False,
+    import_action: str = "stage_only",
+    destination_layer: str = "import_staging_reference",
+) -> Path:
+    pack = base / name
+    record = pack / "records" / "TRANSFER-001.md"
+    record.parent.mkdir(parents=True, exist_ok=True)
+    record.write_text(practice_text("TRANSFER-001") + private_text, encoding="utf-8")
+    payload_lines: list[str] = ["executable_payloads: []"]
+    if executable:
+        helper = pack / "payloads" / "helper.py"
+        helper.parent.mkdir(parents=True, exist_ok=True)
+        helper.write_text("print('must not execute')\n", encoding="utf-8")
+        payload_lines = [
+            "executable_payloads:",
+            "  - id: helper",
+            "    title: helper",
+            "    lifecycle_status: candidate",
+            "    path: payloads/helper.py",
+            f"    source_sha256: \"{sha256(helper)}\"",
+            "    interpreter: python3",
+            "    execute_from_pack: false",
+            "    install_boundary: managed_runtime_copy_required",
+            "    permissions: [filesystem-read]",
+            "    dependencies: []",
+            "    runtime_impact: test",
+        ]
+    manifest_lines = [
+        "manifest_schema_version: 1",
+        f"pack_id: pack.transfer.{name}",
+        f"title: Transfer {name}",
+        "description: Transfer planner fixture.",
+        "lifecycle_status: candidate",
+        "version: 0.1.0",
+        "exported_at: 2026-06-17",
+        "distribution_type: optional_capability",
+        "source_provenance: public test fixture",
+        "maintainer_contact: test",
+        "license: test",
+        "sensitivity: public",
+        "review_state: reviewed",
+        "export_policy:",
+        "  exportability: review_required",
+        "  privacy_class: sanitized",
+        "  excluded_material: [private evidence, raw logs, session transcripts, runtime receipts]",
+        "  review_required: true",
+        "runtime_projection:",
+        "  downstream_only: true",
+        "  generated_adapter_intent: review_required",
+        "  runtime_install: review_required",
+        "  authority: downstream_only",
+        "compatibility:",
+        "  core_schema_version_min: 1",
+        "  core_schema_version_max: 1",
+        "  vault_layout_versions: [1]",
+        "  requires_bootstrap_pack: false",
+        "included_records:",
+        "  - id: TRANSFER-001",
+        "    kind: practice",
+        "    lifecycle_status: candidate",
+        "    path: records/TRANSFER-001.md",
+        "    source_version: 1",
+        f"    content_sha256: \"{sha256(record)}\"",
+        f"    destination_layer: {destination_layer}",
+        "    membership_role: optional_member",
+        "    activation_default: manual_review",
+        f"    import_action: {import_action}",
+        "",
+        *payload_lines,
+        "",
+        "conflict_policy:",
+        "  id_collision: fail_closed",
+        "  same_version_hash_mismatch: fail_closed",
+        "  newer_version_update: reviewed_diff_required",
+        "  local_edit_behavior: preserve_vault_and_propose_merge",
+        "  rollback_notes: discard staged transfer material",
+        "",
+        "integrity:",
+        "  digest_algorithm: sha256",
+        "  manifest_paths_are_relative: true",
+        "  private_vault_content: excluded",
+        "",
+    ]
+    (pack / "manifest.yaml").write_text("\n".join(manifest_lines), encoding="utf-8")
+    return pack
+
+
+def init_blank(vault_root: Path) -> subprocess.CompletedProcess[str]:
+    return run([str(INIT), str(vault_root), "--core-root", str(ROOT), "--apply"])
+
+
+def transfer(pack: Path, vault: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    return run([str(TRANSFER), str(pack), "--core-root", str(ROOT), "--vault-root", str(vault), *extra])
+
+
+def write_conflicting_vault_record(vault: Path, pack: Path) -> None:
+    record = vault / "practices" / "meta" / "TRANSFER-001.md"
+    record.parent.mkdir(parents=True, exist_ok=True)
+    record.write_text(practice_text("TRANSFER-001") + "\nLocal selected Vault edit.\n", encoding="utf-8")
+    index = vault / "indexes" / "practice_index.yaml"
+    index.write_text(
+        "\n".join(
+            [
+                "schema_version: 1",
+                "practices:",
+                "  - id: TRANSFER-001",
+                "    title: TRANSFER-001",
+                "    domain: meta",
+                "    status: candidate",
+                "    path: practices/meta/TRANSFER-001.md",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    packs = vault / "packs"
+    packs.mkdir(parents=True, exist_ok=True)
+    (packs / "deployed-pack-index.yaml").write_text(
+        "\n".join(
+            [
+                "schema_version: 1",
+                "updated: 2026-06-17",
+                "deployed_packs:",
+                "  - pack_id: pack.transfer.conflict",
+                "    version: 0.1.0",
+                "    source:",
+                f"      manifest_sha256: {sha256(pack / 'manifest.yaml')}",
+                "    records:",
+                "      - id: TRANSFER-001",
+                "        kind: practice",
+                "        path: practices/meta/TRANSFER-001.md",
+                f"        deployed_sha256: {'0' * 64}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    errors: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="agent-foundry-pack-transfer-") as tmp:
+        base = Path(tmp)
+        vault = base / "vault"
+        errors.extend(expect("init-blank-vault", init_blank(vault), True, "Blank Vault initialized and validated."))
+
+        clean_pack = write_pack(base, "clean")
+        clean_preview = transfer(clean_pack, vault, "--action", "import-preview", "--import-state", "preview")
+        errors.extend(expect("transfer-clean-preview", clean_preview, True, "status: review_required"))
+        errors.extend(expect("transfer-clean-writes-none", clean_preview, True, "writes: none"))
+        errors.extend(expect("transfer-clean-diff-before-write", clean_preview, True, "diff_before_write:"))
+        errors.extend(expect("transfer-clean-no-silent-activation", clean_preview, True, "existing practice/asset review gates"))
+
+        dry_run = transfer(clean_pack, vault, "--action", "import-dry-run", "--import-state", "dry-run")
+        errors.extend(expect("transfer-dry-run", dry_run, True, "import_state: dry-run"))
+
+        conflict_pack = write_pack(
+            base,
+            "conflict",
+            import_action="create_or_review_update",
+            destination_layer="canonical_vault_record",
+        )
+        write_conflicting_vault_record(vault, conflict_pack)
+        conflict = transfer(conflict_pack, vault, "--action", "import-dry-run", "--import-state", "dry-run")
+        errors.extend(expect("transfer-local-edit-conflict-requires-merge", conflict, True, "merge_required"))
+        errors.extend(expect("transfer-local-edit-conflict-writes-none", conflict, True, "writes: none"))
+
+        accepted = transfer(clean_pack, vault, "--action", "import-preview", "--import-state", "accepted")
+        errors.extend(expect("transfer-accepted-still-review-gated", accepted, False, "accepted import state still requires"))
+
+        private_pack = write_pack(base, "private", private_text="Evidence: /Users/example/private/raw-session.log\n")
+        private_preview = transfer(private_pack, vault)
+        errors.extend(expect("transfer-private-reference-blocked", private_preview, False, "private/local reference"))
+        errors.extend(expect("transfer-private-writes-none", private_preview, False, "writes: none"))
+
+        private_path_pack = write_pack(base, "private-path")
+        local_dir = private_path_pack / "runtime" / "local"
+        local_dir.mkdir(parents=True, exist_ok=True)
+        (local_dir / "runtime_manifest.yaml").write_text("targets: []\n", encoding="utf-8")
+        private_path = transfer(private_path_pack, vault)
+        errors.extend(expect("transfer-private-path-blocked", private_path, False, "private/local path"))
+
+        executable_pack = write_pack(base, "executable", executable=True)
+        executable_preview = transfer(executable_pack, vault)
+        errors.extend(expect("transfer-executable-blocked", executable_preview, False, "cannot install or execute during transfer"))
+
+        no_export_policy = write_pack(base, "no-export-policy")
+        manifest = no_export_policy / "manifest.yaml"
+        manifest.write_text(
+            "\n".join(line for line in manifest.read_text(encoding="utf-8").splitlines() if "export_policy" not in line and "exportability:" not in line and "privacy_class:" not in line and "excluded_material:" not in line and "review_required:" not in line),
+            encoding="utf-8",
+        )
+        no_policy = transfer(no_export_policy, vault)
+        errors.extend(expect("transfer-export-policy-required", no_policy, False, "export_policy is required"))
+
+    if errors:
+        print("Capability pack transfer test failed:")
+        for error in errors:
+            print(error)
+        return 1
+    print("Capability pack transfer test passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/workflows/export-import-capability-packs.md
+++ b/workflows/export-import-capability-packs.md
@@ -1,0 +1,129 @@
+# Export And Import Capability Packs
+
+Use this workflow when a reviewed capability pack may be shared, transferred, or
+staged for import into a selected User Vault.
+
+This workflow is privacy-safe and review-first. It plans and validates transfer
+material; it does not export a private Vault, activate a pack, apply runtime
+changes, or write selected Vault records.
+
+## Boundaries
+
+- Core owns public schemas, workflows, validators, fixtures, examples, and
+  report-only transfer tooling.
+- The selected User Vault owns canonical practice, asset, index, pack metadata,
+  import staging, and reviewed lifecycle state.
+- Generated adapters and runtime installs are downstream projections only.
+- Local Private state includes raw evidence, session transcripts, local notes,
+  runtime receipts, machine paths, local runtime manifests, user settings, and
+  private Vault history.
+- Offline repository snapshots are separate recovery/sync tooling. Do not treat
+  `scripts/export_snapshot.py`, `scripts/import_snapshot.py`, or
+  `scripts/compare_snapshot.py` as capability-pack export/import semantics.
+
+## Allowed Transfer Material
+
+- Capability pack manifest and reviewed metadata.
+- Included practice or asset records only when approved for distribution or
+  represented as sanitized copies.
+- Public Core workflow, schema, template, example, fixture, and checksum
+  references.
+- Review notes that contain only public issue/PR links, sanitized aggregate
+  summaries, or stable record ids.
+
+## Exclusions
+
+Fail closed before sharing or import acceptance when transfer material contains:
+
+- raw private evidence, raw logs, session transcripts, local notes, secrets, or
+  tokens;
+- absolute user paths such as `/Users/...`, `~`, `.agent-foundry`, `.codex`, or
+  `.trae`;
+- runtime receipts, runtime manifests, machine-specific settings, usage/local,
+  runtime/local, or sync/local material;
+- private project ids, raw Vault history, generated output, or runtime files as
+  authority;
+- memory-system records or references;
+- executable payload execution, install side effects, destructive changes, or
+  automatic activation claims.
+
+## Import States
+
+| State | Meaning | Writes |
+| --- | --- | --- |
+| `preview` | Transfer package is inspected for contents, privacy, and compatibility. | none |
+| `dry-run` | Planner reports selected Vault diffs, conflicts, and review gates. | none |
+| `proposed` | Import is ready for human or Reviewer acceptance. | none |
+| `accepted` | Human accepted the import plan; apply must use a separate reviewed workflow. | none in this workflow |
+| `rejected` | Import is declined and staged material should be discarded. | none |
+| `blocked` | Privacy, compatibility, conflict, or authority checks failed. | none |
+
+Imported material must not silently become active. Practice and asset records
+still pass through `workflows/review-practices.md` and
+`workflows/review-assets.md`; pack lifecycle state still follows
+`workflows/manage-capability-pack-lifecycle.md`.
+
+## Safe Sequence
+
+1. Preview the transfer package:
+
+   ```bash
+   python3 scripts/plan_capability_pack_transfer.py \
+     <pack-root> \
+     --vault-root <selected-vault> \
+     --action import-preview \
+     --import-state preview
+   ```
+
+2. Run a dry-run diff before any selected Vault write:
+
+   ```bash
+   python3 scripts/plan_capability_pack_transfer.py \
+     <pack-root> \
+     --vault-root <selected-vault> \
+     --action import-dry-run \
+     --import-state dry-run
+   ```
+
+3. Review the report for allowed contents, excluded material, conflicts,
+   checksum mismatches, local-edit preservation, rollback guidance, and
+   `writes: none`.
+
+4. Route the next decision:
+   - privacy/export boundary: human or Reviewer privacy review;
+   - practice content or lifecycle: `review-practices`;
+   - asset content, published targets, or status: `review-assets`;
+   - runtime apply: explicit runtime-write approval in a separate workflow.
+
+5. Apply accepted material only through an existing reviewed deployment,
+   practice, asset, or lifecycle workflow. This workflow never performs that
+   write.
+
+## Conflict Handling
+
+- Same id with incompatible kind, path, or provenance fails closed.
+- Same pack id and version with a different manifest hash fails closed.
+- Existing selected Vault edits remain canonical user state. The transfer report
+  should propose merge review rather than overwrite.
+- Executable payloads remain inert and cannot be executed or installed during
+  transfer.
+
+## Rollback
+
+- Before apply, rollback means discarding staged transfer material or rejecting
+  the import.
+- After a separately approved Vault change, rollback by reverting the reviewed
+  Vault commit or restoring a reviewed backup.
+- Regenerate adapters from Core plus the selected Vault after approved rollback;
+  do not copy runtime files from another machine.
+
+## Status Output
+
+Transfer reports must include:
+
+- package root, selected Vault root, pack id, version, and review state;
+- allowed export contents and excluded material;
+- diff-before-write rows for each included record;
+- validation status and failure reasons;
+- rollback and handoff guidance;
+- `writes: none`.


### PR DESCRIPTION
## Scope

Implements AF9 #176 as a scoped design/docs/tests/tooling PR for privacy-safe capability pack export/import transfer planning.

Adds:
- `workflows/export-import-capability-packs.md` defining review-first export/import boundaries, allowed transfer material, exclusions, import states, safe sequence, conflict handling, rollback, and status output.
- `scripts/plan_capability_pack_transfer.py`, a report-only transfer planner that validates pack manifests, privacy markers, executable/install side effects, import states, and selected Vault diffs while always printing `writes: none`.
- `scripts/test_capability_pack_transfer.py` covering clean preview/dry-run, accepted-import still requiring reviewed apply handoff, local-edit conflict diff, private text/path markers, executable payload blocking, and missing export policy.

## Safety / boundaries

- No private Vault export.
- No runtime apply.
- No live Vault/runtime/generated/private-state mutation.
- No pack activation/export.
- No destructive operation.
- No memory-system work.
- Existing offline snapshot scripts remain separate and are not treated as capability-pack export/import semantics.

## Verification

- `python3 -m py_compile scripts/plan_capability_pack_transfer.py scripts/test_capability_pack_transfer.py`
- `python3 scripts/test_capability_pack_transfer.py`
- `python3 scripts/check_capability_pack_fixtures.py`
- `python3 scripts/test_capability_pack_plan.py`
- `python3 scripts/test_capability_pack_apply.py`
- `python3 scripts/test_capability_pack_update.py`
- `python3 scripts/test_capability_pack_lifecycle.py`
- `python3 scripts/check_consistency.py`
- `git diff --check`

## Residual risks

- This PR is report-only; actual export package creation/import apply mechanics remain gated to later reviewed workflows.
- Transfer privacy scanning is conservative text/path scanning, not a full secret scanner.
- Accepted import state intentionally remains non-writing and must hand off to existing reviewed practice/asset/deployment workflows.

Next owner: Reviewer for privacy and boundary review.
