### PR TITLE
AF12 #228 Normalize capability pack state taxonomy

### DIFF
--- a/schemas/capability-pack-candidate.schema.yaml
+++ b/schemas/capability-pack-candidate.schema.yaml
@@ -6,7 +6,7 @@ required_fields:
   candidate_id: "Stable candidate id for review, such as candidate.pack.multi-agent.github-collaboration."
   proposed_pack_id: "Proposed pack id if the candidate later becomes a pack, such as pack.multi-agent.github-collaboration."
   title: "Short human-readable candidate title."
-  outcome: "candidate | baseline_control | extend_existing | deferred_overlap | deferred_insufficient_evidence | deferred_privacy_review | rejected_false_positive | rejected_too_broad | rejected_too_narrow | blocked_policy"
+  outcome: "Candidate discovery outcome namespace only: candidate | baseline_control | extend_existing | deferred_overlap | deferred_insufficient_evidence | deferred_privacy_review | rejected_false_positive | rejected_too_broad | rejected_too_narrow | blocked_policy"
   confidence: "high | medium | low"
   summary: "One-paragraph explanation of the candidate and why this outcome was chosen."
   authority_layers: "Evidence references grouped by Core, selected_vault, generated, runtime, and local_private treatment."
@@ -58,6 +58,7 @@ false_positive_control_fields:
 
 rules:
   - "Candidate records are review artifacts, not active pack manifests."
+  - "Candidate discovery outcome values are not pack lifecycle_status values unless a later reviewed pack manifest explicitly uses the pack canonical lifecycle namespace."
   - "A candidate may propose outcome candidate, but only human-reviewed follow-up work may activate or export a pack."
   - "Observed facts must cite evidence references; inference must be labeled separately."
   - "Selected Vault evidence must use record IDs, metadata, or sanitized summaries, not raw private evidence."

--- a/schemas/capability-pack-manifest.schema.yaml
+++ b/schemas/capability-pack-manifest.schema.yaml
@@ -6,7 +6,7 @@ required_fields:
   pack_id: "Stable pack id such as pack.bootstrap.minimal or pack.multi-agent.optional."
   title: "Short human-readable pack title."
   description: "One sentence describing the pack's reusable capability."
-  lifecycle_status: "candidate | reviewed | active | deprecated | retired | archived"
+  lifecycle_status: "candidate | reviewed | proposed | active | exportable | deprecated | retired | archived | blocked"
   version: "Snapshot version string. Use semantic versioning when practical."
   exported_at: "UTC timestamp or YYYY-MM-DD for the exported snapshot."
   distribution_type: "mandatory_bootstrap | optional_capability | product_project_candidate"
@@ -30,7 +30,7 @@ compatibility_fields:
 included_record_fields:
   id: "Stable record id."
   kind: "practice | asset | doc | template | example | config_default"
-  lifecycle_status: "Record lifecycle state intended after reviewed deployment."
+  lifecycle_status: "Record lifecycle state intended after reviewed deployment. This is a member-record state, not a pack report/display/import/runtime status."
   path: "Path inside the pack snapshot, relative to the manifest directory."
   source_version: "Version of this item within the pack."
   content_sha256: "SHA-256 digest of the referenced snapshot file."
@@ -42,7 +42,7 @@ included_record_fields:
 executable_payload_fields:
   id: "Stable payload id."
   title: "Short helper title."
-  lifecycle_status: "candidate | reviewed | active | deprecated | retired | archived"
+  lifecycle_status: "candidate | reviewed | proposed | active | exportable | deprecated | retired | archived | blocked"
   path: "Path inside the pack snapshot, relative to the manifest directory."
   source_sha256: "SHA-256 digest of the referenced helper source."
   interpreter: "Runtime or interpreter such as python3, node, bash, or none."
@@ -84,6 +84,32 @@ advanced_metadata_sections:
     activation_input: "Must not be true."
     export_input: "Must not be true."
 
