### PR TITLE
Fix selected adapter root refresh flow

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -78,6 +78,10 @@ Use this on a new machine after cloning or unpacking the Agent Foundry Core chec
    python3 scripts/sync_status.py
    ```
 
+   In split Core/Vault mode, `install_foundry.py` defaults to the selected generated adapter root and refuses Core reference adapters as a runtime source. When in doubt, pass the generated root printed by `publish_adapters.py` explicitly with `--adapter-root`.
+
+   在 Core/Vault split 模式下，`install_foundry.py` 默认使用 selected generated adapter root，并拒绝把 Core reference adapters 当作 runtime 来源。不确定时，显式传入 `publish_adapters.py` 打印的 generated root：`--adapter-root`。
+
 6. Apply only after the dry-run and status report identify the expected Core, selected Vault, generated output, manual targets, receipt state, and runtime-write approval needs.
 
    只有当 dry-run 和 status report 明确 expected Core、selected Vault、generated output、manual targets、receipt state 和 runtime-write approval needs 后，才 apply。
@@ -168,6 +172,10 @@ Restore local state from public Core plus the selected Vault. Do not restore by 
 Use this after practices, assets, generated output, or runtime adapters may have changed.
 
 当 practices、assets、generated output 或 runtime adapters 可能变化后，使用此流程。
+
+Preserve the same selected adapter root across publish, selected-output quality check, install dry-run/apply, and sync status. Do not refresh managed runtimes from Core reference adapters in split mode.
+
+在 publish、selected-output quality check、install dry-run/apply 和 sync status 中保持同一个 selected adapter root。split 模式下不要从 Core reference adapters 刷新 managed runtimes。
 
 ```bash
 python3 scripts/check_consistency.py

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 # Agent Foundry Roadmap
 
 Status: planning document
-Updated: 2026-06-18
+Updated: 2026-06-20
 Scope: Agent Foundry productization, runtime adapter framework, Trae support, capability-system hardening, repository hygiene, role-orchestration optimization, and memory-system readiness.
 
 ## Purpose
@@ -82,7 +82,7 @@ Agent Foundry should use maturity stages for planning and release versions for d
 | AF-10 | Coordinator Workflow Optimization | Multi-thread role orchestration, rehydration, GitHub state synchronization, Human Decision Contracts, and Project/Roadmap coherence are measured and optimized before memory-system planning expands the workflow surface. AF10 is intentionally phased: foundation and telemetry first, an AF11 pilot in the middle, then analysis, policy, and implementation closeout. | Coordinator and role-thread workflows have measurable overhead, compact handoff patterns, durable state ledgers, and clear guidance for when to use multi-thread orchestration versus single-thread serial work. |
 | AF-11 | GitHub Collaboration Helper Migration | Placeholder for migrating the GitHub-based collaboration workflow helper incubated in Tiny IPA into Agent Foundry as an interleaved pilot after AF10 foundation work and before AF10 final optimization closeout. | Migration scope, ownership boundary, reusable asset shape, user-facing workflow, validation path, and telemetry evidence are defined without importing Tiny IPA project-local assumptions. |
 
-Current planning stage: AF-10 preparation.
+Current planning stage: MS-01 readiness design preparation.
 
 AF-0 explains the existing mixed history. AF-1 starts the stricter planning and multi-agent coordination era. AF-2 designs the productization boundary. AF-3 executes the local Core/Vault split. AF-4 proves the split system works for the current real user across existing deployments and establishes the migration discipline needed for later major upgrades. AF-5 makes onboarding humane and reliable for new users. AF-6 closes the current Foundry product lifecycle so install, pack deployment, refresh, status, and rollback are usable beyond a one-off maintainer path. AF-7 upgrades runtime adapters and adds Trae CN support around a verified global Skill path. AF-8 hardens the capability system under realistic multi-user, multi-machine, multi-runtime, long-running-agent, and drift scenarios. AF-9 adds advanced capability-pack discovery, lifecycle, privacy-safe transfer planning, and user-facing Skill workflow packaging. AF-10 optimizes the Coordinator-driven role workflow using AF9 evidence, then pauses for an AF11 pilot migration, then resumes to analyze real telemetry and harden the workflow model. AF-11 is reserved for the Tiny IPA-incubated GitHub collaboration workflow helper migration pilot. Memory-system planning now uses the separate MS milestone axis.
 

