### PR TITLE
AF9 #188 package capability pack skill workflow surface

### DIFF
--- a/adapters/adapter_profiles.yaml
+++ b/adapters/adapter_profiles.yaml
@@ -26,6 +26,7 @@ adapters:
     command_vocabulary:
       harvest: ["harvest practices", "做一次 harvest practice", "提炼实践", "沉淀经验"]
       discover_assets: ["discover assets", "发现可打包资产"]
+      capability_packs: ["discover capability packs", "evaluate capability pack <path>", "preview capability pack deployment <path>", "apply reviewed capability pack <path>", "review capability pack lifecycle <pack-id>", "preview capability pack transfer <path>"]
       import: ["import skill <source>", "导入这个 skill <source>"]
       publish: ["publish practices", "发布 practices"]
       review: ["review practices", "检查 skill rot"]
@@ -52,6 +53,7 @@ adapters:
     command_vocabulary:
       harvest: ["harvest practices", "做一次 harvest practice"]
       discover_assets: ["discover assets", "发现可打包资产"]
+      capability_packs: ["discover capability packs", "evaluate capability pack <path>", "preview capability pack deployment <path>", "apply reviewed capability pack <path>", "review capability pack lifecycle <pack-id>", "preview capability pack transfer <path>"]
       import: ["import skill <source>", "导入这个 skill <source>"]
       publish: ["publish practices", "发布 practices"]
       review: ["review practices", "检查 skill rot"]
@@ -80,6 +82,7 @@ adapters:
     command_vocabulary:
       harvest: ["harvest practices", "做一次 harvest practice", "提炼实践", "沉淀经验"]
       discover_assets: ["discover assets", "发现可打包资产"]
+      capability_packs: ["discover capability packs", "evaluate capability pack <path>", "preview capability pack deployment <path>", "apply reviewed capability pack <path>", "review capability pack lifecycle <pack-id>", "preview capability pack transfer <path>"]
       import: ["import skill <source>", "导入这个 skill <source>"]
       publish: ["publish practices", "发布 practices"]
       review: ["review practices", "检查 skill rot"]
@@ -106,6 +109,7 @@ adapters:
     command_vocabulary:
       harvest: ["harvest practices", "做一次 harvest practice", "提炼实践", "沉淀经验"]
       discover_assets: ["discover assets", "发现可打包资产"]
+      capability_packs: ["discover capability packs", "evaluate capability pack <path>", "preview capability pack deployment <path>", "apply reviewed capability pack <path>", "review capability pack lifecycle <pack-id>", "preview capability pack transfer <path>"]
       import: ["import skill <source>", "导入这个 skill <source>"]
       publish: ["publish practices", "发布 practices"]
       review: ["review practices", "检查 skill rot"]
@@ -132,6 +136,7 @@ adapters:
     command_vocabulary:
       harvest: ["harvest practices", "做一次 harvest practice"]
       discover_assets: ["discover assets", "发现可打包资产"]
+      capability_packs: ["discover capability packs", "evaluate capability pack <path>", "preview capability pack deployment <path>", "apply reviewed capability pack <path>", "review capability pack lifecycle <pack-id>", "preview capability pack transfer <path>"]
       import: ["import skill <source>", "导入这个 skill <source>"]
       publish: ["publish practices", "发布 practices"]
       review: ["review practices", "检查 skill rot"]

--- a/adapters/chatgpt/custom-instructions.md
+++ b/adapters/chatgpt/custom-instructions.md
@@ -33,6 +33,11 @@ Recognize these short commands:
 
 - `harvest practices` / `做一次 harvest practice`: extract reusable practices from the current session and show a concise review list.
 - `discover assets` / `发现可打包资产`: find repeated workflows that should become skills, subagents, automations, or extensions.
