### PR TITLE
AF12 #232 official capability pack catalog surface

### DIFF
--- a/catalog/capability-packs/index.yaml
+++ b/catalog/capability-packs/index.yaml
@@ -1,0 +1,25 @@
+catalog_schema_version: 1
+catalog_id: core.official-capability-packs
+source: core_repo
+entries:
+  - pack_id: pack.bootstrap.minimal
+    title: Minimal Agent Foundry Bootstrap Pack
+    channel: official
+    catalog_status: available
+    latest_version: 0.2.0
+    manifest_path: fixtures/capability-packs/bootstrap-minimal/manifest.yaml
+    manifest_sha256: dee22dc5a39f29c5cc87f2acaee0f1e24dd22285bf609f28dcca92a213ea1737
+    compatibility_summary: "Core schema 1; Vault layout [1]; bootstrap not required."
+    compatibility_metadata:
+      core_schema_version_min: 1
+      core_schema_version_max: 1
+      vault_layout_versions: [1]
+      requires_bootstrap_pack: false
+    changelog_path: catalog/capability-packs/pack.bootstrap.minimal/CHANGELOG.md
+    readme_path: catalog/capability-packs/pack.bootstrap.minimal/README.md
+    review_evidence: https://github.com/farmerhunter/agent-foundry/issues/232
+    authority_after_deployment: selected_user_vault
+    private_local_evidence: excluded
+    core_release_axis: independent
+    candidate_review_packet: false
+    release_artifact_published: false

--- a/catalog/capability-packs/pack.bootstrap.minimal/CHANGELOG.md
+++ b/catalog/capability-packs/pack.bootstrap.minimal/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.2.0
+
+- Cataloged as the first minimal official Core-hosted capability pack entry.
+- Manifest reference remains the reviewed bootstrap fixture at
+  `fixtures/capability-packs/bootstrap-minimal/manifest.yaml`.
+- Pack version remains independent from Core release or git tag names.
+- No release artifact publishing, export/import, deployment, activation, live
+  Vault mutation, generated adapter publish, runtime install, or private/local
+  evidence export is authorized by this catalog entry.

--- a/catalog/capability-packs/pack.bootstrap.minimal/README.md
+++ b/catalog/capability-packs/pack.bootstrap.minimal/README.md
@@ -1,0 +1,30 @@
+# Minimal Agent Foundry Bootstrap Pack
+
+Official Core catalog entry for the reviewed mandatory bootstrap pack.
+
+This catalog page is discoverability metadata only. The reviewed manifest is
+`fixtures/capability-packs/bootstrap-minimal/manifest.yaml`; the catalog pins
+that manifest by SHA-256 in `catalog/capability-packs/index.yaml`.
+
+## Authority
+
+- Core hosts this official catalog entry and reviewed manifest reference.
+- The selected User Vault remains canonical after accepted deployment.
+- Generated adapters and runtime installs remain downstream projections.
+- Private Vault evidence, local machine paths, runtime manifests, receipts,
+  secrets, raw sessions, and usage rows are excluded.
+
+## Versioning
+
+Pack version `0.2.0` identifies the reviewed bootstrap pack contract. Core git
+tags and releases identify repository snapshots. These are related but
+independent axes.
+
+## Review
+
+Review evidence:
+
+- https://github.com/farmerhunter/agent-foundry/issues/232
+- https://github.com/farmerhunter/agent-foundry/issues/232#issuecomment-4787766294
+- https://github.com/farmerhunter/agent-foundry/issues/232#issuecomment-4787780757
+- https://github.com/farmerhunter/agent-foundry/issues/232#issuecomment-4787793177

