### PR TITLE
Add AF10 workflow comparison telemetry

### DIFF
--- a/scripts/github_collaboration_helper.py
+++ b/scripts/github_collaboration_helper.py
@@ -33,7 +33,13 @@ FORBIDDEN_ACTIONS = {
     "memory-write",
 }
 READ_ONLY_ACTIONS = {"repo-resolve", "auth-smoke", "role-config-check", "inbox", "issue-context", "scheduler-audit"}
-DRY_RUN_ACTIONS = {"handoff-draft", "dispatch-evidence-draft", "release-next-draft", "permission-smoke"}
+DRY_RUN_ACTIONS = {
+    "handoff-draft",
+    "dispatch-evidence-draft",
+    "release-next-draft",
+    "permission-smoke",
+    "comparison-draft",
+}
 REMOTE_RE = re.compile(r"(?:github\.com[:/])([^/]+)/([^/.]+)(?:\.git)?$")
 
 
@@ -150,6 +156,8 @@ def parse_simple_yaml(path: Path) -> dict[str, Any]:
         "telemetry": {
             "required_for_meaningful_transitions": scalar_in_block(telemetry, "required_for_meaningful_transitions"),
             "workflow": scalar_in_block(telemetry, "workflow"),
+            "supports_workflow_comparison": scalar_in_block(telemetry, "supports_workflow_comparison"),
+            "comparison_modes": yaml_list(telemetry, "comparison_modes", indent=2),
         },
         "project_v2": {
             "mode": scalar_in_block(project, "mode"),
@@ -178,6 +186,15 @@ def role_config_errors(config: dict[str, Any]) -> list[str]:
         errors.append("completion_handoff.required_fields must include workflow_telemetry")
     if telemetry.get("required_for_meaningful_transitions") not in ("true", True):
         errors.append("telemetry.required_for_meaningful_transitions must be true")
+    comparison_enabled = telemetry.get("supports_workflow_comparison") in ("true", True)
+    modes = telemetry.get("comparison_modes")
+    required_modes = {
+        "single_agent_baseline",
+        "unoptimized_collaboration_counterfactual",
+        "optimized_collaboration_observed",
+    }
+    if comparison_enabled and (not isinstance(modes, list) or not required_modes.issubset(set(modes))):
+        errors.append("telemetry.comparison_modes must include all three workflow comparison modes")
     if project.get("mode") != "optional_visual_mirror":
         errors.append("project_v2.mode must be optional_visual_mirror")
     return errors
@@ -387,6 +404,117 @@ def telemetry_block(transition_type: str, role_from: str, role_to: str, note: st
 """
 
 
+def comparison_telemetry_block(args: argparse.Namespace) -> str:
+    optimized_transitions = args.optimized_transitions
+    unoptimized_transitions = args.unoptimized_transitions
+    single_agent_transitions = args.single_agent_transitions
+    avoided_transitions = max(unoptimized_transitions - optimized_transitions, 0)
+    full_rehydrate_delta = max(args.unoptimized_full_rehydrates - args.optimized_full_rehydrates, 0)
+    optimized_overhead_delta = optimized_transitions - single_agent_transitions
+    quality_benefit_available = args.quality_benefit not in ("", "unknown", "none")
+    negative_quality_signal = any(
+        (
+            args.blocking_findings_missed,
+            args.failed_verification,
+            args.reopened_issues,
+            args.human_holds,
+            args.late_closure_corrections,
+        )
+    )
+    recommendation = args.recommendation
+    if recommendation == "auto":
+        if negative_quality_signal:
+            recommendation = "insufficient_data"
+        elif optimized_transitions <= single_agent_transitions + 1 and not quality_benefit_available:
+            recommendation = "single_agent"
+        elif optimized_overhead_delta > 0 and not quality_benefit_available:
+            recommendation = "single_agent"
+        elif quality_benefit_available and (avoided_transitions > 0 or full_rehydrate_delta > 0):
+            recommendation = "optimized_collaboration"
+        else:
+            recommendation = "insufficient_data"
+    return f"""workflow_comparison_telemetry:
+  subject: "{args.subject}"
+  comparison_scope:
+    unit: {args.unit}
+    issue_count: {args.issue_count}
+    pr_count: {args.pr_count}
+    user_visible_scope: {str(args.user_visible_scope).lower()}
+    risk_class: {args.risk_class}
+    human_gate_count: {args.human_gate_count}
+  single_agent_baseline:
+    source: {args.single_agent_source}
+    transitions: {single_agent_transitions}
+    rehydration:
+      none: {args.single_agent_none_rehydrates}
+      compact: {args.single_agent_compact_rehydrates}
+      full: {args.single_agent_full_rehydrates}
+    role_dispatches: 0
+    correction_cycles: {args.single_agent_correction_cycles}
+    ledger_estimated_tokens:
+      input: "{args.single_agent_estimated_input_tokens}"
+      output: "{args.single_agent_estimated_output_tokens}"
+      confidence: {args.single_agent_confidence}
+    observed_goal_tokens:
+      value: "{args.single_agent_observed_goal_tokens}"
+      source: "{args.single_agent_observed_source}"
+      notes: "Optional observed session or goal counter; not billing-grade."
+  unoptimized_collaboration_counterfactual:
+    source: estimated
+    assumed_agents: {args.assumed_agents}
+    assumed_transitions: {unoptimized_transitions}
+    assumed_full_rehydrates: {args.unoptimized_full_rehydrates}
+    assumed_compact_rehydrates: {args.unoptimized_compact_rehydrates}
+    assumed_role_dispatches: {args.unoptimized_role_dispatches}
+    assumed_human_gates: {args.unoptimized_human_gates}
+    duplicated_context: {args.unoptimized_duplicated_context}
+    ledger_estimated_tokens:
+      input: "{args.unoptimized_estimated_input_tokens}"
+      output: "{args.unoptimized_estimated_output_tokens}"
+      confidence: {args.unoptimized_confidence}
+    assumptions:
+      - "{args.unoptimized_assumption}"
+  optimized_collaboration_observed:
+    source: {args.optimized_source}
+    transitions: {optimized_transitions}
+    rehydration:
+      none: {args.optimized_none_rehydrates}
+      compact: {args.optimized_compact_rehydrates}
+      full: {args.optimized_full_rehydrates}
+    role_dispatches: {args.optimized_role_dispatches}
+    batch_checkpoints: {args.optimized_batch_checkpoints}
+    bundled_human_gates: {args.optimized_bundled_human_gates}
+    correction_cycles: {args.optimized_correction_cycles}
+    avoided_transitions: {avoided_transitions}
+    ledger_estimated_tokens:
+      input: "{args.optimized_estimated_input_tokens}"
+      output: "{args.optimized_estimated_output_tokens}"
+      confidence: {args.optimized_confidence}
+    observed_goal_tokens:
+      value: "{args.optimized_observed_goal_tokens}"
+      source: "{args.optimized_observed_source}"
+      notes: "Keep separate from ledger estimates."
+  quality_guardrails:
+    blocking_findings_missed: {args.blocking_findings_missed}
+    blocking_findings_caught: {args.blocking_findings_caught}
+    failed_verification: {args.failed_verification}
+    reopened_issues: {args.reopened_issues}
+    human_holds: {args.human_holds}
+    late_closure_corrections: {args.late_closure_corrections}
+  savings_analysis:
+    optimized_vs_unoptimized:
+      transition_delta: {optimized_transitions - unoptimized_transitions}
+      full_rehydrate_delta: {args.optimized_full_rehydrates - args.unoptimized_full_rehydrates}
+      estimated_token_delta: "{args.estimated_token_delta}"
+    optimized_vs_single_agent:
+      overhead_delta: {optimized_overhead_delta}
+      quality_or_parallelism_benefit: "{args.quality_benefit}"
+    recommendation: {recommendation}
+    confidence: {args.analysis_confidence}
+    notes: "Decision-support estimate, not billing-grade accounting."
+"""
+
+
 def compact_packet(args: argparse.Namespace, next_owner: str) -> str:
     return f"""compact_rehydration_packet:
   packet_version: 1
@@ -450,6 +578,12 @@ def cmd_release_next_draft(args: argparse.Namespace) -> None:
     print(telemetry_block("release_next_draft", args.current_owner, args.next_owner, "Preview-only release draft."))
 
 
+def cmd_comparison_draft(args: argparse.Namespace) -> None:
+    print("DRY RUN: workflow comparison telemetry only; no comments, labels, Project fields, merge, closure, runtime, Vault, generated, or memory mutation performed.")
+    print()
+    print(comparison_telemetry_block(args))
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", help="Explicit GitHub repository as owner/repo.")
@@ -505,6 +639,10 @@ def build_parser() -> argparse.ArgumentParser:
     release.add_argument("--next-owner", default="Implementer")
     release.add_argument("--dependency", required=True)
     release.set_defaults(func=cmd_release_next_draft)
+
+    comparison = sub.add_parser("comparison-draft")
+    add_comparison_args(comparison)
+    comparison.set_defaults(func=cmd_comparison_draft)
     return parser
 
 
@@ -516,6 +654,70 @@ def add_draft_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--current-owner", default="Implementer")
     parser.add_argument("--scope", default="bounded helper work")
     parser.add_argument("--risk", default="Preview output must be verified against authority sources.")
+
+
+def add_comparison_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--subject", required=True)
+    parser.add_argument(
+        "--unit",
+        choices=["issue", "issue_batch", "pr", "epic", "milestone", "pilot", "session_goal"],
+        default="issue",
+    )
+    parser.add_argument("--issue-count", type=int, default=1)
+    parser.add_argument("--pr-count", type=int, default=0)
+    parser.add_argument("--user-visible-scope", action="store_true")
+    parser.add_argument("--risk-class", choices=["low", "medium", "high", "mixed"], default="medium")
+    parser.add_argument("--human-gate-count", type=int, default=0)
+    parser.add_argument("--single-agent-source", choices=["observed", "estimated", "unavailable"], default="estimated")
+    parser.add_argument("--single-agent-transitions", type=int, default=1)
+    parser.add_argument("--single-agent-none-rehydrates", type=int, default=1)
+    parser.add_argument("--single-agent-compact-rehydrates", type=int, default=0)
+    parser.add_argument("--single-agent-full-rehydrates", type=int, default=0)
+    parser.add_argument("--single-agent-correction-cycles", type=int, default=0)
+    parser.add_argument("--single-agent-estimated-input-tokens", default="unknown")
+    parser.add_argument("--single-agent-estimated-output-tokens", default="unknown")
+    parser.add_argument("--single-agent-confidence", choices=["low", "medium", "high"], default="low")
+    parser.add_argument("--single-agent-observed-goal-tokens", default="unknown")
+    parser.add_argument("--single-agent-observed-source", default="null")
+    parser.add_argument("--assumed-agents", type=int, choices=[3, 4], default=3)
+    parser.add_argument("--unoptimized-transitions", type=int, default=4)
+    parser.add_argument("--unoptimized-full-rehydrates", type=int, default=4)
+    parser.add_argument("--unoptimized-compact-rehydrates", type=int, default=0)
+    parser.add_argument("--unoptimized-role-dispatches", type=int, default=3)
+    parser.add_argument("--unoptimized-human-gates", type=int, default=0)
+    parser.add_argument("--unoptimized-duplicated-context", choices=["low", "medium", "high"], default="high")
+    parser.add_argument("--unoptimized-estimated-input-tokens", default="unknown")
+    parser.add_argument("--unoptimized-estimated-output-tokens", default="unknown")
+    parser.add_argument("--unoptimized-confidence", choices=["low", "medium", "high"], default="low")
+    parser.add_argument("--unoptimized-assumption", default="Each role handoff performs full rehydration.")
+    parser.add_argument("--optimized-source", choices=["observed", "estimated", "mixed"], default="observed")
+    parser.add_argument("--optimized-transitions", type=int, default=1)
+    parser.add_argument("--optimized-none-rehydrates", type=int, default=0)
+    parser.add_argument("--optimized-compact-rehydrates", type=int, default=1)
+    parser.add_argument("--optimized-full-rehydrates", type=int, default=0)
+    parser.add_argument("--optimized-role-dispatches", type=int, default=0)
+    parser.add_argument("--optimized-batch-checkpoints", type=int, default=0)
+    parser.add_argument("--optimized-bundled-human-gates", type=int, default=0)
+    parser.add_argument("--optimized-correction-cycles", type=int, default=0)
+    parser.add_argument("--optimized-estimated-input-tokens", default="unknown")
+    parser.add_argument("--optimized-estimated-output-tokens", default="unknown")
+    parser.add_argument("--optimized-confidence", choices=["low", "medium", "high"], default="low")
+    parser.add_argument("--optimized-observed-goal-tokens", default="unknown")
+    parser.add_argument("--optimized-observed-source", default="null")
+    parser.add_argument("--blocking-findings-missed", type=int, default=0)
+    parser.add_argument("--blocking-findings-caught", type=int, default=0)
+    parser.add_argument("--failed-verification", type=int, default=0)
+    parser.add_argument("--reopened-issues", type=int, default=0)
+    parser.add_argument("--human-holds", type=int, default=0)
+    parser.add_argument("--late-closure-corrections", type=int, default=0)
+    parser.add_argument("--estimated-token-delta", default="unknown")
+    parser.add_argument("--quality-benefit", default="unknown")
+    parser.add_argument(
+        "--recommendation",
+        choices=["auto", "single_agent", "optimized_collaboration", "full_collaboration", "insufficient_data"],
+        default="auto",
+    )
+    parser.add_argument("--analysis-confidence", choices=["low", "medium", "high"], default="low")
 
 
 def main() -> int:

--- a/scripts/test_github_collaboration_helper.py
+++ b/scripts/test_github_collaboration_helper.py
@@ -95,6 +95,7 @@ def main() -> int:
             ),
         )
         bad_config = base / "bad-routing.yaml"
