### PR TITLE
AF12 #246 ordinary-user daily operation docs

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -4,20 +4,29 @@ Use these short commands in day-to-day agent work.
 
 日常使用时直接说这些短命令即可。
 
-## Commands / 命令
+## Ordinary User Intents / 普通用户意图
+
+Start here for daily operation. Say the intent to the agent; the agent should map it to the reviewed workflow and show the visible outcome before durable changes.
+
+日常操作从这里开始。直接把意图告诉 agent；agent 应把它映射到 reviewed workflow，并在 durable changes 前展示可见结果。
 
 | Command | 中文 | Meaning / 说明 |
 |---|---|---|
 | `harvest practices` | `做一次 harvest practice` | Extract reusable practices from the current session and show a review list.<br>从当前 session 提炼可复用 practice，并展示 review list。 |
 | `discover assets` | `发现可打包资产` | Find repeated workflows that should become skills, subagents, automations, or extensions.<br>发现值得沉淀为 skill、subagent、automation 或扩展项的重复 workflow。 |
-| `discover capability packs` | `发现 capability pack` | Find higher-level reusable capability bundles from repeated practice, asset, workflow, and adapter evidence. Produces candidates only.<br>从重复的 practice、asset、workflow 和 adapter evidence 中发现更高层的 reusable capability bundle；只产出 candidate。 |
-| `evaluate capability pack <path>` | `评估 capability pack <路径>` | Inspect a pack or candidate boundary, false positives, privacy risks, and next reviewer without activating it.<br>检查 pack 或 candidate 的边界、false positive、隐私风险和下一位 reviewer，不激活。 |
-| `scan capability pack candidate boundaries` | `扫描 capability pack candidate 边界` | Advanced maintenance flow: scan evidence for candidate boundaries and produce a review packet only.<br>advanced maintenance flow：扫描 evidence 中的 candidate boundaries，只产出 review packet。 |
-| `assemble capability pack draft <candidate-id>` | `组装 capability pack draft <candidate-id>` | Advanced maintenance flow: assemble a draft proposal for review without creating, activating, exporting, publishing, or deploying a pack.<br>advanced maintenance flow：组装供 review 的 draft proposal，不创建、激活、export、publish 或 deploy pack。 |
-| `review capability pack release <pack-id-or-path>` | `review capability pack release <pack-id-or-path>` | Advanced maintenance flow: review version, taxonomy, compatibility, distribution, and release gates before any later apply step.<br>advanced maintenance flow：在任何后续 apply 前 review version、taxonomy、compatibility、distribution 和 release gates。 |
-| `review capability pack exportability <pack-id-or-path>` | `review capability pack exportability <pack-id-or-path>` | Advanced maintenance flow: review privacy and distribution readiness without exporting private Vault data.<br>advanced maintenance flow：review privacy 和 distribution readiness，不 export private Vault data。 |
-| `review capability pack deprecation <pack-id>` | `review capability pack deprecation <pack-id>` | Advanced maintenance flow: review replacement, rationale, affected records, and downstream follow-up before deprecation.<br>advanced maintenance flow：在 deprecation 前 review replacement、rationale、affected records 和 downstream follow-up。 |
-| `review capability pack split or merge <pack-id>` | `review capability pack split 或 merge <pack-id>` | Advanced maintenance flow: propose split/merge outcomes, membership diffs, and gates as a review packet only.<br>advanced maintenance flow：以 review packet 形式提出 split/merge outcomes、membership diffs 和 gates。 |
+| `refresh practices and assets` | `刷新practices和assets` | Pull remote updates, conditionally publish adapters, and install to local runtimes through the reviewed path.<br>拉取远端更新，必要时发布 adapters，并通过 reviewed path 安装到本地 runtimes。 |
+| `check Agent Foundry status` | `检查 Agent Foundry 状态` | Run a read-only status pass for Core, selected Vault, generated output, runtime receipts, and manual targets.<br>对 Core、selected Vault、generated output、runtime receipts 和 manual targets 做 read-only status 检查。 |
+| `review practices` | `review practices` / `检查 skill rot` | Review practices for duplicates, stale entries, weak or missed activation, and adapter drift.<br>检查 practices 中的重复项、过期项、弱激活/漏激活和 adapter drift。 |
+| `review assets` | `review assets` / `检查 asset rot` | Review reusable assets for usage, overlap, stale triggers, and adapter coverage.<br>检查 reusable assets 的使用情况、重叠、过期 trigger 和 adapter 覆盖。 |
+
+## Normal Capability-Pack Consumption / 普通 Capability Pack 使用
+
+These requests consume reviewed packs. They do not create packs, run candidate discovery, export, publish, split, merge, or deploy runtime files by themselves.
+
+这些请求用于使用 reviewed packs。它们本身不会创建 packs、运行 candidate discovery、export、publish、split、merge 或 deploy runtime files。
+
+| Command | 中文 | Meaning / 说明 |
+|---|---|---|
 | `list capability packs` | `列出 capability packs` | Show reviewed or deployed packs and their display status without changing lifecycle state.<br>列出 reviewed 或 deployed packs 及 display status，不改变 lifecycle state。 |
 | `recommend capability packs for my setup` | `推荐适合当前环境的 capability packs` | Recommend reviewed packs using compatibility, availability, generated output, and runtime status as display/report signals only.<br>根据 compatibility、availability、generated output 和 runtime status 推荐 reviewed packs；这些只是 display/report signals。 |
 | `preview capability pack deployment <path>` | `预览 capability pack 部署 <路径>` | Plan selected Vault impact and review gates before any apply.<br>在任何 apply 前预览 selected Vault 影响和 review gates。 |