+state_namespaces:
+  pack_canonical_lifecycle:
+    owns: "Persisted pack manifest and deployed-pack metadata lifecycle_status values."
+    allowed_values: "candidate | reviewed | proposed | active | exportable | deprecated | retired | archived | blocked"
+    not_allowed_here: "Adopter display status, candidate discovery outcome, transfer/import state, comparison/report classification, generated output status, runtime status, or split/merge report outcome."
+  adopter_discovery_display_status:
+    owns: "Normal-user list/recommend/status copy and Skill display."
+    examples: "available | recommended | compatible | incompatible | installed | deployed | update_available | not_installed"
+    persistence_rule: "Do not persist these as lifecycle_status."
+  candidate_discovery_outcome:
+    owns: "Power-user candidate discovery review-list output."
+    examples: "candidate | baseline_control | extend_existing | deferred_overlap | deferred_insufficient_evidence | deferred_privacy_review | rejected_false_positive | rejected_too_broad | rejected_too_narrow | blocked_policy"
+    persistence_rule: "Candidate outcomes stay in candidate records and must not become active pack lifecycle_status values."
+  transfer_import_state:
+    owns: "Export/import preview and transfer review state."
+    examples: "preview | dry-run | proposed | accepted | rejected | blocked"
+    persistence_rule: "Transfer/import states do not activate, deprecate, retire, or otherwise change pack lifecycle_status."
+  comparison_report_classification:
+    owns: "Update, audit, diff, and lifecycle report classifications."
+    examples: "clean_update_available | merge_required | same_version_hash_mismatch | unsupported | stale | drifted | manual_target_pending"
+    persistence_rule: "Report classifications must be labeled as report output, not lifecycle_status."
+  runtime_generated_status:
+    owns: "Downstream generated output and runtime freshness/receipt status."
+    examples: "generated_current | generated_stale | generated_missing | runtime_current | runtime_drifted | runtime_missing | manual_import_required"
+    persistence_rule: "Generated/runtime status is downstream evidence only and never pack authority."
+
 rules:
   - "A pack snapshot is a transfer and review artifact, not a live source of truth after deployment."
   - "After deployment, selected User Vault records own canonical practice, asset, membership, and provenance state."
@@ -97,3 +123,6 @@ rules:
   - "Same id from unrelated provenance or incompatible kind must fail closed."
   - "Local Vault edits must be treated as canonical user state and handled through a reviewed merge proposal."
   - "Runtime installation is out of scope for the manifest fixture; generated or managed runtime outputs come later."
+  - "Persisted lifecycle_status fields must use the pack_canonical_lifecycle namespace only."
+  - "Do not persist previewed, recommended, compatible, merge_required, drifted, generated_missing, runtime_current, detected, split, or merged as pack lifecycle_status."
+  - "Split and merge are review-only transition actions or report outcomes unless a later reviewed schema explicitly promotes a replacement lifecycle value."

--- a/scripts/manage_capability_pack_lifecycle.py
+++ b/scripts/manage_capability_pack_lifecycle.py
@@ -18,20 +18,28 @@ from plan_capability_pack import scalar_texts, validate_deployed_pack_metadata
 PRACTICE_RETIRE_STATUS = "archived"
 ASSET_RETIRE_STATUS = "retired"
 LIFECYCLE_STATES = {
-    "detected",
     "candidate",
+    "reviewed",
     "proposed",
     "active",
     "exportable",
     "deprecated",
-    "split",
-    "merged",
     "retired",
+    "archived",
     "blocked",
 }
 LEGACY_DEPLOYED_STATES = {"deployed", "disabled"}
 WRITE_ACTIONS = {"disable", "retire"}
 REVIEW_ONLY_ACTIONS = {"activate", "exportable", "deprecate", "split", "merge"}