+        legacy_config = base / "legacy-routing.yaml"
         write(
             bad_config,
             "\n".join(
@@ -106,6 +107,26 @@ def main() -> int:
                     "needs_labels: []",
                     "project_v2:",
                     "  mode: required_scheduler",
+                ]
+            ),
+        )
+        write(
+            legacy_config,
+            "\n".join(
+                [
+                    "schema_version: 1",
+                    "roles:",
+                    "  reviewer:",
+                    "    inbox_label: needs:reviewer",
+                    "needs_labels:",
+                    "  - needs:reviewer",
+                    "completion_handoff:",
+                    "  required_fields:",
+                    "    - workflow_telemetry",
+                    "telemetry:",
+                    "  required_for_meaningful_transitions: true",
+                    "project_v2:",
+                    "  mode: optional_visual_mirror",
                 ]
             ),
         )
@@ -153,6 +174,13 @@ def main() -> int:
                 "role-config-fails-closed",
                 run(["role-config-check", "--config", str(bad_config)], base),
                 "status: invalid",
+            )
+        )
+        errors.extend(
+            expect_ok(
+                "role-config-legacy-comparison-optional",
+                run(["role-config-check", "--config", str(legacy_config)], base),
+                "status: ok",
             )
         )
         errors.extend(
@@ -207,6 +235,13 @@ def main() -> int:
         )
         errors.extend(
             expect_ok(
+                "permission-comparison-dry-run",
+                run(["permission-smoke", "comparison-draft"], base),
+                "dry_run_allowed",
+            )
+        )
+        errors.extend(
+            expect_ok(
                 "handoff-draft",
                 run(
                     [
@@ -248,6 +283,96 @@ def main() -> int:
                     base,
                 ),
                 "no labels, comments, Project fields",
+            )
+        )
+        errors.extend(
+            expect_ok(
+                "comparison-draft",
+                run(
+                    [
+                        "comparison-draft",
+                        "--subject",
+                        "AF10 #215 telemetry comparison",
+                        "--unit",
+                        "issue_batch",
+                        "--issue-count",
+                        "4",
+                        "--single-agent-transitions",
+                        "2",
+                        "--unoptimized-transitions",
+                        "8",
+                        "--unoptimized-full-rehydrates",
+                        "6",
+                        "--optimized-transitions",
+                        "4",
+                        "--optimized-compact-rehydrates",
+                        "4",
+                        "--optimized-full-rehydrates",
+                        "0",
+                        "--quality-benefit",
+                        "preserved independent review only where useful",
+                    ],
+                    base,
+                ),
+                "workflow_comparison_telemetry:",
+            )
+        )
+        errors.extend(
+            expect_ok(
+                "comparison-draft-three-modes",
+                run(["comparison-draft", "--subject", "AF10 #215"], base),
+                "unoptimized_collaboration_counterfactual:",
+            )
+        )
+        errors.extend(
+            expect_ok(
+                "comparison-draft-no-write",
+                run(["comparison-draft", "--subject", "AF10 #215"], base),
+                "no comments, labels, Project fields",
+            )
+        )
+        errors.extend(
+            expect_ok(
+                "comparison-negative-quality-insufficient",
+                run(
+                    [
+                        "comparison-draft",
+                        "--subject",
+                        "AF10 #215 quality guardrail",
+                        "--human-holds",
+                        "1",
+                        "--unoptimized-transitions",
+                        "8",
+                        "--optimized-transitions",
+                        "4",
+                    ],
+                    base,
+                ),
+                "recommendation: insufficient_data",
+            )
+        )
+        errors.extend(
+            expect_ok(
+                "comparison-unknown-benefit-prefers-single-agent",
+                run(
+                    [
+                        "comparison-draft",
+                        "--subject",
+                        "AF10 #215 unknown benefit",
+                        "--single-agent-transitions",
+                        "1",
+                        "--unoptimized-transitions",
+                        "8",
+                        "--unoptimized-full-rehydrates",
+                        "6",
+                        "--optimized-transitions",
+                        "4",
+                        "--optimized-full-rehydrates",
+                        "0",
+                    ],
+                    base,
+                ),
+                "recommendation: single_agent",
             )
         )
 

--- a/templates/github-role-routing.template.yaml
+++ b/templates/github-role-routing.template.yaml
@@ -67,6 +67,11 @@ project_v2:
 telemetry:
   required_for_meaningful_transitions: true
   workflow: "workflows/coordinate-agent-work.md"
+  supports_workflow_comparison: true
+  comparison_modes:
+    - single_agent_baseline
+    - unoptimized_collaboration_counterfactual
+    - optimized_collaboration_observed
   ledger_parent_issue: "<parent-issue-number>"
   skip_rule: "only trivial comments may skip telemetry with an explicit reason"
 

--- a/workflows/coordinate-agent-work.md
+++ b/workflows/coordinate-agent-work.md
@@ -9,6 +9,14 @@ This workflow defines the minimum telemetry that Coordinator-led role orchestrat
 
 The goal is not billing-grade token accounting. The goal is to make coordination overhead visible enough to decide when multi-thread role orchestration is worth its cost, when a compact handoff is enough, and when a single-thread or batch checkpoint is safer and cheaper.
 
+AF10-B telemetry should support three-way comparison:
+
+1. Single-agent baseline: what happened, or what is expected to happen, when one session owns the whole task.
+2. Unoptimized collaboration counterfactual: what a full three- or four-agent workflow would likely cost if every role handoff used full rehydration and separate review by default.
+3. Optimized collaboration observed result: what happened after compact packets, batch checkpoints, bundled human gates, and selective role dispatch were applied.
+
+Use this comparison as decision support for workflow routing. It should help answer whether collaboration was worth its coordination cost, whether optimization reduced avoidable overhead, and when a future task should stay single-agent.
+
 ## Non-Scope
 
 - No memory-system implementation.
@@ -282,6 +290,104 @@ workflow_cost_ledger:
   overhead_notes: []
 ```
 
+## Workflow Comparison Telemetry
+
+Use this optional block when AF10 needs to compare a task, issue batch, Epic, milestone, or pilot across the three routing modes. It can be recorded in an issue comment, parent Epic comment, PR summary, or final Coordinator analysis.
+
+```yaml
+workflow_comparison_telemetry:
+  subject: "AF10 follow-up #215"
+  comparison_scope:
+    unit: issue | issue_batch | pr | epic | milestone | pilot | session_goal
+    issue_count: 1
+    pr_count: 0
+    user_visible_scope: false
+    risk_class: low | medium | high | mixed
+    human_gate_count: 0
+  single_agent_baseline:
+    source: observed | estimated | unavailable
+    transitions: 0
+    rehydration:
+      none: 1
+      compact: 0
+      full: 0
+    role_dispatches: 0
+    correction_cycles: 0
+    elapsed_time: unknown
+    ledger_estimated_tokens:
+      input: unknown
+      output: unknown
+      confidence: low | medium | high
+    observed_goal_tokens:
+      value: unknown
+      source: null
+      notes: "Optional observed session or goal counter; not billing-grade."
+  unoptimized_collaboration_counterfactual:
+    source: estimated
+    assumed_agents: 3 | 4
+    assumed_transitions: 0
+    assumed_full_rehydrates: 0
+    assumed_compact_rehydrates: 0
+    assumed_role_dispatches: 0
+    assumed_human_gates: 0
+    duplicated_context: low | medium | high
+    ledger_estimated_tokens:
+      input: unknown
+      output: unknown
+      confidence: low | medium | high
+    assumptions:
+      - "Each role handoff performs full rehydration."
+  optimized_collaboration_observed:
+    source: observed | estimated | mixed
+    transitions: 0
+    rehydration:
+      none: 0
+      compact: 0
+      full: 0
+    role_dispatches: 0
+    batch_checkpoints: 0
+    bundled_human_gates: 0
+    correction_cycles: 0
+    avoided_transitions: 0
+    ledger_estimated_tokens:
+      input: unknown
+      output: unknown
+      confidence: low | medium | high
+    observed_goal_tokens:
+      value: unknown
+      source: null
+      notes: "Keep separate from ledger estimates."
+  quality_guardrails:
+    blocking_findings_missed: 0
+    blocking_findings_caught: 0
+    failed_verification: 0
+    reopened_issues: 0
+    human_holds: 0
+    late_closure_corrections: 0
+  savings_analysis:
+    optimized_vs_unoptimized:
+      transition_delta: unknown
+      full_rehydrate_delta: unknown
+      estimated_token_delta: unknown
+    optimized_vs_single_agent:
+      overhead_delta: unknown
+      quality_or_parallelism_benefit: unknown
+    recommendation: single_agent | optimized_collaboration | full_collaboration | insufficient_data
+    confidence: low | medium | high
+    notes: "Decision-support estimate, not billing-grade accounting."
+```
+
+### Comparison Rules
+
+- Use `single_agent_baseline` for the one-session route. Prefer observed data when a comparable task was actually done by one session; otherwise mark it as `estimated` or `unavailable`.
+- Use `unoptimized_collaboration_counterfactual` for the three- or four-agent route without AF10-B optimization. This is usually estimated, not actually executed. State assumptions explicitly.
+- Use `optimized_collaboration_observed` for the real optimized workflow when compact packets, batch checkpoints, bundled human gates, or selective role dispatch were used.
+- Keep `ledger_estimated_tokens` separate from `observed_goal_tokens` in every mode. Observed counters can calibrate estimate bands only when scope and time window are named.
+- Keep quality guardrails beside savings. Lower token or transition cost is not a win if blocking findings are missed, verification fails, issues reopen, or the human needs corrective holds.
+- Prefer normalized comparisons for similar task classes: risk class, issue count, PR count, user-visible scope, and human-gate count.
+- Mark confidence as `low` until at least three comparable flows exist for the same class.
+- Do not close a telemetry enhancement issue with only one ad hoc report when the intended deliverable is reusable measurement support.
+
 ## Telemetry Layer Rules
 
 Use ledger estimates to compare transition shapes, not to claim exact model or billing usage.
@@ -289,6 +395,8 @@ Use ledger estimates to compare transition shapes, not to claim exact model or b
 Record observed token counters separately when the runtime exposes them. Name the source, scope, and time window, for example `goal tokensUsed` for one Coordinator thread goal. Do not sum observed counters with ledger estimates unless the scopes are proven compatible.
 
 When estimates and observed counters differ, analyze the delta instead of forcing equality. Typical delta sources include repeated durable reads, tool output context, hidden prompt or system overhead, live coordination turns, final closure work, or separate role threads not covered by the observed counter.
+
+Use workflow comparison telemetry when the question is about route selection, not just one transition. The comparison layer may include observed single-agent data, estimated unoptimized collaboration data, and observed optimized collaboration data in the same block, but it must label each source separately.
 
 ## Overhead Classification
 
@@ -313,6 +421,7 @@ Use these routing rules after AF10-B when they do not weaken authority reads, re
 6. Bundle human-gate review points, options, consequences, verification, residual risks, and the authorization phrase or trial response in one live request. This reduces approval correction loops and makes the gate meaningful.
 7. Sample telemetry for meaningful transitions. Skip trivial comments, typo fixes, and no-state-change updates, or record an explicit skip reason instead of adding noisy ledger entries.
 8. Track expected savings qualitatively until enough comparable before/after flows exist. Use transition count, full rehydrate count, duplicated-context level, correction cycles, and observed goal counters as the first quantitative indicators.
+9. When comparing routing options, use the three-way comparison shape: single-agent baseline, unoptimized collaboration counterfactual, and optimized collaboration observed result.
 
 ## Usage Guidance
 
@@ -328,6 +437,7 @@ Prefer telemetry on:
 - Project state repair;
 - AF11 pilot dispatch and callback;
 - final AF10-B analysis.
+- route-choice comparisons between single-agent, unoptimized collaboration, and optimized collaboration.
 
 Prefer compact telemetry for routine handoffs. If filling the telemetry block would cost more than the transition teaches, skip it and state why in the durable comment.
 


### PR DESCRIPTION
## Summary

Implements #215 as reusable workflow comparison telemetry support instead of a one-off measurement report.

- Adds a three-way workflow comparison telemetry shape to workflows/coordinate-agent-work.md: single-agent baseline, unoptimized three/four-agent collaboration counterfactual, and optimized collaboration observed result.
- Extends the GitHub collaboration role-routing template to declare support for comparison telemetry modes.
- Adds a dry-run github_collaboration_helper.py comparison-draft command that emits a no-mutation comparison block with quality guardrails and decision-support savings analysis.
- Adds fixture tests for the new command and template validation.

## User-facing / adopter-facing note

This gives Coordinators a standard way to compare whether a task should be handled by one agent, a full unoptimized multi-agent flow, or the optimized collaboration workflow. The output is decision-support telemetry, not billing-grade accounting. It keeps ledger estimates separate from observed goal token counters and requires quality guardrails to stay beside any claimed savings.

Trial path:

```bash
python3 scripts/github_collaboration_helper.py comparison-draft \
  --subject "AF10 #215 telemetry comparison" \
  --unit issue_batch \
  --issue-count 4 \
  --single-agent-transitions 2 \
  --unoptimized-transitions 8 \
  --unoptimized-full-rehydrates 6 \
  --optimized-transitions 4 \
  --optimized-compact-rehydrates 4 \
  --optimized-full-rehydrates 0 \
  --quality-benefit "preserved review quality while avoiding role churn"
```

Expected result: a `workflow_comparison_telemetry` YAML block with `single_agent_baseline`, `unoptimized_collaboration_counterfactual`, `optimized_collaboration_observed`, `quality_guardrails`, and `savings_analysis`.

## Verification

- `python3 scripts/test_github_collaboration_helper.py`
- `python3 scripts/test_adapter_quality_split.py`
- `python3 scripts/check_consistency.py`
- `git diff --check`

## Exclusions and residual risks

- No GitHub mutation helper is added.
- No Project v2 mutation is added.
- No Vault, runtime, generated adapter, private config, or memory-system mutation is added.
- The first implementation is a dry-run generator plus workflow/template contract. It does not automatically harvest live token counters from every runtime.
- Estimate bands still need calibration from future comparable flows.

## Next gate

Review should check whether the three comparison modes match #215 intent and whether the no-mutation boundary is preserved.

Closes #215