--- a/scripts/install_foundry.py
+++ b/scripts/install_foundry.py
@@ -50,6 +50,27 @@ def configured_roots(core_root_arg: str, vault_root_arg: str) -> tuple[Path, Pat
     return Path(core_text).expanduser().resolve(), Path(vault_text).expanduser().resolve()
 
 
+def default_adapter_root(core_root: Path, vault_root: Path) -> Path:
+    if core_root != vault_root:
+        return DEFAULT_GENERATED_ROOT.resolve()
+    return core_root / "adapters"
+
+
+def check_adapter_root_guard(core_root: Path, vault_root: Path, adapter_root: Path) -> int:
+    if core_root == vault_root:
+        return 0
+    core_adapters = (core_root / "adapters").resolve()
+    if adapter_root.resolve() != core_adapters:
+        return 0
+    print("Refusing split-mode install from Core reference adapters.")
+    print(f"core_root: {core_root}")
+    print(f"vault_root: {vault_root}")
+    print(f"adapter_root: {adapter_root}")
+    print("Use the selected generated adapter output instead, for example:")
+    print(f"  python3 scripts/install_foundry.py --adapter-root {DEFAULT_GENERATED_ROOT}")
+    return 1
+
+
 def install(
     *,
     core_root: Path,
@@ -61,6 +82,9 @@ def install(
     write_locator: bool = True,
 ) -> int:
     print_operation_context("install", core_root=core_root, vault_root=vault_root, adapter_root=adapter_root)
+    guard_code = check_adapter_root_guard(core_root, vault_root, adapter_root)
+    if guard_code != 0:
+        return guard_code
 
     if not skip_check:
         code = run(["python3", "scripts/check_consistency.py"], execute=True)
@@ -196,7 +220,11 @@ def main() -> int:
     parser.add_argument("--skip-check", action="store_true", help="Skip consistency check.")
     parser.add_argument("--core-root", default="", help="Core root to validate and record in the local locator.")
     parser.add_argument("--vault-root", default="", help="Vault root to validate and record in the local locator.")
-    parser.add_argument("--adapter-root", default="", help="Adapter output root to install from. Defaults to <core-root>/adapters.")
+    parser.add_argument(
+        "--adapter-root",
+        default="",
+        help="Adapter output root to install from. Defaults to selected generated output in split mode, otherwise <core-root>/adapters.",
+    )
     parser.add_argument("--generated-root", dest="adapter_root", default="", help="Fresh Install generated adapter output root.")
     parser.add_argument("--bootstrap-pack", default=str(DEFAULT_BOOTSTRAP_PACK), help="Mandatory bootstrap capability pack root.")
     parser.add_argument("--force", action="store_true", help="Allow blank Vault initialization over existing marker files.")
@@ -206,7 +234,7 @@ def main() -> int:
         return fresh_install(args)
 
     core_root, vault_root = configured_roots(args.core_root, args.vault_root)
-    adapter_root = Path(args.adapter_root).expanduser().resolve() if args.adapter_root else core_root / "adapters"
+    adapter_root = Path(args.adapter_root).expanduser().resolve() if args.adapter_root else default_adapter_root(core_root, vault_root)
     return install(
         core_root=core_root,
         vault_root=vault_root,

--- a/scripts/operation_context.py
+++ b/scripts/operation_context.py
@@ -231,8 +231,15 @@ def build_context(
         warnings.append("invoked from product project context; writes must go only to the declared Agent Foundry targets")
     if operation == "publish" and adapter_root == (core_root / "adapters").resolve():
         warnings.append("publish output points at Core adapters; apply should refuse Core template overwrite")
+    if operation in {"install", "refresh"} and core_root != vault_root and adapter_root == (core_root / "adapters").resolve():
+        warnings.append(
+            "split-mode install points at Core reference adapters; use the selected generated adapter root from publish output"
+        )
     if operation in {"install", "refresh"} and not (adapter_root / "adapter-publish-manifest.yaml").exists():
-        warnings.append("adapter_root has no adapter-publish-manifest.yaml; selected-output install receipt may be unavailable")
+        warnings.append(
+            "adapter_root has no adapter-publish-manifest.yaml; preserve one selected generated adapter root across "
+            "publish, selected-output quality check, install dry-run/apply, and sync status"
+        )
     return {
         "schema_version": 1,
         "operation": operation,

--- a/scripts/operation_context.py
+++ b/scripts/operation_context.py
@@ -229,7 +229,7 @@ def build_context(
     cwd = (cwd or Path.cwd()).expanduser().resolve()
     core_root = (core_root or ROOT).expanduser().resolve()
     vault_root = (vault_root or core_root).expanduser().resolve()
-    adapter_root = (adapter_root or (core_root / "adapters")).expanduser().resolve()
+    adapter_root = (adapter_root or default_adapter_root(core_root, vault_root)).expanduser().resolve()
     context = classify_context(cwd, core_root, vault_root, adapter_root)
     root_errors = validate(core_root, vault_root)
     routes = operation_routes(operation, context, cwd, core_root, vault_root, adapter_root)

--- a/scripts/operation_context.py
+++ b/scripts/operation_context.py
@@ -13,6 +13,7 @@ from foundry_config import CONFIG_PATH, ROOT, parse_config
 from runtime_manifest import LOCAL_MANIFEST, parse_targets
 
 
+DEFAULT_GENERATED_ROOT = Path.home() / ".agent-foundry" / "generated" / "agent-foundry-adapters"
 CONTEXT_PRODUCT = "product_project_evidence"
 CONTEXT_CORE = "foundry_core_maintenance"
 CONTEXT_VAULT = "foundry_vault_operation"
@@ -36,6 +37,12 @@ def configured_roots(core_root_arg: str = "", vault_root_arg: str = "") -> tuple
     core_root = Path(core_text).expanduser().resolve()
     vault_root = Path(vault_text).expanduser().resolve() if vault_text else core_root
     return core_root, vault_root
+
+
+def default_adapter_root(core_root: Path, vault_root: Path) -> Path:
+    if core_root != vault_root:
+        return DEFAULT_GENERATED_ROOT.resolve()
+    return core_root / "adapters"
 
 
 def runtime_paths() -> list[Path]:
@@ -313,7 +320,7 @@ def main() -> int:
     args = parser.parse_args()
 
     core_root, vault_root = configured_roots(args.core_root, args.vault_root)
-    adapter_root = Path(args.adapter_root).expanduser().resolve() if args.adapter_root else core_root / "adapters"
+    adapter_root = Path(args.adapter_root).expanduser().resolve() if args.adapter_root else default_adapter_root(core_root, vault_root)
     cwd = Path(args.cwd).expanduser().resolve() if args.cwd else Path.cwd()
     report = build_context(args.operation, cwd, core_root, vault_root, adapter_root)
     if args.json:

--- a/scripts/publish_adapters.py
+++ b/scripts/publish_adapters.py
@@ -408,6 +408,18 @@ def write_generated_skill_outputs(
     return written
 
 
+def print_follow_up_commands(core_root: Path, vault_root: Path, output_root: Path) -> None:
+    print("Next commands using the same selected adapter root:")
+    print(
+        "  python3 scripts/check_adapter_quality.py "
+        f"--core-root {core_root} --vault-root {vault_root} "
+        f"--surface selected-output --generated-root {output_root}"
+    )
+    print(f"  python3 scripts/install_foundry.py --core-root {core_root} --vault-root {vault_root} --adapter-root {output_root}")
+    print(f"  python3 scripts/sync_status.py --core-root {core_root} --vault-root {vault_root} --adapter-root {output_root}")
+    print("Runtime apply remains a separate reviewed action: re-run install_foundry.py with --apply only when runtime writes are authorized.")
+
+
 def publish(core_root: Path, vault_root: Path, output_root: Path, apply: bool) -> int:
     print_operation_context("publish", core_root=core_root, vault_root=vault_root, adapter_root=output_root)
     errors = validate(core_root, vault_root)
@@ -422,6 +434,7 @@ def publish(core_root: Path, vault_root: Path, output_root: Path, apply: bool) -
     if not active_practices and not active_assets:
         print("Selected Vault has no active or revised practices/assets. Nothing to publish.")
         write_manifest(output_root, manifest_text(active_practices, active_assets, []), apply)
+        print_follow_up_commands(core_root, vault_root, output_root)
         return 0
 
     if not (core_root / "adapters" / "adapter_profiles.yaml").exists():
@@ -440,6 +453,7 @@ def publish(core_root: Path, vault_root: Path, output_root: Path, apply: bool) -
     print(f"Adapter publish {'wrote' if apply else 'planned'} {len(written)} files.")
     print(f"Active practices selected: {len(active_practices)}")
     print(f"Active assets selected: {len(active_assets)}")
+    print_follow_up_commands(core_root, vault_root, output_root)
     return 0
 
 

--- a/scripts/sync_status.py
+++ b/scripts/sync_status.py
@@ -449,6 +449,7 @@ def setup_report(core_root: Path, vault_root: Path, adapter_root: Path, receipt_
         "deployed_packs:",
         *(f"- {pack}" for pack in packs),
         *(["- none detected"] if not packs else []),
+        "adapter_root_rule: preserve this selected adapter root across publish, selected-output quality, install, and status",
         f"generated_output: {output_state} path={adapter_root} files={output_count}",
         *activation_freshness_lines(vault_root, adapter_root),
         "runtime targets:",
@@ -542,7 +543,11 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Print local Agent Foundry sync status for offline and remote workflows.")
     parser.add_argument("--core-root", default="", help="Agent Foundry Core root. Defaults to configured core_root.")
     parser.add_argument("--vault-root", default="", help="Selected Agent Foundry Vault root. Defaults to configured vault_root.")
-    parser.add_argument("--adapter-root", default="", help="Generated adapter output root. Defaults to <core-root>/adapters.")
+    parser.add_argument(
+        "--adapter-root",
+        default="",
+        help="Generated adapter output root. Defaults to receipt/default generated root in split mode, otherwise <core-root>/adapters.",
+    )
     parser.add_argument("--receipt-path", default="", help="Adapter install receipt path. Defaults to runtime/local receipt.")
     args = parser.parse_args()
 

--- a/scripts/test_operation_context.py
+++ b/scripts/test_operation_context.py
@@ -186,6 +186,19 @@ def main() -> int:
         default_install_root = fake_home / ".agent-foundry" / "generated" / "agent-foundry-adapters"
         (default_install_root / "adapter-publish-manifest.yaml").parent.mkdir(parents=True, exist_ok=True)
         (default_install_root / "adapter-publish-manifest.yaml").write_text("schema_version: 1\n", encoding="utf-8")
+        default_context = run(
+            [
+                str(CONTEXT),
+                "install",
+                "--cwd",
+                str(product),
+                "--json",
+            ],
+            product,
+            env=default_env,
+        )
+        errors.extend(expect_text("context-default-generated-root", default_context, f'"adapter_root": "{default_install_root.resolve()}"'))
+
         default_install = run(
             [
                 str(INSTALL),

--- a/scripts/test_operation_context.py
+++ b/scripts/test_operation_context.py
@@ -142,6 +142,14 @@ def main() -> int:
         finally:
             operation_context.LOCAL_MANIFEST = original_manifest
 
+        direct_default = operation_context.build_context("install", product, ROOT.resolve(), vault.resolve())
+        expected_default_root = operation_context.DEFAULT_GENERATED_ROOT.resolve()
+        if direct_default.get("adapter_root") != str(expected_default_root):
+            errors.append(
+                "build-context-default-generated-root: expected split-mode generated root, got "
+                f"{direct_default.get('adapter_root')}"
+            )
+
         for name, operation, cwd, expected in [
             ("product-harvest", "harvest", product, "product_project_evidence"),
             ("runtime-import", "import", runtime, "runtime_install_state"),

--- a/scripts/test_operation_context.py
+++ b/scripts/test_operation_context.py
@@ -167,6 +167,7 @@ def main() -> int:
         )
         errors.extend(expect_text("publish-context-banner", publish, "work_context: product_project_evidence"))
         errors.extend(expect_text("publish-context-route", publish, f"allowed_writes:\n  - {generated.resolve()}"))
+        errors.extend(expect_text("publish-followup-root", publish, f"--adapter-root {generated.resolve()}"))
 
         default_generated = base / "default-locator-generated"
         default_env = write_locator(fake_home, ROOT.resolve(), vault.resolve())
@@ -181,6 +182,43 @@ def main() -> int:
         )
         errors.extend(expect_text("publish-default-locator-context", default_publish, "work_context: product_project_evidence"))
         errors.extend(expect_text("publish-default-locator-vault", default_publish, f"vault_root: {vault.resolve()}"))
+
+        default_install_root = fake_home / ".agent-foundry" / "generated" / "agent-foundry-adapters"
+        (default_install_root / "adapter-publish-manifest.yaml").parent.mkdir(parents=True, exist_ok=True)
+        (default_install_root / "adapter-publish-manifest.yaml").write_text("schema_version: 1\n", encoding="utf-8")
+        default_install = run(
+            [
+                str(INSTALL),
+                "--skip-check",
+                "--target",
+                "chatgpt",
+            ],
+            product,
+            env=default_env,
+        )
+        errors.extend(expect_text("install-default-generated-root", default_install, f"adapter_root: {default_install_root.resolve()}"))
+
+        core_adapter_install = run(
+            [
+                str(INSTALL),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(vault),
+                "--adapter-root",
+                str(ROOT / "adapters"),
+                "--skip-check",
+                "--target",
+                "chatgpt",
+            ],
+            product,
+        )
+        output = core_adapter_install.stdout + core_adapter_install.stderr
+        if core_adapter_install.returncode == 0 or "Refusing split-mode install from Core reference adapters." not in output:
+            errors.append(
+                "install-refuses-core-adapters: expected split-mode refusal for Core adapters\n"
+                f"{core_adapter_install.returncode}\n{output}"
+            )
 
         install = run(
             [

--- a/scripts/test_sync_status_report.py
+++ b/scripts/test_sync_status_report.py
@@ -157,6 +157,7 @@ def main() -> int:
             "deployed_pack: pack.bootstrap.minimal",
             "deployed_packs:",
             "- pack.bootstrap.minimal (version=0.1.0, status=deployed, type=mandatory_bootstrap, source=local_path)",
+            "adapter_root_rule: preserve this selected adapter root across publish, selected-output quality, install, and status",
             f"generated_output: ready path={generated} files=1",
             "activation: stale-generated-output missing_active_practices=1 missing_active_assets=1",
             "activation missing practice: PRACTICE-ACTIVE-001",

--- a/workflows/publish-adapters.md
+++ b/workflows/publish-adapters.md
@@ -12,6 +12,7 @@ Current AF-3 capability:
 
 - use `scripts/publish_adapters.py` for selected Core/Vault root validation and deterministic publishing;
 - pass `--core-root` and `--vault-root` when Core and Vault are split;
+- preserve the same selected adapter root across publish, selected-output quality check, install dry-run/apply, and sync status;
 - blank Vault publishing is valid and reports `nothing to publish`;
 - nonblank Vault publishing currently generates minimal transitional adapter files from Core adapter profiles plus selected active/revised Vault records;
 - full semantic regeneration of every adapter file from canonical sections remains future generator work.
@@ -29,6 +30,8 @@ The publish script prints an operation-context preflight before writing. If runn
 - Vault is the selected canonical record source;
 - allowed writes are limited to the generated adapter output root;
 - runtime install paths are forbidden until the install workflow runs.
+
+After publish, copy the printed follow-up commands rather than retyping defaults. The follow-up commands intentionally pass the same `--output-root` as `--generated-root` or `--adapter-root` so install and status do not inspect stale Core reference adapters.
 
 ## 1. Select Practices
 
@@ -94,6 +97,7 @@ Then run:
 ```bash
 python3 scripts/check_consistency.py
 python3 scripts/test_foundry_roots.py
+python3 scripts/check_adapter_quality.py --surface selected-output --generated-root <same-output-root>
 ```
 
 If unavailable, follow `workflows/check-consistency.md` manually.


### PR DESCRIPTION
## Summary
- make split Core/Vault installs default to the selected generated adapter root instead of Core reference adapters
- fail closed when split-mode install explicitly points at Core `adapters/`
- print publish follow-up commands that preserve one selected adapter root through quality, install, and status
- clarify status/docs/roadmap so current planning moves to MS-01 readiness preparation

## Final adopter-facing note
Capability: harvest/publish/refresh now has a clearer selected adapter root path. After publishing generated adapters, users get exact follow-up commands for selected-output quality, install dry-run, and status using the same root. In split Core/Vault mode, runtime install defaults to selected generated output and refuses Core reference adapters as a runtime source.

Changed behavior: `install_foundry.py` no longer silently defaults to `<core-root>/adapters` when Core and Vault are split. `sync_status.py` now names the adapter-root preservation rule. Publish and deployment docs tell users to keep one selected adapter root across publish, quality, install, and status. Roadmap status no longer says AF-10 preparation.

Use/trial path: run `python3 scripts/publish_adapters.py --output-root <generated-root> --apply`, then use the printed `check_adapter_quality.py`, `install_foundry.py`, and `sync_status.py` commands. In split mode, try `python3 scripts/install_foundry.py --adapter-root <core-root>/adapters --skip-check --target chatgpt` and confirm it refuses.

Verification: `python3 scripts/test_operation_context.py`; `python3 scripts/test_sync_status_report.py`; `python3 scripts/test_adapter_quality_split.py`; `python3 scripts/check_consistency.py`.

Exclusions: no Vault records, generated adapter output, runtime files, local config, GitHub labels, or Project fields changed. Runtime apply remains a separate reviewed action.

Residual risks: this does not add an index auto-fix helper, and adapter quality phrase contracts remain enforced by existing checks rather than a new schema.

Human trial required: no. The behavior is objectively covered by fixture tests and docs.

Next gate: reviewer check for the medium-risk install default change, then auto-merge if no issues remain.

Closes #187