@@ -25,23 +34,36 @@ Use these short commands in day-to-day agent work.
 | `verify capability pack <pack-id>` | `验证 capability pack <pack-id>` | Read pack metadata, selected Vault impact, generated output, runtime receipts, and manual target state before declaring the pack usable.<br>读取 pack metadata、selected Vault 影响、generated output、runtime receipts 和 manual target state，再判断 pack 是否可用。 |
 | `update capability pack <pack-id-or-path>` | `更新 capability pack <pack-id-or-path>` | Compare a reviewed newer pack against deployed metadata and local edits; report clean update, merge required, blocked, or unsupported before writes.<br>把 reviewed newer pack 与 deployed metadata 和本地改动比较；写入前报告 clean update、merge required、blocked 或 unsupported。 |
 | `disable capability pack <pack-id>` | `停用 capability pack <pack-id>` | Produce a dry-run lifecycle/rollback plan first; do not delete records or mutate runtime files silently.<br>先生成 dry-run lifecycle/rollback plan；不要静默删除 records 或修改 runtime files。 |
+
+## Advanced Maintenance And Debug / 高级维护与 Debug
+
+The commands below are secondary. Use them when you explicitly need power-user maintenance, transfer review, runtime repair, import review, or deterministic CLI/debug evidence.
+
+下面的命令是 secondary。只有在你明确需要 power-user maintenance、transfer review、runtime repair、import review 或 deterministic CLI/debug evidence 时再使用。
+
+| Command | 中文 | Meaning / 说明 |
+|---|---|---|
+| `discover capability packs` | `发现 capability pack` | Power-user diagnostic flow: find higher-level reusable capability bundles and produce candidates only.<br>power-user diagnostic flow：发现更高层的 reusable capability bundle；只产出 candidates。 |
+| `evaluate capability pack <path>` | `评估 capability pack <路径>` | Inspect a pack or candidate boundary, false positives, privacy risks, and next reviewer without activating it.<br>检查 pack 或 candidate 的边界、false positive、隐私风险和下一位 reviewer，不激活。 |
+| `scan capability pack candidate boundaries` | `扫描 capability pack candidate 边界` | Advanced maintenance flow: scan evidence for candidate boundaries and produce a review packet only.<br>advanced maintenance flow：扫描 evidence 中的 candidate boundaries，只产出 review packet。 |
+| `assemble capability pack draft <candidate-id>` | `组装 capability pack draft <candidate-id>` | Advanced maintenance flow: assemble a draft proposal for review without creating, activating, exporting, publishing, or deploying a pack.<br>advanced maintenance flow：组装供 review 的 draft proposal，不创建、激活、export、publish 或 deploy pack。 |
+| `review capability pack release <pack-id-or-path>` | `review capability pack release <pack-id-or-path>` | Advanced maintenance flow: review version, taxonomy, compatibility, distribution, and release gates before any later apply step.<br>advanced maintenance flow：在任何后续 apply 前 review version、taxonomy、compatibility、distribution 和 release gates。 |
+| `review capability pack exportability <pack-id-or-path>` | `review capability pack exportability <pack-id-or-path>` | Advanced maintenance flow: review privacy and distribution readiness without exporting private Vault data.<br>advanced maintenance flow：review privacy 和 distribution readiness，不 export private Vault data。 |
+| `review capability pack deprecation <pack-id>` | `review capability pack deprecation <pack-id>` | Advanced maintenance flow: review replacement, rationale, affected records, and downstream follow-up before deprecation.<br>advanced maintenance flow：在 deprecation 前 review replacement、rationale、affected records 和 downstream follow-up。 |
+| `review capability pack split or merge <pack-id>` | `review capability pack split 或 merge <pack-id>` | Advanced maintenance flow: propose split/merge outcomes, membership diffs, and gates as a review packet only.<br>advanced maintenance flow：以 review packet 形式提出 split/merge outcomes、membership diffs 和 gates。 |
 | `review capability pack lifecycle <pack-id>` | `review capability pack lifecycle <pack-id>` | Dry-run lifecycle transitions such as activate, exportable, split, merge, deprecate, disable, or retire.<br>dry-run 检查 activate、exportable、split、merge、deprecate、disable、retire 等 lifecycle transition。 |
 | `preview capability pack transfer <path>` | `预览 capability pack transfer <路径>` | Validate export/import transfer material with privacy-safe, writes-none checks.<br>用 privacy-safe、writes-none 检查验证 export/import transfer material。 |
 | `import skill <source>` | `导入这个 skill <source>` | Evaluate an external skill, repo, prompt pack, article, or local folder.<br>评估外部 skill、repo、prompt pack、文章或本地目录。 |
 | `publish practices` | `发布 practices` | Publish adapters from current active practices. Usually not needed manually.<br>从当前 active practices 发布 adapters；通常不需要手动执行。 |
 | `check operation context` | `检查操作上下文` | Show the current Agent Foundry Core/Vault/evidence/runtime context before writes.<br>在写入前显示当前 Agent Foundry Core/Vault/evidence/runtime 上下文。 |