--- a/schemas/capability-pack-catalog.schema.yaml
+++ b/schemas/capability-pack-catalog.schema.yaml
@@ -1,0 +1,83 @@
+# Official capability pack catalog schema.
+# Human-readable AF-12 catalog format, not a strict machine validator yet.
+# The catalog is Core-hosted discoverability metadata. It is not selected Vault
+# authority, a deployment receipt, or an export/import package.
+
+required_fields:
+  catalog_schema_version: "Integer schema version for this catalog format."
+  catalog_id: "Stable catalog id, such as core.official-capability-packs."
+  source: "Catalog source namespace. Current supported value: core_repo."
+  entries: "Official capability pack entries."
+
+entry_required_fields:
+  pack_id: "Stable capability pack id matching the referenced manifest."
+  title: "Human-readable pack title for official discovery."
+  channel: "Catalog channel. Official Core catalog entries must use official."
+  catalog_status: "Catalog display status: available | deprecated | retired | blocked."
+  latest_version: "Latest reviewed pack contract version, independent from Core tags/releases."
+  manifest_path: "Repository-relative path to the reviewed manifest reference."
+  manifest_sha256: "SHA-256 digest of the referenced manifest_path content."
+  compatibility_summary: "Short user-facing compatibility summary."
+  compatibility_metadata: "Core schema, Vault layout, and bootstrap requirements copied from the manifest for display."
+  changelog_path: "Repository-relative path to the human-readable official changelog."
+  readme_path: "Repository-relative path to the official pack overview."
+  review_evidence: "Public issue, PR, or review URL for the catalog entry."
+  authority_after_deployment: "Must name selected User Vault as canonical after accepted deployment."
+  private_local_evidence: "Must state that private/local/raw evidence is excluded."
+  core_release_axis: "Must state that pack version and Core release/tag are independent axes."
+  candidate_review_packet: "Must be false for official catalog entries."
+  release_artifact_published: "Must be false until a later reviewed release workflow exists."
+
+compatibility_metadata_fields:
+  core_schema_version_min: "Minimum Core schema version supported by the pack."
+  core_schema_version_max: "Maximum Core schema version supported by the pack."
+  vault_layout_versions: "List of supported selected Vault layout versions."
+  requires_bootstrap_pack: "Boolean copied from the reviewed manifest."
+
+status_namespaces:
+  catalog_status:
+    owns: "Official catalog availability/display state."
+    allowed_values: "available | deprecated | retired | blocked"
+    persistence_rule: "Do not persist catalog_status as manifest or deployed-pack lifecycle_status."
+  pack_canonical_lifecycle:
+    owns: "Referenced manifest and deployed-pack metadata lifecycle_status."
+    allowed_values: "candidate | reviewed | proposed | active | exportable | deprecated | retired | archived | blocked"
+    persistence_rule: "Canonical lifecycle remains in the reviewed manifest and selected Vault metadata after deployment."
+  candidate_review_packet:
+    owns: "Power-user diagnostic candidate records and review-list output."
+    persistence_rule: "Candidate review packets are not official catalog entries and cannot be deployment, export, or activation inputs by default."
+
+rules:
+  - "Core hosts the official catalog as first-party discoverability and availability metadata."
+  - "The catalog indexes reviewed manifests; it does not replace manifest validation or selected Vault authority."
+  - "After accepted deployment, selected User Vault records own canonical practice, asset, membership, provenance, and deployed-pack state."
+  - "Pack version and Core release/tag are independent axes: Core release identifies repository state; pack version identifies the reviewed pack contract."
+  - "Every official entry must pin manifest_sha256 for manifest_path."
+  - "Same pack_id plus same latest_version plus different manifest_sha256 must fail closed and require review."
+  - "Catalog status values are not pack lifecycle_status values."
+  - "Official entries must not contain raw private Vault evidence, local machine paths, runtime manifests, receipts, secrets, raw sessions, or usage rows."
+  - "Local candidate review packets cannot appear in the official catalog until a later reviewed maintainer flow creates a reviewed manifest and catalog entry."
+  - "Current AF-12 catalog work does not publish release artifacts, create a separate repository, export/import/deploy/activate packs, mutate live Vault state, or publish generated adapters/Skills."
+
+example_entry:
+  pack_id: pack.bootstrap.minimal
+  title: Minimal Agent Foundry Bootstrap Pack
+  channel: official
+  catalog_status: available
+  latest_version: 0.2.0
+  manifest_path: fixtures/capability-packs/bootstrap-minimal/manifest.yaml
+  manifest_sha256: dee22dc5a39f29c5cc87f2acaee0f1e24dd22285bf609f28dcca92a213ea1737
+  compatibility_summary: "Core schema 1; Vault layout [1]; bootstrap not required."
+  compatibility_metadata:
+    core_schema_version_min: 1
+    core_schema_version_max: 1
+    vault_layout_versions: [1]
+    requires_bootstrap_pack: false
+  changelog_path: catalog/capability-packs/pack.bootstrap.minimal/CHANGELOG.md
+  readme_path: catalog/capability-packs/pack.bootstrap.minimal/README.md
+  review_evidence: https://github.com/farmerhunter/agent-foundry/issues/232
+  authority_after_deployment: selected_user_vault
+  private_local_evidence: excluded
+  core_release_axis: independent
+  candidate_review_packet: false
+  release_artifact_published: false

