### PR TITLE
AF9 #177 advanced capability workflow surface

### DIFF
--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -693,6 +693,46 @@ def check_capability_pack_lifecycle_script() -> list[str]:
     return output.splitlines()
 
 
+def check_capability_pack_transfer_script() -> list[str]:
+    script = ROOT / "scripts" / "test_capability_pack_transfer.py"
+    if not script.exists():
+        return ["Missing scripts/test_capability_pack_transfer.py"]
+    result = subprocess.run(
+        ["python3", str(script)],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode == 0:
+        return []
+    output = (result.stdout + result.stderr).strip()
+    if not output:
+        return ["Capability pack transfer fixture failed without output"]
+    return output.splitlines()
+
+
+def check_advanced_capability_workflow_surface_script() -> list[str]:
+    script = ROOT / "scripts" / "test_advanced_capability_workflow_surface.py"
+    if not script.exists():
+        return ["Missing scripts/test_advanced_capability_workflow_surface.py"]
+    result = subprocess.run(
+        ["python3", str(script)],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode == 0:
+        return []
+    output = (result.stdout + result.stderr).strip()
+    if not output:
+        return ["Advanced capability workflow surface fixture failed without output"]
+    return output.splitlines()
+
+
 def check_sync_status_report_script() -> list[str]:
     script = ROOT / "scripts" / "test_sync_status_report.py"
     if not script.exists():
@@ -838,6 +878,8 @@ def main() -> int:
     errors += check_capability_pack_apply_script()
     errors += check_capability_pack_update_script()
     errors += check_capability_pack_lifecycle_script()
+    errors += check_capability_pack_transfer_script()
+    errors += check_advanced_capability_workflow_surface_script()
     errors += check_sync_status_report_script()
     errors += check_capability_scenario_matrix_script()
     errors += check_runtime_import_script()

--- a/scripts/test_advanced_capability_workflow_surface.py
+++ b/scripts/test_advanced_capability_workflow_surface.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""AF9 advanced capability workflow surface regression checks."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INIT = ROOT / "scripts" / "init_vault.py"
+PLAN = ROOT / "scripts" / "plan_capability_pack.py"
+LIFECYCLE = ROOT / "scripts" / "manage_capability_pack_lifecycle.py"
+TRANSFER = ROOT / "scripts" / "plan_capability_pack_transfer.py"
+BOOTSTRAP_PACK = ROOT / "fixtures" / "capability-packs" / "bootstrap-minimal"
+
+
+def run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, *args],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def expect(name: str, result: subprocess.CompletedProcess[str], should_pass: bool, expected_text: str = "") -> list[str]:
+    output = result.stdout + result.stderr
+    if (result.returncode == 0) == should_pass and (not expected_text or expected_text in output):
+        print(f"{name}: ok")
+        return []
+    return [
+        f"{name}: expected {'pass' if should_pass else 'failure'}"
+        + (f" containing {expected_text!r}" if expected_text else "")
+        + f", got exit {result.returncode}\n{output.strip()}"
+    ]
+
+
+def require_text(path: Path, snippets: list[str]) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    errors: list[str] = []
+    for snippet in snippets:
+        if snippet not in text:
+            errors.append(f"{path.relative_to(ROOT)} missing {snippet!r}")
+        else:
+            print(f"{path.relative_to(ROOT)} contains {snippet}: ok")
+    return errors
+
+
+def write_candidate_as_manifest(base: Path) -> Path:
+    pack = base / "candidate-as-manifest"
+    pack.mkdir(parents=True)
+    (pack / "manifest.yaml").write_text(
+        "\n".join(
+            [
+                "candidate_schema_version: 1",
+                "candidate_id: candidate.pack.review-only",
+                "proposed_pack_id: pack.review-only",
+                "title: Review-only candidate",
+                "outcome: candidate",
+                "confidence: medium",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return pack
+
+
+def write_deployed_index(vault: Path) -> None:
+    packs = vault / "packs"
+    packs.mkdir(parents=True, exist_ok=True)
+    (packs / "deployed-pack-index.yaml").write_text(
+        "\n".join(
+            [
+                "schema_version: 1",
+                "updated: 2026-06-17",
+                "deployed_packs:",
+                "  - pack_id: pack.bootstrap.minimal",
+                "    version: 0.2.0",
+                "    lifecycle_status: active",
+                "    source:",
+                f"      manifest_sha256: {'0' * 64}",
+                "    records:",
+                "      - id: BOOT-001",
+                "        kind: practice",
+                "        path: practices/meta/BOOT-001-bootstrap-orientation.md",
+                f"        deployed_sha256: {'1' * 64}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    errors: list[str] = []
+    errors.extend(
+        require_text(
+            ROOT / "workflows" / "discover-capability-packs.md",
+            [
+                "Advanced Workflow Surface",
+                "Advanced capability discovery is optional",
+                "scripts/manage_capability_pack_lifecycle.py",
+                "scripts/plan_capability_pack_transfer.py",
+                "writes: none",
+            ],
+        )
+    )
+    errors.extend(
+        require_text(
+            ROOT / "workflows" / "manage-capability-pack-lifecycle.md",
+            ["activate", "exportable", "writes: none", "#176"],
+        )
+    )
+    errors.extend(
+        require_text(
+            ROOT / "workflows" / "export-import-capability-packs.md",
+            ["review-first", "Import States", "writes: none", "private Vault"],
+        )
+    )
+
+    with tempfile.TemporaryDirectory(prefix="agent-foundry-advanced-workflow-") as tmp:
+        base = Path(tmp)
+        vault = base / "vault"
+        errors.extend(
+            expect(
+                "advanced-init-blank-vault",
+                run([str(INIT), str(vault), "--core-root", str(ROOT), "--apply"]),
+                True,
+                "Blank Vault initialized and validated.",
+            )
+        )
+
+        basic_plan = run([str(PLAN), str(BOOTSTRAP_PACK), "--core-root", str(ROOT), "--vault-root", str(vault)])
+        errors.extend(expect("advanced-basic-pack-flow-still-works", basic_plan, True, "add: 24"))
+        errors.extend(expect("advanced-basic-pack-writes-none", basic_plan, True, "writes: none"))
+
+        candidate_pack = write_candidate_as_manifest(base)
+        candidate_plan = run([str(PLAN), str(candidate_pack), "--core-root", str(ROOT), "--vault-root", str(vault)])
+        errors.extend(expect("advanced-candidate-not-active-manifest", candidate_plan, False, "review-only"))
+
+        transfer_preview = run(
+            [
+                str(TRANSFER),
+                str(BOOTSTRAP_PACK),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(vault),
+                "--action",
+                "import-preview",
+                "--import-state",
+                "preview",
+            ]
+        )
+        errors.extend(expect("advanced-transfer-dry-run-first", transfer_preview, False, "writes: none"))
+        errors.extend(expect("advanced-transfer-needs-export-policy", transfer_preview, False, "export_policy is required"))
+
+        write_deployed_index(vault)
+        lifecycle_exportable = run(
+            [
+                str(LIFECYCLE),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(vault),
+                "--pack-id",
+                "pack.bootstrap.minimal",
+                "--action",
+                "exportable",
+            ]
+        )
+        errors.extend(expect("advanced-lifecycle-exportable-review-gated", lifecycle_exportable, False, "review_gate:"))
+        errors.extend(expect("advanced-lifecycle-exportable-writes-none", lifecycle_exportable, False, "writes: none"))
+
+    if errors:
+        print("Advanced capability workflow surface test failed:")
+        for error in errors:
+            print(error)
+        return 1
+    print("Advanced capability workflow surface test passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/workflows/discover-capability-packs.md
+++ b/workflows/discover-capability-packs.md
@@ -175,7 +175,54 @@ After review, Architect decides whether to:
 - create a follow-up for implementation;
 - close as rejected or deferred.
 
-## 8. AF9 Fixture Expectations
+## 8. Advanced Workflow Surface
+
+Advanced capability discovery is optional. Basic pack deployment, planning,
+update comparison, lifecycle reports, and transfer validation must still work
+when no candidate records exist.
+
+Use this sequence only when an issue or human asks for advanced discovery:
+
+1. Run discovery as evidence gathering. Output candidate records or a review
+   packet only; do not write canonical pack metadata or selected Vault records.
+2. Validate any candidate record against
+   `schemas/capability-pack-candidate.schema.yaml`. Candidate records remain
+   review artifacts and must not be passed to activation, export, or deployment
+   tooling as active pack manifests.
+3. If the candidate becomes a reviewed pack manifest, validate it with
+   `scripts/plan_capability_pack.py` before any deployment flow. Advanced
+   metadata is additive and optional; `manifest_schema_version: 1` packs without
+   advanced sections remain valid.
+4. For lifecycle review, use
+   `scripts/manage_capability_pack_lifecycle.py` in dry-run mode. Review-only
+   actions such as `activate`, `exportable`, `deprecate`, `split`, and `merge`
+   must report status, gates, rollback/defer guidance, and `writes: none`.
+5. For export/import review, use
+   `scripts/plan_capability_pack_transfer.py` before sharing or import
+   acceptance. Transfer reports must be privacy-safe, dry-run first, and
+   `writes: none`.
+6. Route the result to the next owner:
+   - Reviewer for candidate false-positive and boundary review;
+   - Architect for split/merge or lifecycle policy decisions;
+   - human for privacy/export, runtime-write, destructive, or final `main` merge
+     decisions;
+   - Harvester only when a canonical practice or asset change is actually
+     required.
+
+Failure states:
+
+- `candidate_schema_version` appears in a pack manifest path: block as
+  review-only candidate material.
+- Generated or runtime evidence claims canonical authority: reject as
+  false-positive or block policy.
+- Transfer material contains private/local markers, executable install side
+  effects, or missing export policy: block before sharing or import acceptance.
+- Lifecycle metadata is malformed, missing hashes, local-private, or destructive:
+  block and report rollback/defer/downstream guidance.
+- Existing selected Vault edits conflict with imported content: preserve the
+  Vault and route to reviewed merge; do not overwrite.
+
+## 9. AF9 Fixture Expectations
 
 Use these fixtures from AF9 #172 while validating the protocol:
 


### PR DESCRIPTION
## Scope

Implements AF9 #177 as a scoped advanced capability discovery and lifecycle workflow surface PR after #173/#174/#175/#176 landed.

Changed files:
- `workflows/discover-capability-packs.md`
- `scripts/test_advanced_capability_workflow_surface.py`
- `scripts/check_consistency.py`

Implemented:
- Added an Advanced Workflow Surface section to the discovery workflow tying candidate discovery, candidate schema review-only handling, pack planning, lifecycle dry-run reporting, and privacy-safe transfer planning into one optional sequence.
- Added focused regression coverage proving advanced discovery remains optional, basic pack planning still works without candidate records, candidate schema records are not active manifests, transfer review is dry-run/fail-closed, and lifecycle `exportable` remains review-gated with `writes: none`.
- Added #176 transfer and #177 advanced workflow tests to `check_consistency.py` so privacy-safe transfer and advanced workflow surface regressions stay covered.

## Verification

- `python3 -m py_compile scripts/test_advanced_capability_workflow_surface.py scripts/check_consistency.py`
- `python3 scripts/test_advanced_capability_workflow_surface.py`
- `python3 scripts/test_capability_pack_transfer.py`
- `python3 scripts/check_capability_pack_fixtures.py`
- `python3 scripts/test_capability_pack_plan.py`
- `python3 scripts/test_capability_pack_apply.py`
- `python3 scripts/test_capability_pack_update.py`
- `python3 scripts/test_capability_pack_lifecycle.py`
- `python3 scripts/test_capability_scenario_matrix.py`
- `python3 scripts/check_consistency.py`
- `git diff --check`

## Safety confirmations

- No direct canonical Vault mutation outside approved flow.
- No runtime apply.
- No private Vault export.
- No pack activation/export.
- No memory-system work.
- No destructive operation, merge, or issue/Epic closure.

## Residual risks

- This PR documents and verifies the integrated workflow surface; it does not add a new automatic discovery engine.
- Candidate creation remains evidence/proposal-first and requires follow-up review before activation/export/import apply.
- #179 still owns final user-facing usage/tryout output before AF9 closure.

Next owner: Reviewer for #177 workflow surface, compatibility, and failure-state review.