-| `check Agent Foundry status` | `检查 Agent Foundry 状态` | Run a read-only status pass for Core, selected Vault, generated output, runtime receipts, and manual targets.<br>对 Core、selected Vault、generated output、runtime receipts 和 manual targets 做 read-only status 检查。 |
 | `check adapter drift` | `检查 adapter drift` | Inspect whether generated output or installed runtime files are stale before applying changes.<br>在 apply 前检查 generated output 或已安装 runtime files 是否 stale。 |
 | `restore Agent Foundry on this machine` | `在这台机器恢复 Agent Foundry` | Recreate local config, generated output, and runtime install state from Core plus the selected Vault.<br>从 Core 加 selected Vault 重建本机 local config、generated output 和 runtime install state。 |
-| `review practices` | `review practices` / `检查 skill rot` | Review the practice repo for duplicates, stale entries, weak or missed activation, and adapter drift.<br>检查 practice repo 中的重复项、过期项、弱激活/漏激活和 adapter drift。 |
-| `review assets` | `review assets` / `检查 asset rot` | Review reusable assets for usage, overlap, stale triggers, and adapter coverage.<br>检查 reusable assets 的使用情况、重叠、过期 trigger 和 adapter 覆盖。 |
-| `refresh practices and assets` | `刷新practices和assets` | Pull remote updates, conditionally publish adapters, and install to local runtimes.<br>拉取远端更新，必要时发布 adapters，并安装到本地 runtimes。 |
 
 ## Direct Status Command / 直接状态命令
 