--- a/scripts/test_advanced_capability_workflow_surface.py
+++ b/scripts/test_advanced_capability_workflow_surface.py
@@ -3,10 +3,13 @@
 
 from __future__ import annotations
 
+import hashlib
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
+
+from deploy_capability_pack import parse_simple_yaml, top_level_scalars
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -15,6 +18,45 @@ PLAN = ROOT / "scripts" / "plan_capability_pack.py"
 LIFECYCLE = ROOT / "scripts" / "manage_capability_pack_lifecycle.py"
 TRANSFER = ROOT / "scripts" / "plan_capability_pack_transfer.py"
 BOOTSTRAP_PACK = ROOT / "fixtures" / "capability-packs" / "bootstrap-minimal"
+CATALOG_INDEX = ROOT / "catalog" / "capability-packs" / "index.yaml"
+CATALOG_SCHEMA = ROOT / "schemas" / "capability-pack-catalog.schema.yaml"
+CATALOG_STATUSES = {"available", "deprecated", "retired", "blocked"}
+CANONICAL_LIFECYCLE_STATUSES = {
+    "candidate",
+    "reviewed",
+    "proposed",
+    "active",
+    "exportable",
+    "deprecated",
+    "retired",
+    "archived",
+    "blocked",
+}
+REQUIRED_CATALOG_ENTRY_FIELDS = {
+    "pack_id",
+    "title",
+    "channel",
+    "catalog_status",
+    "latest_version",
+    "manifest_path",
+    "manifest_sha256",
+    "compatibility_summary",
+    "compatibility_metadata",
+    "changelog_path",
+    "readme_path",
+    "review_evidence",
+    "authority_after_deployment",
+    "private_local_evidence",
+    "core_release_axis",
+    "candidate_review_packet",
+    "release_artifact_published",
+}
+REQUIRED_COMPATIBILITY_METADATA_FIELDS = {
+    "core_schema_version_min",
+    "core_schema_version_max",
+    "vault_layout_versions",
+    "requires_bootstrap_pack",
+}
 
 
 def run(args: list[str]) -> subprocess.CompletedProcess[str]:
@@ -48,6 +90,118 @@ def require_text(path: Path, snippets: list[str]) -> list[str]:
             errors.append(f"{path.relative_to(ROOT)} missing {snippet!r}")
         else:
             print(f"{path.relative_to(ROOT)} contains {snippet}: ok")