+- `discover capability packs` / `evaluate capability pack <path>`: find or inspect higher-level pack candidates without activation.
+- `preview capability pack deployment <path>`: plan selected Vault impact and review gates before apply.
+- `apply reviewed capability pack <path>`: apply only after the reviewed plan and required gates are accepted.
+- `review capability pack lifecycle <pack-id>`: dry-run lifecycle transitions before any state change.
+- `preview capability pack transfer <path>`: validate export/import transfer material with privacy-safe, writes-none checks.
 - `import skill <source>` / `导入这个 skill <source>`: evaluate an external skill or prompt source.
 - `publish practices` / `发布 practices`: publish adapters from current active practices.
 - `review practices` / `检查 skill rot`: review for duplicates, stale entries, weak rules, and adapter drift.
@@ -46,6 +51,8 @@ session summary -> candidate lessons -> classification -> dedupe -> decision -> 
 ```
 
 For harvest work, run the current capability check before routing or drafting; do not use future architecture concepts as current writable substrate. Route artifacts before abstracting practices. Treat user method corrections as process evidence first. Apply the generalization gate before drafting practice candidates, and list important rejected-as-practice items. Present a concise review list before mutation, including canonical impact, adapter impact, and runtime/global instruction impact when relevant. Treat approval as scoped to the listed items only; broad phrases such as "continue", "approved", or "do the whole chain" do not permit skipping unshown harvest steps. After approval, continue through the listed canonical changes, checks, PR/traceability, merge/apply, and adapter/runtime publish automatically unless the diff departs from the approved list, checks fail, risk increases, or a new unlisted runtime/global target appears.
+
+For capability-pack work, use the Skill-first intents above as the primary interface. Discovery/evaluation reads `workflows/discover-capability-packs.md` and writes no canonical state. Deployment preview runs the plan workflow before apply. Reviewed apply requires accepted review/approval evidence. Lifecycle review reads `workflows/manage-capability-pack-lifecycle.md` and starts with dry-run reports. Transfer preview reads `workflows/export-import-capability-packs.md` and blocks local-private, runtime, executable, or memory-system material. Treat raw capability-pack scripts as advanced/debug details.
 
 Do not put raw lessons directly into skills or prompts. New practices should start as `candidate` or `proposed` unless I explicitly approve activation. After I approve a practice, apply it, promote it to `active` when applicable, update the index, and publish the relevant adapters automatically. Only `active` practices should be published into default agent adapters.
 

--- a/adapters/chatgpt/knowledge/commands.md
+++ b/adapters/chatgpt/knowledge/commands.md
@@ -7,6 +7,12 @@ Use these short commands:
 | Command | 中文 | Meaning |
 |---|---|---|
 | `harvest practices` | `做一次 harvest practice` | Extract reusable practices from the current session and show a review list. |
+| `discover capability packs` | `发现 capability pack` | Find higher-level reusable capability bundles from repeated practice, asset, workflow, and adapter evidence. Produces candidates only. |
+| `evaluate capability pack <path>` | `评估 capability pack <路径>` | Inspect a pack or candidate boundary, false positives, privacy risks, and next reviewer without activating it. |
+| `preview capability pack deployment <path>` | `预览 capability pack 部署 <路径>` | Plan selected Vault impact and review gates before any apply. |
+| `apply reviewed capability pack <path>` | `应用已 review 的 capability pack <路径>` | Apply only after the reviewed plan and required human gates are accepted; generated/runtime follow-up stays separate. |
+| `review capability pack lifecycle <pack-id>` | `review capability pack lifecycle <pack-id>` | Dry-run lifecycle transitions such as activate, exportable, split, merge, deprecate, disable, or retire. |
+| `preview capability pack transfer <path>` | `预览 capability pack transfer <路径>` | Validate export/import transfer material with privacy-safe, writes-none checks. |
 | `import skill <source>` | `导入这个 skill <source>` | Evaluate an external skill, repo, prompt pack, article, or local folder. |
 | `publish practices` | `发布 practices` | Publish adapters from current active practices. Usually not needed manually. |
 | `review practices` | `检查 skill rot` | Review the practice repo for duplicates, stale entries, weak or missed activation, and adapter drift. |

--- a/adapters/claude-code/CLAUDE.md
+++ b/adapters/claude-code/CLAUDE.md
@@ -35,6 +35,11 @@ Short commands:
 - `harvest practices` / `做一次 harvest practice`
 - `discover assets` / `harvest skills` / `harvest assets` / `发现可打包资产`
 - `import skill <source>` / `导入这个 skill <source>`
+- `discover capability packs` / `evaluate capability pack <path>`
+- `preview capability pack deployment <path>`
+- `apply reviewed capability pack <path>`
+- `review capability pack lifecycle <pack-id>`
+- `preview capability pack transfer <path>`
 - `publish practices` / `发布 practices`
 - `review practices` / `检查 skill rot`
 - `review assets` / `检查 asset rot`
@@ -58,6 +63,8 @@ When asked to harvest, persist, deduplicate, merge, or publish reusable lessons:
 12. Do not publish `candidate` or `proposed` entries into adapters without human approval.
 
 When asked to discover reusable assets or harvest skills, read `workflows/discover-assets.md`, search `indexes/asset_index.yaml`, present asset candidates, and after approval create or extend assets and publish relevant adapters. For whole-session or phase-level skill harvests, set an explicit evidence window that includes earlier phases, linked issues, PRs, and commits rather than only the latest discussion topic.
+
+When asked to work with capability packs, use the Skill-first intents above as the primary interface. Discovery/evaluation reads `workflows/discover-capability-packs.md` and writes no canonical state. Deployment preview runs the plan workflow before apply. Reviewed apply requires accepted review/approval evidence. Lifecycle review reads `workflows/manage-capability-pack-lifecycle.md` and starts with dry-run reports. Transfer preview reads `workflows/export-import-capability-packs.md` and blocks local-private, runtime, executable, or memory-system material. Treat raw capability-pack scripts as advanced/debug details.
 
 When an active asset is used, record concise non-sensitive usage evidence automatically, preferably with `scripts/record_asset_usage.py`.
 

--- a/adapters/codex/skills/practice-harvester/SKILL.md
+++ b/adapters/codex/skills/practice-harvester/SKILL.md
@@ -30,6 +30,11 @@ Before substantial changes, check:
 - `discover assets` / `harvest skills` / `harvest assets` / `发现可打包资产`: find repeated workflows that should become skills, subagents, automations, or extensions.
 - `import skill <source>` / `导入这个 skill <source>`: run the external skill import workflow.
 - `publish practices` / `发布 practices`: publish adapters from current active practices.
+- `discover capability packs` / `evaluate capability pack`: read `workflows/discover-capability-packs.md`, gather evidence, and output candidate or false-positive review only.
+- `preview capability pack deployment`: run the capability-pack plan workflow first; report selected Vault impact, review gates, and `writes: none`.
+- `apply reviewed capability pack`: require accepted review/approval evidence, apply through the reviewed pack workflow, then publish or inspect adapters separately.
+- `review capability pack lifecycle`: read `workflows/manage-capability-pack-lifecycle.md` and produce dry-run lifecycle status before any state change.
+- `preview capability pack transfer`: read `workflows/export-import-capability-packs.md` and run privacy-safe transfer validation with no selected Vault writes.
 - `review practices` / `检查 skill rot`: review for duplicates, stale entries, weak rules, and adapter drift.
 - `review assets` / `检查 asset rot`: review reusable assets for usage, overlap, stale triggers, and adapter coverage.
 - `refresh practices and assets` / `刷新practices和assets`: pull remote updates, conditionally regenerate adapters, and install to local runtimes. Read `workflows/refresh.md` from the agent-foundry repo.
@@ -38,7 +43,7 @@ Before substantial changes, check:
 
 1. Locate Agent Foundry Core and Vault. Prefer explicit roots when available, then `AGENT_FOUNDRY_CORE` plus `AGENT_FOUNDRY_VAULT` after commands support them, then `~/.agent-foundry/config.yaml`, then `AGENT_FOUNDRY_HOME` as same-root compatibility, then the current directory only if it validates as the required Core and Vault context. The current project is evidence source, not canonical destination.
 2. Select the workflow from the short command or user intent.
-3. Read `references/harvest-workflow.md` for harvesting, `references/import-policy.md` for imports, `references/asset-policy.md` for assets, `workflows/refresh.md` from the repo for refresh, or the repository workflow file for publish/review.
+3. Read `references/harvest-workflow.md` for harvesting, `references/import-policy.md` for imports, `references/asset-policy.md` for assets, `workflows/refresh.md` from the repo for refresh, `workflows/discover-capability-packs.md` for pack discovery/evaluation, `workflows/manage-capability-pack-lifecycle.md` for lifecycle review, `workflows/export-import-capability-packs.md` for transfer review, or the repository workflow file for publish/review.
 4. Read `references/schema.md`.
 5. When harvesting skills or assets from a long session, set an explicit evidence window that includes earlier phases, linked issues, PRs, and commits rather than only the latest discussion topic.
 6. Run the current capability check before routing or drafting; do not use future architecture concepts as current writable substrate.
@@ -54,12 +59,22 @@ Before substantial changes, check:
 16. After the user approves a practice or asset change, apply the canonical change and publish relevant adapters automatically.
 17. Report candidates, decisions, changed files, and review needs.
 
+## Capability Pack Workflow Intents
+
+- Discovery/evaluation: users may ask to "discover capability packs" or "evaluate capability pack"; output candidate evidence, confidence, false-positive controls, and next review owner without writing canonical records.
+- Deployment preview: users may ask to "preview capability pack deployment"; run `scripts/plan_capability_pack.py` against the selected Vault, report diffs and gates, and stop before apply.
+- Reviewed apply: users may ask to "apply reviewed capability pack"; confirm accepted review/approval evidence, run the existing reviewed apply workflow, and keep generated/runtime follow-up separate.
+- Lifecycle review: users may ask to "review capability pack lifecycle"; run dry-run lifecycle reporting with `writes: none` unless the transition is explicitly supported and approved.
+- Transfer preview: users may ask to "preview capability pack transfer"; use privacy-safe export/import validation and block local-private, runtime, executable, or memory-system material.
+
 ## Guardrails
 
 - Apply governance practices GOV-001 through GOV-006 across all projects, not only inside Agent Foundry: protect canonical source of truth, prefer the smallest maintainable mechanism, treat transient context as evidence, preserve maintainability plus native runtime capability, do not use future architecture as current substrate, and mark current versus proposed capability.
 - Do not add raw session notes directly into agent skills.
 - Do not publish `candidate` or `proposed` entries into default adapters.
 - Do not import external skills directly into active adapters.
+- Do not make raw scripts the primary capability-pack user interface; route user requests through the Skill intents above and treat scripts as implementation details or advanced/debug commands.
+- Do not apply, activate, export, import, split, merge, deprecate, disable, retire, or runtime-install capability packs without the matching review and human gates.
 - Ask for human approval before promoting a practice to `active`; after approval, publish relevant adapters unless the user asks to stage only.
 - Record concise, non-sensitive asset usage evidence automatically when an active asset is invoked.
 - Treat memory as evidence, not source of truth.

--- a/adapters/hermes/skills/practice-harvester/SKILL.md
+++ b/adapters/hermes/skills/practice-harvester/SKILL.md
@@ -30,6 +30,11 @@ Before substantial changes, check:
 - `discover assets` / `harvest skills` / `harvest assets` / `发现可打包资产`: find repeated workflows that should become skills, subagents, automations, or extensions.
 - `import skill <source>` / `导入这个 skill <source>`: run the external skill import workflow.
 - `publish practices` / `发布 practices`: publish adapters from current active practices.
+- `discover capability packs` / `evaluate capability pack`: read `workflows/discover-capability-packs.md`, gather evidence, and output candidate or false-positive review only.
+- `preview capability pack deployment`: run the capability-pack plan workflow first; report selected Vault impact, review gates, and `writes: none`.
+- `apply reviewed capability pack`: require accepted review/approval evidence, apply through the reviewed pack workflow, then publish or inspect adapters separately.
+- `review capability pack lifecycle`: read `workflows/manage-capability-pack-lifecycle.md` and produce dry-run lifecycle status before any state change.
+- `preview capability pack transfer`: read `workflows/export-import-capability-packs.md` and run privacy-safe transfer validation with no selected Vault writes.
 - `review practices` / `检查 skill rot`: review for duplicates, stale entries, weak rules, and adapter drift.
 - `review assets` / `检查 asset rot`: review reusable assets for usage, overlap, stale triggers, and adapter coverage.
 - `refresh practices and assets` / `刷新practices和assets`: pull remote updates, conditionally regenerate adapters, and install to local runtimes. Read `workflows/refresh.md` from the agent-foundry repo.
@@ -38,7 +43,7 @@ Before substantial changes, check:
 
 1. Locate Agent Foundry Core and Vault. Prefer explicit roots when available, then `AGENT_FOUNDRY_CORE` plus `AGENT_FOUNDRY_VAULT` after commands support them, then `~/.agent-foundry/config.yaml`, then `AGENT_FOUNDRY_HOME` as same-root compatibility, then the current directory only if it validates as the required Core and Vault context. The current project is evidence source, not canonical destination.
 2. Select the workflow from the short command or user intent.
-3. Read `references/harvest-workflow.md` for harvesting, `references/import-policy.md` for imports, `references/asset-policy.md` for assets, `workflows/refresh.md` from the repo for refresh, or the repository workflow file for publish/review.
+3. Read `references/harvest-workflow.md` for harvesting, `references/import-policy.md` for imports, `references/asset-policy.md` for assets, `workflows/refresh.md` from the repo for refresh, `workflows/discover-capability-packs.md` for pack discovery/evaluation, `workflows/manage-capability-pack-lifecycle.md` for lifecycle review, `workflows/export-import-capability-packs.md` for transfer review, or the repository workflow file for publish/review.
 4. Read `references/schema.md`.
 5. When harvesting skills or assets from a long session, set an explicit evidence window that includes earlier phases, linked issues, PRs, and commits rather than only the latest discussion topic.
 6. Run the current capability check before routing or drafting; do not use future architecture concepts as current writable substrate.
@@ -54,12 +59,22 @@ Before substantial changes, check:
 16. After the user approves a practice or asset change, apply the canonical change and publish relevant adapters automatically.
 17. Report candidates, decisions, changed files, and review needs.
 
+## Capability Pack Workflow Intents
+
+- Discovery/evaluation: users may ask to "discover capability packs" or "evaluate capability pack"; output candidate evidence, confidence, false-positive controls, and next review owner without writing canonical records.
+- Deployment preview: users may ask to "preview capability pack deployment"; run `scripts/plan_capability_pack.py` against the selected Vault, report diffs and gates, and stop before apply.
+- Reviewed apply: users may ask to "apply reviewed capability pack"; confirm accepted review/approval evidence, run the existing reviewed apply workflow, and keep generated/runtime follow-up separate.
+- Lifecycle review: users may ask to "review capability pack lifecycle"; run dry-run lifecycle reporting with `writes: none` unless the transition is explicitly supported and approved.
+- Transfer preview: users may ask to "preview capability pack transfer"; use privacy-safe export/import validation and block local-private, runtime, executable, or memory-system material.
+
 ## Guardrails
 
 - Apply governance practices GOV-001 through GOV-006 across all projects, not only inside Agent Foundry: protect canonical source of truth, prefer the smallest maintainable mechanism, treat transient context as evidence, preserve maintainability plus native runtime capability, do not use future architecture as current substrate, and mark current versus proposed capability.
 - Do not add raw session notes directly into agent skills.
 - Do not publish `candidate` or `proposed` entries into default adapters.
 - Do not import external skills directly into active adapters.
+- Do not make raw scripts the primary capability-pack user interface; route user requests through the Skill intents above and treat scripts as implementation details or advanced/debug commands.
+- Do not apply, activate, export, import, split, merge, deprecate, disable, retire, or runtime-install capability packs without the matching review and human gates.
 - Ask for human approval before promoting a practice to `active`; after approval, publish relevant adapters unless the user asks to stage only.
 - Record concise, non-sensitive asset usage evidence automatically when an active asset is invoked.
 - Treat memory as evidence, not source of truth.

--- a/adapters/trae/skills/agent-foundry/SKILL.md
+++ b/adapters/trae/skills/agent-foundry/SKILL.md
@@ -28,6 +28,12 @@ Before substantial changes, check:
 - 沉淀经验
 - discover assets
 - 发现可打包资产
+- discover capability packs
+- evaluate capability pack
+- preview capability pack deployment
+- apply reviewed capability pack
+- review capability pack lifecycle
+- preview capability pack transfer
 - import skill
 - 导入这个 skill
 - publish practices
@@ -38,6 +44,16 @@ Before substantial changes, check:
 - 检查 asset rot
 - refresh practices and assets
 - 刷新practices和assets
+
+## Capability Pack Workflow
+
+- Use natural-language Skill requests as the primary interface: discover or evaluate capability packs, preview deployment, apply a reviewed pack, review lifecycle transition, or preview transfer.
+- Discovery and evaluation read `workflows/discover-capability-packs.md` and produce evidence or false-positive review only.
+- Deployment preview runs the capability-pack planning workflow before any selected Vault write.
+- Reviewed apply requires accepted review/approval evidence and keeps generated/runtime follow-up separate.
+- Lifecycle review uses dry-run reports first; activation, exportability, split, merge, deprecation, disable, retire, and runtime writes keep their review or human gates.
+- Transfer preview uses privacy-safe export/import validation and blocks local-private, runtime, executable, or memory-system material.
+- Treat raw scripts for capability packs as implementation details or advanced/debug commands, not the primary user surface.
 
 ## Role Routing
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -10,6 +10,12 @@ Use these short commands in day-to-day agent work.
 |---|---|---|
 | `harvest practices` | `做一次 harvest practice` | Extract reusable practices from the current session and show a review list.<br>从当前 session 提炼可复用 practice，并展示 review list。 |
 | `discover assets` | `发现可打包资产` | Find repeated workflows that should become skills, subagents, automations, or extensions.<br>发现值得沉淀为 skill、subagent、automation 或扩展项的重复 workflow。 |
+| `discover capability packs` | `发现 capability pack` | Find higher-level reusable capability bundles from repeated practice, asset, workflow, and adapter evidence. Produces candidates only.<br>从重复的 practice、asset、workflow 和 adapter evidence 中发现更高层的 reusable capability bundle；只产出 candidate。 |
+| `evaluate capability pack <path>` | `评估 capability pack <路径>` | Inspect a pack or candidate boundary, false positives, privacy risks, and next reviewer without activating it.<br>检查 pack 或 candidate 的边界、false positive、隐私风险和下一位 reviewer，不激活。 |
+| `preview capability pack deployment <path>` | `预览 capability pack 部署 <路径>` | Plan selected Vault impact and review gates before any apply.<br>在任何 apply 前预览 selected Vault 影响和 review gates。 |
+| `apply reviewed capability pack <path>` | `应用已 review 的 capability pack <路径>` | Apply only after the reviewed plan and required human gates are accepted; generated/runtime follow-up stays separate.<br>仅在 reviewed plan 和必要 human gate 被接受后 apply；generated/runtime 后续步骤保持分离。 |
+| `review capability pack lifecycle <pack-id>` | `review capability pack lifecycle <pack-id>` | Dry-run lifecycle transitions such as activate, exportable, split, merge, deprecate, disable, or retire.<br>dry-run 检查 activate、exportable、split、merge、deprecate、disable、retire 等 lifecycle transition。 |
+| `preview capability pack transfer <path>` | `预览 capability pack transfer <路径>` | Validate export/import transfer material with privacy-safe, writes-none checks.<br>用 privacy-safe、writes-none 检查验证 export/import transfer material。 |
 | `import skill <source>` | `导入这个 skill <source>` | Evaluate an external skill, repo, prompt pack, article, or local folder.<br>评估外部 skill、repo、prompt pack、文章或本地目录。 |
 | `publish practices` | `发布 practices` | Publish adapters from current active practices. Usually not needed manually.<br>从当前 active practices 发布 adapters；通常不需要手动执行。 |
 | `check operation context` | `检查操作上下文` | Show the current Agent Foundry Core/Vault/evidence/runtime context before writes.<br>在写入前显示当前 Agent Foundry Core/Vault/evidence/runtime 上下文。 |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -154,9 +154,26 @@ Capability packs are reviewed bundles that can add or change practices, assets, 
 
 Capability packs 是经过 review 的 bundles，可能新增或改变 practices、assets、generated output 和 runtime-facing behavior。
 
-Use plan commands before apply commands:
+Use Skill-first requests for normal work:
 
-先使用 plan commands，再使用 apply commands：
+正常工作优先使用 Skill-first 请求：
+
+```text
+discover capability packs
+evaluate capability pack <pack-path>
+preview capability pack deployment <pack-path>
+apply reviewed capability pack <pack-path>
+review capability pack lifecycle <pack-id>
+preview capability pack transfer <pack-path>
+```
+
+These requests route through the relevant Agent Foundry workflows, preserve review gates, and keep raw scripts as implementation details or advanced/debug commands.
+
+这些请求会路由到对应的 Agent Foundry workflows，保留 review gates，并把 raw scripts 作为 implementation details 或 advanced/debug commands。
+
+Use plan commands before apply commands when operating manually or debugging:
+
+手动操作或 debug 时，先使用 plan commands，再使用 apply commands：
 
 ```bash
 python3 scripts/plan_capability_pack.py <pack-path> --vault-root <vault-root>