-When you are not sure whether local agent rules are current, ask an agent to run the status command or run it yourself:
+When you are not sure whether local agent rules are current, first ask an agent `check Agent Foundry status`. If you need the direct CLI fallback, run:
 
-当你不确定本机 agent rules 是否最新时，可以让 agent 运行 status command，也可以自己执行：
+当你不确定本机 agent rules 是否最新时，先让 agent 执行 `check Agent Foundry status`。如果需要直接 CLI fallback，再运行：
 
 ```bash
 python3 scripts/sync_status.py

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -80,17 +80,27 @@ Recreate local state from Core plus the selected Vault, then verify with `sync_s
 
 ## Daily Workflow / 日常流程
 
-Use `refresh practices and assets` at the start of a session, after switching machines, or when local agent rules may be stale.
+Daily operation should start from what you want done, not from the script that might implement it. Ask the agent in natural language, then review the visible outcome before approving durable changes.
 
-在 session 开始、切换机器后，或本地 agent rules 可能 stale 时，使用 `refresh practices and assets`。
+日常操作应从你的意图开始，而不是从可能实现它的 script 开始。用自然语言告诉 agent 目标，然后先 review 可见结果，再批准 durable changes。
 
-Use `check Agent Foundry status` or `python3 scripts/sync_status.py` when you only need a read-only answer to whether this machine is current.
+Use this ordinary loop:
 
-只需要 read-only 检查这台机器是否 current 时，使用 `check Agent Foundry status` 或 `python3 scripts/sync_status.py`。
+普通日常 loop：
 
-Use `harvest practices` after a session when you want to preserve reusable lessons.
+1. Start with `check Agent Foundry status` when you need a read-only answer about Core, selected Vault, generated output, runtime receipts, or manual targets.
+2. Use `refresh practices and assets` at the start of a session, after switching machines, or when local agent rules may be stale.
+3. Use `harvest practices` after real work when you want to preserve reusable lessons.
+4. Review the numbered candidate list. Approve only the items you want promoted or merged.
+5. After approval, expect selected Vault records, indexes, and relevant generated adapters to change; runtime writes still follow the reviewed status or install path.
+6. Run `check Agent Foundry status` again when you need the next safe action or troubleshooting boundary.
 
-想在一次 session 后沉淀可复用经验时，使用 `harvest practices`。
+1. 需要 read-only 了解 Core、selected Vault、generated output、runtime receipts 或 manual targets 状态时，先用 `check Agent Foundry status`。
+2. 在 session 开始、切换机器后，或本地 agent rules 可能 stale 时，使用 `refresh practices and assets`。
+3. 完成真实工作并想沉淀可复用经验时，使用 `harvest practices`。
+4. Review 编号 candidate list。只批准你想 promote 或 merge 的项目。
+5. 批准后，预期 selected Vault records、indexes 和相关 generated adapters 会变化；runtime writes 仍走 reviewed status 或 install path。
+6. 需要 next safe action 或排查边界时，再运行 `check Agent Foundry status`。
 
 Use `discover assets` when repeated manual work should become a reusable skill, subagent, automation, or extension.
 
@@ -99,6 +109,14 @@ Use `discover assets` when repeated manual work should become a reusable skill, 
 Use `review practices` and `review assets` periodically to prevent skill rot and asset rot.
 
 定期使用 `review practices` 和 `review assets`，避免 skill rot 和 asset rot。