+    return errors
+
+
+def scalar(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, list):
+        return "[" + ", ".join(scalar(item) for item in value) + "]"
+    return ""
+
+
+def validate_official_catalog() -> list[str]:
+    errors: list[str] = []
+    if not CATALOG_INDEX.exists():
+        return [f"{CATALOG_INDEX.relative_to(ROOT)} missing"]
+    if not CATALOG_SCHEMA.exists():
+        errors.append(f"{CATALOG_SCHEMA.relative_to(ROOT)} missing")
+
+    try:
+        catalog = parse_simple_yaml(CATALOG_INDEX.read_text(encoding="utf-8"))
+    except ValueError as exc:
+        return [f"{CATALOG_INDEX.relative_to(ROOT)} parse error: {exc}"]
+
+    if scalar(catalog.get("catalog_schema_version")) != "1":
+        errors.append("official catalog schema version must be 1")
+    if catalog.get("catalog_id") != "core.official-capability-packs":
+        errors.append("official catalog_id must be core.official-capability-packs")
+    if catalog.get("source") != "core_repo":
+        errors.append("official catalog source must be core_repo")
+
+    entries = catalog.get("entries", [])
+    if not isinstance(entries, list) or not entries:
+        errors.append("official catalog entries must be a non-empty list")
+        return errors
+
+    seen_versions: dict[tuple[str, str], str] = {}
+    for raw_entry in entries:
+        if not isinstance(raw_entry, dict):
+            errors.append("official catalog entry must be a mapping")
+            continue
+        entry = raw_entry
+        pack_id = scalar(entry.get("pack_id", "<unknown>"))
+        missing = sorted(REQUIRED_CATALOG_ENTRY_FIELDS - set(entry.keys()))
+        for field in missing:
+            errors.append(f"official catalog {pack_id} missing {field}")
+
+        if entry.get("channel") != "official":
+            errors.append(f"official catalog {pack_id} channel must be official")
+        if entry.get("catalog_status") not in CATALOG_STATUSES:
+            errors.append(f"official catalog {pack_id} invalid catalog_status {entry.get('catalog_status')}")
+        if "lifecycle_status" in entry:
+            errors.append(f"official catalog {pack_id} must use catalog_status, not lifecycle_status")
+        if entry.get("core_release_axis") != "independent":
+            errors.append(f"official catalog {pack_id} must keep pack version and Core release/tag independent")
+        if scalar(entry.get("candidate_review_packet")) != "false":
+            errors.append(f"official catalog {pack_id} must not be a candidate review packet")
+        if scalar(entry.get("release_artifact_published")) != "false":
+            errors.append(f"official catalog {pack_id} must not publish release artifacts in AF12")
+        if scalar(entry.get("authority_after_deployment")) != "selected_user_vault":
+            errors.append(f"official catalog {pack_id} must name selected User Vault authority after deployment")
+        if scalar(entry.get("private_local_evidence")) != "excluded":
+            errors.append(f"official catalog {pack_id} must exclude private/local evidence")
+
+        compatibility = entry.get("compatibility_metadata", {})
+        if not isinstance(compatibility, dict):
+            errors.append(f"official catalog {pack_id} compatibility_metadata must be a mapping")
+        else:
+            for field in sorted(REQUIRED_COMPATIBILITY_METADATA_FIELDS - set(compatibility.keys())):
+                errors.append(f"official catalog {pack_id} compatibility_metadata missing {field}")
+
+        manifest_rel = scalar(entry.get("manifest_path"))
+        manifest_path = ROOT / manifest_rel
+        if not manifest_rel or not manifest_path.exists():
+            errors.append(f"official catalog {pack_id} manifest_path missing: {manifest_rel}")
+            continue
+        manifest_hash = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+        if entry.get("manifest_sha256") != manifest_hash:
+            errors.append(f"official catalog {pack_id} manifest_sha256 mismatch")
+
+        manifest = top_level_scalars(manifest_path.read_text(encoding="utf-8"))
+        if manifest.get("pack_id") != pack_id:
+            errors.append(f"official catalog {pack_id} manifest pack_id mismatch")
+        if manifest.get("version") != scalar(entry.get("latest_version")):
+            errors.append(f"official catalog {pack_id} latest_version must match manifest version")
+        if manifest.get("lifecycle_status") not in CANONICAL_LIFECYCLE_STATUSES:
+            errors.append(f"official catalog {pack_id} manifest lifecycle_status must use canonical lifecycle namespace")
+        if manifest.get("lifecycle_status") == scalar(entry.get("catalog_status")):
+            errors.append(f"official catalog {pack_id} catalog_status must be separate from manifest lifecycle_status")
+
+        version_key = (pack_id, scalar(entry.get("latest_version")))
+        prior_hash = seen_versions.get(version_key)
+        if prior_hash and prior_hash != scalar(entry.get("manifest_sha256")):
+            errors.append(f"official catalog {pack_id} same version has conflicting manifest_sha256")
+        seen_versions[version_key] = scalar(entry.get("manifest_sha256"))
+
+        for path_field in ["changelog_path", "readme_path"]:
+            rel_path = scalar(entry.get(path_field))
+            if not rel_path or not (ROOT / rel_path).exists():
+                errors.append(f"official catalog {pack_id} missing {path_field}: {rel_path}")
+
+    catalog_text = CATALOG_INDEX.read_text(encoding="utf-8")
+    if "candidate_schema_version" in catalog_text:
+        errors.append("official catalog must not contain candidate review packet fields")
+    for forbidden in ["/Users/", "gho_", "runtime/local/", "usage/local/"]:
+        if forbidden in catalog_text:
+            errors.append(f"official catalog contains private/local marker {forbidden}")
+
+    print("official capability catalog surface: ok")
     return errors
 
 
