### PR TITLE
Activate GitHub collaboration helper launcher path

### DIFF
--- a/scripts/github_collaboration_helper.py
+++ b/scripts/github_collaboration_helper.py
@@ -32,7 +32,15 @@ FORBIDDEN_ACTIONS = {
     "vault-write",
     "memory-write",
 }
-READ_ONLY_ACTIONS = {"repo-resolve", "auth-smoke", "role-config-check", "inbox", "issue-context", "scheduler-audit"}
+READ_ONLY_ACTIONS = {
+    "repo-resolve",
+    "auth-smoke",
+    "role-config-check",
+    "inbox",
+    "issue-context",
+    "scheduler-audit",
+    "activation-report",
+}
 DRY_RUN_ACTIONS = {
     "handoff-draft",
     "dispatch-evidence-draft",
@@ -73,6 +81,21 @@ def run_gh(args: list[str]) -> Any:
         return json.loads(result.stdout)
     except json.JSONDecodeError:
         return result.stdout
+
+
+def default_core_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def path_status(path: Path, required_text: list[str] | None = None) -> dict[str, Any]:
+    exists = path.exists()
+    payload: dict[str, Any] = {"path": str(path), "exists": exists}
+    if not exists or required_text is None:
+        return payload
+    text = path.read_text(encoding="utf-8")
+    payload["required_text_present"] = {item: item in text for item in required_text}
+    payload["ok"] = all(payload["required_text_present"].values())
+    return payload
 
 
 def repo_from_remote(cwd: Path) -> str | None:
@@ -382,6 +405,71 @@ def cmd_permission_smoke(args: argparse.Namespace) -> None:
         raise SystemExit(7)
 
 
+def cmd_activation_report(args: argparse.Namespace) -> None:
+    core_root = Path(args.core_root).expanduser().resolve() if args.core_root else default_core_root()
+    workflow = core_root / "workflows" / "github-collaboration-helper.md"
+    helper = core_root / "scripts" / "github_collaboration_helper.py"
+    routing = core_root / "templates" / "github-role-routing.template.yaml"
+    launcher = (
+        Path(args.launcher).expanduser()
+        if args.launcher
+        else Path.home() / ".agent-foundry" / "bin" / "agent-foundry-github-collab"
+    )
+    runtime_skill = Path(args.runtime_skill).expanduser() if args.runtime_skill else Path.home() / ".codex" / "skills" / "agent-collaboration" / "SKILL.md"
+    generated_skill = (
+        Path(args.generated_skill).expanduser()
+        if args.generated_skill
+        else Path.home()
+        / ".agent-foundry"
+        / "generated"
+        / "agent-foundry-adapters"
+        / "codex"
+        / "skills"
+        / "agent-collaboration"
+        / "SKILL.md"
+    )
+    activation_terms = [
+        "activation evidence",
+        "target runtime",
+        "user-facing activation instructions",
+    ]
+    helper_terms = [
+        "activation-report",
+        "GitHub collaboration helper",
+    ]
+    payload = {
+        "core_root": str(core_root),
+        "target_runtime": args.target_runtime,
+        "launcher": path_status(launcher),
+        "user_entrypoint": str(launcher),
+        "helper": path_status(helper, ["Read-only and dry-run GitHub collaboration helper pilot"]),
+        "workflow_contract": path_status(workflow, helper_terms),
+        "routing_template": path_status(routing, ["needs_labels", "optional_visual_mirror"]),
+        "installed_runtime_skill": path_status(runtime_skill, activation_terms),
+        "generated_skill": path_status(generated_skill, activation_terms),
+        "safe_trial_commands": [
+            f"{launcher} --repo <owner>/<repo> auth-smoke",
+            f"{launcher} role-config-check --config {routing}",
+            f"{launcher} --repo <owner>/<repo> issue-context <issue> --comment-limit 3",
+            f"{launcher} --json activation-report",
+        ],
+        "mutation_performed": False,
+    }
+    payload["status"] = "ok" if all(
+        [
+            payload["helper"].get("ok", payload["helper"]["exists"]),
+            payload["launcher"]["exists"],
+            payload["workflow_contract"].get("ok", payload["workflow_contract"]["exists"]),
+            payload["routing_template"].get("ok", payload["routing_template"]["exists"]),
+            payload["generated_skill"].get("ok", payload["generated_skill"]["exists"]),
+            payload["installed_runtime_skill"].get("ok", payload["installed_runtime_skill"]["exists"]),
+        ]
+    ) else "incomplete"
+    print_json_or_text(payload, args.json)
+    if payload["status"] != "ok":
+        raise SystemExit(8)
+
+
 def telemetry_block(transition_type: str, role_from: str, role_to: str, note: str) -> str:
     return f"""workflow_telemetry:
   transition_type: {transition_type}
@@ -616,6 +704,14 @@ def build_parser() -> argparse.ArgumentParser:
     audit.add_argument("--config")
     audit.add_argument("--fixture-json", required=True)
     audit.set_defaults(func=cmd_scheduler_audit)
+
+    activation = sub.add_parser("activation-report")
+    activation.add_argument("--core-root", help="Agent Foundry Core root. Defaults to this helper's checkout.")
+    activation.add_argument("--launcher", help="Runtime launcher path to inspect.")
+    activation.add_argument("--runtime-skill", help="Installed Codex agent-collaboration SKILL.md to inspect.")
+    activation.add_argument("--generated-skill", help="Generated selected-output Codex agent-collaboration SKILL.md to inspect.")
+    activation.add_argument("--target-runtime", default="codex", help="Runtime being checked; informational.")
+    activation.set_defaults(func=cmd_activation_report)
 
     perm = sub.add_parser("permission-smoke")
     perm.add_argument("action")

--- a/scripts/install_foundry.py
+++ b/scripts/install_foundry.py
@@ -11,6 +11,7 @@ from adapter_install_receipt import write_receipt
 from deploy_capability_pack import deploy as deploy_capability_pack, top_level_scalars
 from foundry_config import CONFIG_PATH, parse_config, write_config
 from init_vault import initialize
+from install_helper_launchers import install_launchers
 from operation_context import print_operation_context
 from publish_adapters import publish as publish_adapters
 from runtime_manifest import parse_targets, read_manifest
@@ -106,6 +107,9 @@ def install(
 
     if apply and write_locator:
         write_config(CONFIG_PATH, core_root, core_root, vault_root)
+
+    print(f"\n## helper launchers: {'apply' if apply else 'dry-run'}", flush=True)
+    install_launchers(apply=apply)
 
     targets = parse_targets(read_manifest())
     selected = [target] if target else list(targets)

--- a/scripts/install_helper_launchers.py
+++ b/scripts/install_helper_launchers.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Install stable Agent Foundry helper launchers.
+
+Launchers are intentionally tiny runtime entry points. They locate the selected
+Core through the machine-local Agent Foundry locator, then execute the canonical
+helper script from that Core checkout. They do not copy helper implementations
+into runtime state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import stat
+from pathlib import Path
+
+
+DEFAULT_BIN_DIR = Path.home() / ".agent-foundry" / "bin"
+GITHUB_COLLAB_LAUNCHER = "agent-foundry-github-collab"
+
+
+def launcher_text() -> str:
+    return '''#!/usr/bin/env python3
+"""Runtime launcher for the Agent Foundry GitHub collaboration helper."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def parse_config(path: Path) -> dict[str, str]:
+    data: dict[str, str] = {}
+    if not path.exists():
+        raise SystemExit(f"foundry_config_missing: {path}")
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or ":" not in stripped:
+            continue
+        key, value = stripped.split(":", 1)
+        if key.strip() in {"core_root", "repo_root", "vault_root"}:
+            data[key.strip()] = value.strip().strip('"')
+    return data
+
+
+def main() -> int:
+    config_path = Path(os.environ.get("AGENT_FOUNDRY_CONFIG", Path.home() / ".agent-foundry" / "config.yaml"))
+    config = parse_config(config_path.expanduser())
+    core_root_text = config.get("core_root") or config.get("repo_root")
+    if not core_root_text:
+        raise SystemExit(f"foundry_core_root_missing: {config_path}")
+    core_root = Path(core_root_text).expanduser()
+    helper = core_root / "scripts" / "github_collaboration_helper.py"
+    if not helper.exists():
+        raise SystemExit(f"foundry_helper_missing: {helper}")
+    return subprocess.run([sys.executable, str(helper), *sys.argv[1:]], check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+'''
+
+
+def install_launchers(*, bin_dir: Path = DEFAULT_BIN_DIR, apply: bool = False) -> list[Path]:
+    launcher = bin_dir.expanduser() / GITHUB_COLLAB_LAUNCHER
+    if not apply:
+        print(f"would write launcher: {launcher}")
+        return [launcher]
+    launcher.parent.mkdir(parents=True, exist_ok=True)
+    launcher.write_text(launcher_text(), encoding="utf-8")
+    mode = launcher.stat().st_mode
+    launcher.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    print(f"wrote launcher: {launcher}")
+    return [launcher]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Install Agent Foundry helper launchers.")
+    parser.add_argument("--apply", action="store_true", help="Write launchers. Default is dry-run.")
+    parser.add_argument("--bin-dir", default=str(DEFAULT_BIN_DIR), help="Launcher directory.")
+    args = parser.parse_args()
+    install_launchers(bin_dir=Path(args.bin_dir), apply=args.apply)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_github_collaboration_helper.py
+++ b/scripts/test_github_collaboration_helper.py
@@ -59,7 +59,19 @@ def main() -> int:
         fixture = base / "issue.json"
         inbox = base / "inbox.json"
         auth = base / "auth.json"
+        runtime_skill = base / "runtime-skill.md"
+        generated_skill = base / "generated-skill.md"
+        launcher = base / "bin" / "agent-foundry-github-collab"
         write(auth, json.dumps({"status": "ok", "nameWithOwner": "farmerhunter/agent-foundry"}))
+        write(
+            runtime_skill,
+            "activation evidence\n target runtime\n user-facing activation instructions\n",
+        )
+        write(
+            generated_skill,
+            "activation evidence\n target runtime\n user-facing activation instructions\n",
+        )
+        write(launcher, "#!/bin/sh\nexit 0\n")
         write(
             fixture,
             json.dumps(
@@ -224,6 +236,24 @@ def main() -> int:
                     base,
                 ),
                 "mutation_performed: False",
+            )
+        )
+        errors.extend(
+            expect_ok(
+                "activation-report-fixture",
+                run(
+                    [
+                        "activation-report",
+                        "--launcher",
+                        str(launcher),
+                        "--runtime-skill",
+                        str(runtime_skill),
+                        "--generated-skill",
+                        str(generated_skill),
+                    ],
+                    base,
+                ),
+                "user_entrypoint:",
             )
         )
         errors.extend(

--- a/scripts/test_helper_launchers.py
+++ b/scripts/test_helper_launchers.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Regression tests for Agent Foundry runtime helper launchers."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from install_helper_launchers import install_launchers
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def run(command: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def expect(name: str, condition: bool, detail: str) -> list[str]:
+    if condition:
+        print(f"{name}: ok")
+        return []
+    return [f"{name}: {detail}"]
+
+
+def main() -> int:
+    errors: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="agent-foundry-helper-launcher-") as raw:
+        base = Path(raw)
+        home = base / "home"
+        core = base / "core"
+        non_core = base / "product"
+        helper = core / "scripts" / "github_collaboration_helper.py"
+        launcher_dir = home / ".agent-foundry" / "bin"
+        config = home / ".agent-foundry" / "config.yaml"
+        write(
+            helper,
+            "\n".join(
+                [
+                    "#!/usr/bin/env python3",
+                    "import sys",
+                    "print('helper-cwd=' + __import__('os').getcwd())",
+                    "print('helper-args=' + ' '.join(sys.argv[1:]))",
+                ]
+            )
+            + "\n",
+        )
+        write(
+            config,
+            "\n".join(
+                [
+                    "schema_version: 1",
+                    f"repo_root: \"{core}\"",
+                    f"core_root: \"{core}\"",
+                    f"vault_root: \"{base / 'vault'}\"",
+                ]
+            )
+            + "\n",
+        )
+        non_core.mkdir()
+
+        install_launchers(bin_dir=launcher_dir, apply=True)
+        launcher = launcher_dir / "agent-foundry-github-collab"
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        result = run([str(launcher), "--json", "activation-report"], cwd=non_core, env=env)
+        output = result.stdout + result.stderr
+        errors.extend(expect("launcher-executable", os.access(launcher, os.X_OK), str(launcher)))
+        errors.extend(expect("launcher-non-core-cwd", result.returncode == 0, output))
+        errors.extend(expect("launcher-forwards-args", "helper-args=--json activation-report" in output, output))
+        expected_cwd = str(non_core.resolve())
+        errors.extend(expect("launcher-preserves-cwd", f"helper-cwd={expected_cwd}" in output, output))
+
+        missing_env = env.copy()
+        missing_env["AGENT_FOUNDRY_CONFIG"] = str(base / "missing.yaml")
+        missing = run([str(launcher), "repo-resolve"], cwd=non_core, env=missing_env)
+        missing_output = missing.stdout + missing.stderr
+        errors.extend(expect("launcher-missing-config-fails", missing.returncode != 0, missing_output))
+        errors.extend(expect("launcher-missing-config-message", "foundry_config_missing" in missing_output, missing_output))
+
+    if errors:
+        print("Helper launcher tests failed:")
+        for error in errors:
+            print(error)
+        return 1
+    print("Helper launcher tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflows/github-collaboration-helper.md
+++ b/workflows/github-collaboration-helper.md
@@ -8,6 +8,50 @@ configuration shape, evidence requirements, and safety boundaries before helper
 scripts exist. It does not publish generated Skills, install runtime adapters,
 mutate GitHub state, or write Vault/private state.
 
+## Codex Target Activation
+
+Codex users should have one stable helper entry point across projects and
+threads:
+
+```text
+~/.agent-foundry/bin/agent-foundry-github-collab
+```
+
+That file is a launcher, not a deployed copy of the helper implementation. It
+reads the machine-local locator at `~/.agent-foundry/config.yaml`, resolves the
+selected Agent Foundry Core checkout, and then executes:
+
+```text
+<core_root>/scripts/github_collaboration_helper.py
+```
+
+This keeps the Core helper source canonical while avoiding project-specific
+paths in user-facing instructions. A user working in another repository or a
+new Codex thread should not need to know where the Core checkout lives.
+
+Activation evidence for this helper must include:
+
+- the launcher exists at `~/.agent-foundry/bin/agent-foundry-github-collab`;
+- the launcher resolves `core_root` through `~/.agent-foundry/config.yaml`;
+- read-only or dry-run commands work from a non-Core working directory;
+- installed generated runtime guidance, such as the Codex
+  `agent-collaboration` Skill, describes the activation gate or points to this
+  workflow clearly enough that a new thread can discover the safe path;
+- any missing new-thread or manual trial evidence is recorded as an explicit
+  blocker or follow-up, not silently treated as complete.
+
+Useful smoke commands:
+
+```text
+~/.agent-foundry/bin/agent-foundry-github-collab activation-report
+~/.agent-foundry/bin/agent-foundry-github-collab role-config-check --config <core_root>/templates/github-role-routing.template.yaml
+~/.agent-foundry/bin/agent-foundry-github-collab --repo farmerhunter/agent-foundry issue-context 222 --comment-limit 3
+~/.agent-foundry/bin/agent-foundry-github-collab permission-smoke agent-label
+```
+
+The last command must fail closed because `agent-label` mutates scheduler
+ownership and is outside AF11 activation scope.
+
 ## User-Facing Entry Points
 
 Agents should expose these as natural-language workflows rather than requiring


### PR DESCRIPTION
## Summary

Implements the #222 Codex target activation correction for the GitHub collaboration helper without copying the helper implementation into runtime state.

- Adds a stable launcher installer for `agent-foundry-github-collab`; the launcher resolves `~/.agent-foundry/config.yaml` and executes the canonical selected Core helper.
- Adds `activation-report` to the helper to inspect launcher, Core helper, workflow contract, routing template, generated Codex skill, and installed Codex skill activation guidance.
- Wires launcher installation into `install_foundry.py` dry-run/apply flow.
- Documents the Codex target activation path and smoke commands.
- Adds launcher and activation-report regression tests.

## Verification

- `python3 scripts/test_helper_launchers.py`
- `python3 scripts/test_github_collaboration_helper.py`
- `python3 scripts/check_consistency.py`
- `python3 scripts/check_adapter_quality.py --surface selected-output --generated-root /Users/jinghuliu/.agent-foundry/generated/agent-foundry-adapters`
- `git diff --check`
- `python3 scripts/sync_status.py`
- `python3 scripts/install_foundry.py --skip-check --target codex`

## Target-Environment Smoke

- Temporary launcher installed under `/tmp/agent-foundry-af222-bin`.
- From non-Core cwd `/tmp`, verified:
  - `agent-foundry-github-collab --repo farmerhunter/agent-foundry role-config-check --config /Users/jinghuliu/Coding/agent-foundry/templates/github-role-routing.template.yaml`
  - `agent-foundry-github-collab --repo farmerhunter/agent-foundry issue-context 222 --comment-limit 1`
  - `agent-foundry-github-collab permission-smoke agent-label` fails closed with `unit_b_forbidden_mutation`.
- `activation-report --launcher /tmp/agent-foundry-af222-bin/agent-foundry-github-collab` returned `status: ok` and verified installed/generated Codex skill guidance.

## Boundaries

- No `agent-label`, mutation helper, Project v2 adapter, live dispatch automation, issue/Epic closure automation, or memory-system work.
- No Vault canonical practice/asset mutation.
- No generated adapter publish.
- No real runtime apply was performed; the real managed launcher path `~/.agent-foundry/bin/agent-foundry-github-collab` remains pending explicit runtime apply authorization.

## Residual Risks

- New-thread discovery was not live-tested from a fresh Codex thread in this implementation session. The installed and generated Codex skill files were inspected by `activation-report`, and the final handoff should include an explicit user trial path or follow-up gate before #222 closure.

Closes #222 after reviewer acceptance and required adopter-facing closure note.