+
+For normal capability-pack use, stay with the Skill-facing requests in [Capability Pack Safety](#capability-pack-safety--capability-pack-安全规则). Do not run candidate discovery, release review, split, merge, export, or transfer workflows unless you explicitly want a power-user maintenance review packet.
+
+普通 capability-pack 使用请留在 [Capability Pack Safety](#capability-pack-safety--capability-pack-安全规则) 中的 Skill-facing requests。除非你明确需要 power-user maintenance review packet，否则不要运行 candidate discovery、release review、split、merge、export 或 transfer workflows。
+
+Raw CLI commands are secondary. Use them when the agent asks for a deterministic verification command, when you are debugging, or when [Deployment](deployment.md) tells you to operate runtime/install state directly.
+
+Raw CLI commands 是 secondary。只有当 agent 要求 deterministic verification command、你正在 debug，或 [Deployment](deployment.md) 要求你直接处理 runtime/install state 时再使用。
 
 ## Refresh Practices And Assets / 刷新 Practices 和 Assets
 
@@ -126,6 +144,10 @@ Expected behavior:
 - Report current commit, unpushed work, generated output state, runtime receipts, and updated runtimes.
 - 汇报 current commit、未 push 工作、generated output state、runtime receipts 和已更新 runtimes。
 
+If refresh reports generated output as stale, the normal next step is adapter publish through the reviewed path. If it reports runtime drift, read the status output first; runtime install or repair is a separate step, not an implicit side effect of harvest.
+
+如果 refresh 报告 generated output stale，普通 next step 是通过 reviewed path publish adapters。如果报告 runtime drift，先阅读 status output；runtime install 或 repair 是单独步骤，不是 harvest 的隐式副作用。
+
 ## Status And Drift / Status 和 Drift
 
 Run status before applying runtime writes, after long idle periods, after switching machines, or when a rule appears not to affect an agent.
@@ -147,6 +169,10 @@ If generated output is missing or stale, publish adapters first. If runtime rece
 Do not repair runtime drift by editing Vault records.
 
 不要通过编辑 Vault records 来修复 runtime drift。
+
+For runtime target changes, Trae setup, cross-machine restore, or manual target repair, escalate to [Deployment](deployment.md). For complete architecture and governance references, use [System Design](system-design.md) and [Lifecycle Compatibility](lifecycle-compatibility.md).
+
+需要 runtime target changes、Trae setup、cross-machine restore 或 manual target repair 时，升级查看 [Deployment](deployment.md)。需要完整 architecture 和 governance reference 时，查看 [System Design](system-design.md) 与 [Lifecycle Compatibility](lifecycle-compatibility.md)。
 
 ## Capability Pack Safety / Capability Pack 安全规则
 


### PR DESCRIPTION
## Summary

Implements #246 by making the ordinary-user docs Skill-facing before raw CLI:

- updates `docs/usage.md` with a daily operation loop for status, refresh, harvest, approval, generated/runtime follow-up, troubleshooting, and escalation links
- restructures `docs/commands.md` by user intent: ordinary daily intents, normal capability-pack consumption, and advanced maintenance/debug as secondary
- keeps power-user/candidate/release/export/split/merge flows outside the ordinary-user critical path

## Verification

- `python3 scripts/check_consistency.py`
- `git diff --check origin/codex/af12-docs-ux`
- targeted grep/read-through for ordinary-user intent wording, CLI/debug secondary marking, normal capability-pack consumption, runtime/generated status guidance, and no #247 cleanup terms

## Boundaries

No architecture/spec rewrite, runtime behavior change, generated Skill/adapter publish, live Vault/private/runtime/generated mutation, final `main` integration, #247/#244 implementation, #226/#227 closure, or memory-system work.

Next owner: Reviewer.