@@ -99,6 +253,21 @@ def write_deployed_index(vault: Path) -> None:
 
 def main() -> int:
     errors: list[str] = []
+    errors.extend(validate_official_catalog())
+    errors.extend(
+        require_text(
+            CATALOG_SCHEMA,
+            [
+                "catalog_status",
+                "available | deprecated | retired | blocked",
+                "selected User Vault",
+                "Pack version and Core release/tag are independent axes",
+                "Same pack_id plus same latest_version plus different manifest_sha256 must fail closed",
+                "Candidate review packets are not official catalog entries",
+                "Current AF-12 catalog work does not publish release artifacts",
+            ],
+        )
+    )
     errors.extend(
         require_text(
             ROOT / "workflows" / "discover-capability-packs.md",
@@ -120,6 +289,8 @@ def main() -> int:
                 "scripts/manage_capability_pack_lifecycle.py",
                 "scripts/plan_capability_pack_transfer.py",
                 "writes: none",
+                "separate from the official Core catalog",
+                "cannot become an official catalog entry",
             ],
         )
     )
@@ -139,6 +310,11 @@ def main() -> int:
                 "review a pack release or version update",
                 "review exportability",
                 "review packets by default",
+                "official Core catalog",
+                "catalog_status",
+                "selected Vault remains canonical",
+                "same `pack_id` plus same pack version with",
+                "pack version and Core release/tag remain independent axes",
                 "pack identity",
                 "adopter display status",
                 "exact selected Vault write target",

--- a/workflows/discover-capability-packs.md
+++ b/workflows/discover-capability-packs.md
@@ -198,6 +198,12 @@ When a later reviewed power-user step asks for a durable candidate record, write
 it using `schemas/capability-pack-candidate.schema.yaml`. That candidate record
 remains a review artifact and is still not an active pack manifest.
 
+Candidate review packets are also separate from the official Core catalog in
+`catalog/capability-packs/index.yaml`. A candidate may cite official packs as
+existing coverage or provenance, but it cannot become an official catalog entry,
+export/import/deploy input, or active pack manifest until a later reviewed
+maintainer flow creates a reviewed manifest and catalog entry.
+
 ## 7. Review Handoff
 
 Route candidates to Reviewer for false-positive and boundary review when the

--- a/workflows/manage-capability-pack-lifecycle.md
+++ b/workflows/manage-capability-pack-lifecycle.md
@@ -51,6 +51,12 @@ Raw scripts remain implementation/debug substrate. Normal-user output must not
 make candidate discovery, pack authoring, export publication, or maintainer
 release decisions part of routine consumption.
 
+When a normal-user list or recommendation flow reads the official Core catalog,
+the catalog is a discovery surface only. It may show official availability,
+version, manifest hash, compatibility summary, changelog, and review evidence,
+but it must still route preview/apply work through the reviewed manifest and the
+selected Vault. The selected Vault remains canonical after accepted deployment.
+
 ## Power-User Maintenance Contract
 
 Power-user capability-pack workflows are advanced maintenance-level workflows.