--- a/scripts/test_advanced_capability_workflow_surface.py
+++ b/scripts/test_advanced_capability_workflow_surface.py
@@ -103,6 +103,8 @@ def main() -> int:
         require_text(
             ROOT / "workflows" / "discover-capability-packs.md",
             [
+                "Skill-First Entry Points",
+                "discover capability packs",
                 "Advanced Workflow Surface",
                 "Advanced capability discovery is optional",
                 "scripts/manage_capability_pack_lifecycle.py",
@@ -114,15 +116,44 @@ def main() -> int:
     errors.extend(
         require_text(
             ROOT / "workflows" / "manage-capability-pack-lifecycle.md",
-            ["activate", "exportable", "writes: none", "#176"],
+            ["Skill-First Entry Points", "review capability pack lifecycle", "activate", "exportable", "writes: none", "#176"],
         )
     )
     errors.extend(
         require_text(
             ROOT / "workflows" / "export-import-capability-packs.md",
-            ["review-first", "Import States", "writes: none", "private Vault"],
+            ["Skill-First Entry Points", "preview capability pack transfer", "review-first", "Import States", "writes: none", "private Vault"],
         )
     )
+    skill_first_snippets = [
+        "discover capability packs",
+        "preview capability pack deployment",
+        "apply reviewed capability pack",
+        "review capability pack lifecycle",
+        "preview capability pack transfer",
+    ]
+    for path in [
+        ROOT / "docs" / "commands.md",
+        ROOT / "docs" / "usage.md",
+        ROOT / "adapters" / "codex" / "skills" / "practice-harvester" / "SKILL.md",
+        ROOT / "adapters" / "hermes" / "skills" / "practice-harvester" / "SKILL.md",
+        ROOT / "adapters" / "trae" / "skills" / "agent-foundry" / "SKILL.md",
+        ROOT / "adapters" / "claude-code" / "CLAUDE.md",
+        ROOT / "adapters" / "chatgpt" / "custom-instructions.md",
+        ROOT / "adapters" / "chatgpt" / "knowledge" / "commands.md",
+    ]:
+        errors.extend(require_text(path, skill_first_snippets))
+    for path in [
+        ROOT / "docs" / "usage.md",
+        ROOT / "adapters" / "codex" / "skills" / "practice-harvester" / "SKILL.md",
+        ROOT / "adapters" / "trae" / "skills" / "agent-foundry" / "SKILL.md",
+    ]:
+        errors.extend(
+            require_text(
+                path,
+                ["raw scripts", "implementation details", "advanced/debug"],
+            )
+        )
 
     with tempfile.TemporaryDirectory(prefix="agent-foundry-advanced-workflow-") as tmp:
         base = Path(tmp)

--- a/workflows/discover-capability-packs.md
+++ b/workflows/discover-capability-packs.md
@@ -8,6 +8,18 @@ This workflow proposes candidates only. It does not activate, export, deploy,
 install, publish, or mutate any pack, Vault record, generated adapter, runtime
 copy, private state, or memory-system record.
 
+## Skill-First Entry Points
+
+For normal agent use, invoke this workflow with natural-language requests such
+as:
+
+- `discover capability packs`
+- `evaluate capability pack <path>`
+
+The agent should translate those requests into the evidence-gathering sequence
+below. Raw scripts are implementation details or advanced/debug commands, not
+the primary user surface.
+
 ## Invariant
 
 Capability pack discovery outputs reviewable candidate records, not canonical

--- a/workflows/export-import-capability-packs.md
+++ b/workflows/export-import-capability-packs.md
@@ -7,6 +7,20 @@ This workflow is privacy-safe and review-first. It plans and validates transfer
 material; it does not export a private Vault, activate a pack, apply runtime
 changes, or write selected Vault records.
 
+## Skill-First Entry Points
+
+For normal agent use, invoke this workflow with natural-language requests such
+as:
+
+- `preview capability pack transfer <pack-path>`
+- `preview capability pack export <pack-path>`
+- `preview capability pack import <pack-path>`
+
+The agent should translate those requests into privacy-safe, writes-none
+validation before any sharing, import acceptance, selected Vault write, or
+runtime follow-up. Raw scripts are implementation details or advanced/debug
+commands, not the primary user surface.
+
 ## Boundaries
 
 - Core owns public schemas, workflows, validators, fixtures, examples, and

--- a/workflows/manage-capability-pack-lifecycle.md
+++ b/workflows/manage-capability-pack-lifecycle.md
@@ -7,6 +7,20 @@ exportability discussion.
 This workflow plans and reports lifecycle transitions. It does not bypass
 practice review, asset review, runtime approval, export review, or human approval.
 
+## Skill-First Entry Points
+
+For normal agent use, invoke this workflow with natural-language requests such
+as:
+
+- `review capability pack lifecycle <pack-id>`
+- `review capability pack activation <pack-id>`
+- `review capability pack deprecation <pack-id>`
+- `retire reviewed capability pack <pack-id>`
+
+The agent should translate those requests into dry-run lifecycle reports first.
+Raw scripts are implementation details or advanced/debug commands, not the
+primary user surface.
+
 ## Invariants
 
 - Selected User Vault metadata owns canonical pack lifecycle state after


### PR DESCRIPTION
## Summary

Closes #188 after review/merge.

- Adds Skill-first capability-pack intents across Core reference adapters and user docs: discovery/evaluation, deployment preview, reviewed apply, lifecycle review, and transfer preview.
- Updates AF9 workflow docs so raw capability-pack scripts are implementation details or advanced/debug commands rather than the primary user surface.
- Extends `test_advanced_capability_workflow_surface.py` to verify the Skill-first surface across docs and adapters.

## Canonical source note

The selected Vault canonical `ASSET-META-001 Practice Harvester` was updated in companion Vault PR: farmerhunter/agent-foundry-vault-farmerhunter#4.

## Verification

- `python3 scripts/test_advanced_capability_workflow_surface.py`
- `python3 scripts/check_consistency.py`
- `python3 scripts/check_adapter_quality.py --surface core`
- `python3 scripts/check_adapter_quality.py --surface selected-output --generated-root /Users/jinghuliu/.agent-foundry/generated/agent-foundry-adapters`
- Selected-output publish completed with `python3 scripts/publish_adapters.py --vault-root /Users/jinghuliu/.agent-foundry/vault/agent-foundry-vault-farmerhunter --output-root /Users/jinghuliu/.agent-foundry/generated/agent-foundry-adapters --apply`
- Generated readback confirmed Codex, Hermes, Trae, and ChatGPT surfaces contain the new capability-pack intents.

## Boundaries

- No memory-system work.
- No runtime apply.
- No private Vault export.
- No pack activation/export/import beyond reviewed gates.
- No destructive git operation.