+REVIEW_ONLY_TARGET_LIFECYCLE = {
+    "activate": "active",
+    "exportable": "exportable",
+    "deprecate": "deprecated",
+}
+REVIEW_ONLY_TRANSITION_OUTCOMES = {
+    "split": "split",
+    "merge": "merged",
+}
 LOCAL_PRIVATE_RE = re.compile(
     r"(^~|/Users/|\.agent-foundry|\.codex|\.trae|raw session|raw log|runtime manifest|"
     r"local receipt|secret|token)",
@@ -287,14 +295,10 @@ def print_followup_guidance(action: str) -> None:
 
 
 def report_review_only_action(records: list[PackRecord], action: str) -> int:
-    target_state = {
-        "activate": "active",
-        "exportable": "exportable",
-        "deprecate": "deprecated",
-        "split": "split",
-        "merge": "merged",
-    }[action]
-    print(f"target_state: {target_state}")
+    if action in REVIEW_ONLY_TARGET_LIFECYCLE:
+        print(f"target_lifecycle_status: {REVIEW_ONLY_TARGET_LIFECYCLE[action]}")
+    else:
+        print(f"transition_outcome: {REVIEW_ONLY_TRANSITION_OUTCOMES[action]}")
     print("status: review_required")
     print("records:")
     if not records:

--- a/scripts/test_capability_pack_lifecycle.py
+++ b/scripts/test_capability_pack_lifecycle.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import hashlib
+import importlib.util
 import shutil
 import subprocess
 import sys
@@ -21,6 +22,17 @@ STATUS = ROOT / "scripts" / "sync_status.py"
 BOOTSTRAP_PACK = ROOT / "fixtures" / "capability-packs" / "bootstrap-minimal"
 OPTIONAL_PACK = ROOT / "fixtures" / "capability-packs" / "optional-multi-agent"
 OPTIONAL_ID = "pack.multi-agent.optional"
+EXPECTED_LIFECYCLE_STATES = {
+    "candidate",
+    "reviewed",
+    "proposed",
+    "active",
+    "exportable",
+    "deprecated",
+    "retired",
+    "archived",
+    "blocked",
+}
 
 
 def run(args: list[str]) -> subprocess.CompletedProcess[str]:
@@ -86,6 +98,25 @@ def lifecycle(vault: Path, action: str, apply: bool) -> subprocess.CompletedProc
     if apply:
         args.append("--apply")
     return run(args)
+
+
+def assert_lifecycle_namespace() -> list[str]:
+    spec = importlib.util.spec_from_file_location("manage_capability_pack_lifecycle", LIFECYCLE)
+    if spec is None or spec.loader is None:
+        return ["cannot load manage_capability_pack_lifecycle.py"]
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    errors: list[str] = []
+    actual = set(module.LIFECYCLE_STATES)
+    if actual != EXPECTED_LIFECYCLE_STATES:
+        errors.append(f"lifecycle namespace mismatch: {sorted(actual)}")
+    for report_only in ["detected", "split", "merged", "recommended", "merge_required", "drifted"]:
+        if report_only in actual:
+            errors.append(f"{report_only} must not be a canonical lifecycle state")
+    print("lifecycle-namespace: ok" if not errors else "lifecycle-namespace: failed")
+    return errors
 
 
 def add_metadata_section(vault: Path, lines: list[str]) -> None:
@@ -155,6 +186,7 @@ def add_deployed_pack_contract(vault: Path, source_authority: str) -> None:
 
 def main() -> int:
     errors: list[str] = []
+    errors.extend(assert_lifecycle_namespace())
     with tempfile.TemporaryDirectory(prefix="agent-foundry-pack-lifecycle-") as tmp:
         base = Path(tmp)
         vault = base / "vault"
@@ -241,17 +273,19 @@ def main() -> int:
         errors.extend(expect("activate-apply-refused", activate_apply, False, "cannot be applied"))
 
         exportable_plan = lifecycle(vault, "exportable", apply=False)
-        errors.extend(expect("exportable-review-only", exportable_plan, False, "target_state: exportable"))
+        errors.extend(expect("exportable-review-only", exportable_plan, False, "target_lifecycle_status: exportable"))
         errors.extend(expect("exportable-no-runtime-authority", exportable_plan, False, "runtime_followup:"))
 
         deprecate_plan = lifecycle(vault, "deprecate", apply=False)
-        errors.extend(expect("deprecate-review-only", deprecate_plan, False, "target_state: deprecated"))
+        errors.extend(expect("deprecate-review-only", deprecate_plan, False, "target_lifecycle_status: deprecated"))
         errors.extend(expect("deprecate-reports-records", deprecate_plan, False, "ASSET-COLLAB-PACK-001 asset"))
 
         split_plan = lifecycle(vault, "split", apply=False)
         errors.extend(expect("split-review-only", split_plan, False, "before-after membership diff"))
+        errors.extend(expect("split-transition-outcome", split_plan, False, "transition_outcome: split"))
         merge_plan = lifecycle(vault, "merge", apply=False)
         errors.extend(expect("merge-review-only", merge_plan, False, "split/merge requires"))
+        errors.extend(expect("merge-transition-outcome", merge_plan, False, "transition_outcome: merged"))
 
         metadata_with_valid_contract = metadata.read_text(encoding="utf-8")
         add_deployed_pack_contract(vault, "runtime generated adapter authority")

--- a/workflows/discover-capability-packs.md
+++ b/workflows/discover-capability-packs.md
@@ -110,6 +110,9 @@ requires review before activation or export.
 
 ## 4. Classify Candidate Outcome
 
+Candidate outcomes are a power-user discovery namespace. They explain whether a
+reusable boundary is worth review; they are not persisted pack lifecycle states.
+
 Use the first matching outcome:
 
 | Outcome | Use when |

--- a/workflows/export-import-capability-packs.md
+++ b/workflows/export-import-capability-packs.md
@@ -61,7 +61,11 @@ Fail closed before sharing or import acceptance when transfer material contains:
 - executable payload execution, install side effects, destructive changes, or
   automatic activation claims.
 
-## Import States
+## Import States / Transfer State Namespace
+
+Transfer/import states describe a privacy-safe review workflow. They are not
+pack canonical lifecycle states and must not be persisted as
+`lifecycle_status`.
 
 | State | Meaning | Writes |
 | --- | --- | --- |

--- a/workflows/manage-capability-pack-lifecycle.md
+++ b/workflows/manage-capability-pack-lifecycle.md
@@ -32,25 +32,39 @@ primary user surface.
 - Local-private evidence, raw logs, runtime manifests, receipts, user paths,
   secrets, and memory-system records are not pack lifecycle authority.
 
-## Lifecycle States
+## State Namespace Rule
+
+Capability-pack workflows use several state namespaces. Persisted
+`lifecycle_status` fields belong only to the canonical pack lifecycle namespace.
+Display, candidate, transfer/import, comparison/report, and runtime/generated
+statuses must be labeled as their own output types and must not be written as
+pack lifecycle values.
+
+| Namespace | Owns | Examples |
+| --- | --- | --- |
+| Pack canonical lifecycle | Manifest and deployed-pack metadata `lifecycle_status`. | `candidate`, `reviewed`, `proposed`, `active`, `exportable`, `deprecated`, `retired`, `archived`, `blocked` |
+| Adopter discovery/display status | Normal-user list/recommend/status copy. | `available`, `recommended`, `compatible`, `incompatible`, `installed`, `deployed`, `update_available`, `not_installed` |
+| Candidate discovery outcome | Power-user discovery review-list output. | `candidate`, `baseline_control`, `extend_existing`, `deferred_overlap`, `rejected_false_positive`, `blocked_policy` |
+| Transfer/import state | Export/import preview and import review state. | `preview`, `dry-run`, `proposed`, `accepted`, `rejected`, `blocked` |
+| Comparison/report classification | Update, audit, diff, and lifecycle reports. | `clean_update_available`, `merge_required`, `same_version_hash_mismatch`, `unsupported`, `stale`, `drifted` |
+| Runtime/generated status | Downstream generated output and runtime freshness. | `generated_current`, `generated_stale`, `generated_missing`, `runtime_current`, `runtime_drifted`, `manual_import_required` |
+
+## Canonical Lifecycle States
 
 | State | Meaning | Agent action | Required gate |
 | --- | --- | --- | --- |
-| `detected` | Evidence suggests a possible pack. | Gather public/sanitized evidence and score signals. | Privacy gate if private evidence is needed. |
 | `candidate` | Reviewable candidate output from discovery. | Prepare candidate packet and false-positive controls. | Reviewer/Architect review before promotion. |
+| `reviewed` | Pack snapshot or boundary passed review but is not yet proposed for deployment. | Preserve as reviewed artifact or release input. | Reviewer/Architect acceptance. |
 | `proposed` | Boundary accepted for possible deployment. | Produce dry-run plan, diff, and lifecycle impact. | Human approval before active use. |
 | `active` | Reviewed pack is deployed as an optional capability. | Report status and downstream follow-up. | Activation approval and record governance. |
 | `exportable` | Pack may be exported after privacy review. | Produce exportability status only. | Human privacy/export review; #176 owns mechanics. |
 | `deprecated` | Pack remains readable but is no longer preferred. | Warn, suggest replacement, avoid new activation. | Reviewed rationale and user-visible status. |
-| `split` | Pack boundary is divided into multiple packs. | Produce membership diff and conflict report. | Human approval with rollback/defer plan. |
-| `merged` | Pack boundary is merged into another pack. | Produce target-pack diff and conflict report. | Human approval with conflict handling. |
 | `retired` | Pack should no longer be used. | Dry-run/apply only after approval. | Human approval and practice/asset lifecycle review. |
+| `archived` | Pack is retained only for history or provenance. | Keep readable; do not recommend or newly deploy. | Reviewed archival rationale. |
 | `blocked` | Transition is unsafe or lacks evidence. | Explain blockers and write nothing. | Human correction or explicit hold. |
 
 ## Transition Gates
 
-- `detected -> candidate`: requires passing discovery authority, privacy,
-  false-positive, and bootstrap-duplicate gates. No activation or export.
 - `candidate -> proposed`: requires Reviewer boundary review and Architect
   acceptance.
 - `proposed -> active`: requires human approval of boundary, included records,
@@ -61,10 +75,10 @@ primary user surface.
   user-visible warning/status report.
 - `deprecated -> retired`: requires dry-run report, affected records, generated
   and runtime follow-up, and human approval.
-- `active/proposed -> split`: requires proposed new pack ids, before/after
+- `active/proposed -> split outcome`: requires proposed new pack ids, before/after
   membership diff, per-record hashes, conflicts, local-edit handling, generated
   and runtime follow-up, rollback/defer plan, and human approval.
-- `active/proposed -> merged`: requires target pack id, membership diff,
+- `active/proposed -> merge outcome`: requires target pack id, membership diff,
   duplicate/conflict handling, local-edit handling, generated and runtime
   follow-up, rollback/defer plan, and human approval.
 - Any transition becomes `blocked` when metadata is malformed, hashes are
@@ -110,8 +124,9 @@ primary user surface.
      --apply
    ```
 
-   `activate`, `exportable`, `deprecate`, `split`, and `merge` are review-only
-   planning surfaces in #175. They must keep `writes: none`.
+  `activate`, `exportable`, `deprecate`, `split`, and `merge` are review-only
+  planning surfaces in #175. They must keep `writes: none`. `split` and
+  `merge` report transition outcomes, not persisted lifecycle statuses.
 
 5. After an approved Vault lifecycle change, publish and inspect downstream
    state separately:
@@ -154,7 +169,7 @@ Lifecycle tooling must refuse writes and print `writes: none` when it sees:
 
 ## #176 Boundary
 
-#175 may show `exportable` as a lifecycle status and report that export review is
-required. It must not implement export/import mechanics, produce export bundles,
-or mark a pack exportable from generated/runtime evidence alone. Privacy-safe
-export/import behavior belongs to #176.
+#175 may show `exportable` as a canonical lifecycle status and report that
+export review is required. It must not implement export/import mechanics,
+produce export bundles, or mark a pack exportable from generated/runtime
+evidence alone. Privacy-safe export/import behavior belongs to #176.


### PR DESCRIPTION
## Summary

Implements #228 bounded terminology alignment for capability-pack state taxonomy.

- Adds a consolidated `state_namespaces` reference to `schemas/capability-pack-manifest.schema.yaml`.
- Separates canonical pack lifecycle from adopter display, candidate outcome, transfer/import, comparison/report, and runtime/generated status namespaces.
- Aligns candidate, discovery, transfer/import, and lifecycle workflow wording with the accepted #226 taxonomy.
- Updates lifecycle tooling so `split` / `merge` report `transition_outcome` instead of pretending to be persisted lifecycle states.
- Adds lifecycle regression coverage proving transient/report states such as `detected`, `split`, `merged`, `recommended`, `merge_required`, and `drifted` are not canonical lifecycle states.

## Verification

- `python3 -m py_compile scripts/manage_capability_pack_lifecycle.py scripts/plan_capability_pack_transfer.py scripts/test_capability_pack_lifecycle.py scripts/test_capability_pack_transfer.py scripts/test_advanced_capability_workflow_surface.py`
- `python3 scripts/test_capability_pack_lifecycle.py`
- `python3 scripts/test_capability_pack_transfer.py`
- `python3 scripts/test_advanced_capability_workflow_surface.py`
- `python3 scripts/check_capability_pack_fixtures.py`
- `python3 scripts/test_capability_pack_plan.py`
- `python3 scripts/test_capability_pack_apply.py`
- `python3 scripts/test_capability_pack_update.py`
- `python3 scripts/check_consistency.py`
- targeted taxonomy grep over schemas/workflows/scripts/tests
- `git diff --check`

## Boundaries

No live Vault/private-state/runtime/generated mutation, generated Skill/adapter publish, pack activation/export/import/deploy, Project v2 mutation, memory-system work, broad docs reorganization, or issue/Epic/stage closure performed.

## Residual risks

- This normalizes terminology and regression coverage; later #226 child tasks still need to preserve the namespace split when adding normal-user or power-user UX flows.
- Existing legacy deployed metadata values `deployed` / `disabled` remain compatibility inputs in tooling, not newly endorsed canonical lifecycle values.