@@ -113,6 +119,49 @@ pack lifecycle values.
 | Transfer/import state | Export/import preview and import review state. | `preview`, `dry-run`, `proposed`, `accepted`, `rejected`, `blocked` |
 | Comparison/report classification | Update, audit, diff, and lifecycle reports. | `clean_update_available`, `merge_required`, `same_version_hash_mismatch`, `unsupported`, `stale`, `drifted` |
 | Runtime/generated status | Downstream generated output and runtime freshness. | `generated_current`, `generated_stale`, `generated_missing`, `runtime_current`, `runtime_drifted`, `manual_import_required` |
+| Official catalog status | Core catalog availability and display state. | `available`, `deprecated`, `retired`, `blocked` |
+
+Official catalog status values are not canonical `lifecycle_status` values. The
+official catalog uses `catalog_status` so that display availability does not
+change the manifest or deployed-pack lifecycle namespace.
+
+## Official Core Catalog
+
+The current-stage official catalog is Core-hosted and schema-backed:
+
+- `schemas/capability-pack-catalog.schema.yaml`
+- `catalog/capability-packs/index.yaml`
+- `catalog/capability-packs/<pack-id>/README.md`
+- `catalog/capability-packs/<pack-id>/CHANGELOG.md`
+
+Each official catalog entry must include:
+
+- pack id, title, official channel, and `catalog_status`;
+- latest pack version;
+- reviewed manifest path and `manifest_sha256`;
+- compatibility summary and manifest-derived compatibility metadata;
+- changelog and readme paths;
+- public review evidence;
+- explicit selected Vault authority after deployment;
+- explicit private/local evidence exclusion;
+- explicit pack-version versus Core-release independence;
+- `candidate_review_packet: false`;
+- `release_artifact_published: false` until a later reviewed release workflow
+  exists.
+
+Manifest hash checks fail closed: the same `pack_id` plus same pack version with
+a different `manifest_sha256` requires review before list, recommendation,
+preview, apply, export, import, or deployment work can proceed.
+
+The official catalog is not a separate repository, release artifact channel,
+export/import package, deployment receipt, generated adapter, runtime install,
+or selected Vault source of truth. A Core tag or release may advertise a catalog
+snapshot, but pack version and Core release/tag remain independent axes.
+
+Local candidate review packets remain diagnostic or power-user review artifacts.
+They cannot appear in the official catalog, become official packs, or become
+export/import/deploy inputs without a later reviewed maintainer flow that
+creates a reviewed manifest and official catalog entry.
 
 ## Canonical Lifecycle States
 


### PR DESCRIPTION
## Summary

Refs #232.

- Adds a Core-hosted official capability pack catalog schema and minimal official catalog index.
- Catalogs the reviewed bootstrap pack with pinned manifest SHA-256, compatibility metadata, changelog/readme references, review evidence, selected Vault authority, private/local evidence exclusion, and explicit pack-version/Core-release independence.
- Extends capability-pack workflow guidance for official catalog status namespace, candidate packet separation, fail-closed manifest hash expectations, and non-authority boundaries.
- Adds targeted regression coverage in `scripts/test_advanced_capability_workflow_surface.py` for the #232 acceptance points.

## Verification

- `python3 scripts/test_advanced_capability_workflow_surface.py` passed.
- `python3 scripts/check_consistency.py` passed.
- `python3 -m py_compile scripts/test_advanced_capability_workflow_surface.py scripts/check_consistency.py` passed.
- `git diff --check` passed.
- Targeted `rg` read-through for catalog/hash/status/authority/candidate/private anchors passed.

## Boundaries

No new repository, release artifact publishing, real pack export/import/deploy/activation, live Vault/private-state/runtime/generated mutation, generated Skill/adapter publish, Project v2 mutation, memory-system work, broad AF12 docs rewrite, #226/#227 closure, or final `main` integration was performed.

## Residual Risk

The catalog currently indexes the existing reviewed bootstrap fixture manifest rather than duplicating a full pack payload under `catalog/`, to avoid creating a second payload source that could drift. Later tooling can add stricter machine validation or release artifacts under a separate reviewed scope.