### PR TITLE
AF12 #247 power-user docs navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,16 +156,26 @@ DeepSeek, MiniMax, and similar model providers are treated as underlying models 
 
 ## Documentation / 文档入口
 
-Start with task-oriented docs, then use complete references only when you need them.
+Start with the tier that matches your task, then use complete references only when you need them.
 
-先看 task-oriented docs；只有需要时再进入完整 reference。
+先看与你任务匹配的层级；只有需要时再进入完整 reference。
 
-- [Usage](docs/usage.md): ordinary daily operation, first maintenance loops, safe approvals, and normal capability-pack use.
-- [Commands](docs/commands.md): short Skill-facing intents and CLI fallback reference.
-- [Deployment](docs/deployment.md): fresh install, runtime target changes, Trae setup, sync, status, repair, and cross-machine restore.
-- [Philosophy](docs/philosophy.md): why this project exists.
-- [System Design](docs/system-design.md): complete architecture, boundaries, lifecycle, and governance reference.
-- [Lifecycle Compatibility](docs/lifecycle-compatibility.md): how the full loop maps across agent systems.
+| Tier | Start here | When to use it | 中文 |
+| --- | --- | --- | --- |
+| Beginner / first value | This README | Minimal onboarding, one representative harvest/review scenario, visible outcome, verification, and next safe step. | 新手 first value：最小 onboarding、一个 harvest/review 场景、可见结果、验证和下一步。 |
+| Ordinary daily operation | [Usage](docs/usage.md), [Commands](docs/commands.md) | Daily status, refresh, harvest, review, publish, normal runtime/generated checks, and normal capability-pack consumption. | 普通日常：status、refresh、harvest、review、publish、runtime/generated 检查和普通 capability-pack 使用。 |
+| Complete / power-user reference | [Deployment](docs/deployment.md), [System Design](docs/system-design.md), [Lifecycle Compatibility](docs/lifecycle-compatibility.md) | Full runtime setup/repair, architecture boundaries, lifecycle/governance, advanced/debug workflows, and maintainer decisions. | 完整/高级参考：runtime setup/repair、architecture boundaries、lifecycle/governance、advanced/debug workflows 和 maintainer decisions。 |
+
+Additional references:
+
+补充参考：
+
 - [Offline Sync](docs/offline-sync.md): snapshot and remote sync strategy.
-- [Roadmap](docs/roadmap.md): project planning and milestone history.
+- [Runtime Adapter Framework And Trae](docs/runtime-adapter-framework-and-trae.md): runtime adapter framework and Trae support reference.
 - [Standards and Sources](docs/standards-and-sources.md): external conventions and adapter standards.
+- [Roadmap](docs/roadmap.md): project planning and milestone history.
+- [Philosophy](docs/philosophy.md): why this project exists.
+
+Planning/evidence docs such as [Memory System Handoff Dump](docs/memory-system-handoff-dump.md) are not beginner or ordinary-user operating guides.
+
+[Memory System Handoff Dump](docs/memory-system-handoff-dump.md) 等 planning/evidence docs 不是 beginner 或 ordinary-user operating guides。

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -41,6 +41,10 @@ The commands below are secondary. Use them when you explicitly need power-user m
 
 下面的命令是 secondary。只有在你明确需要 power-user maintenance、transfer review、runtime repair、import review 或 deterministic CLI/debug evidence 时再使用。
 
+For complete reference material, use the complete/power-user reference map in [Usage](usage.md), [Deployment](deployment.md), and the relevant workflow docs. Do not treat this section as the beginner or ordinary-user first path.
+
+完整 reference material 请看 [Usage](usage.md) 中的 complete/power-user reference map、[Deployment](deployment.md) 和相关 workflow docs。不要把本节当作 beginner 或 ordinary-user first path。
+
 | Command | 中文 | Meaning / 说明 |
 |---|---|---|
 | `discover capability packs` | `发现 capability pack` | Power-user diagnostic flow: find higher-level reusable capability bundles and produce candidates only.<br>power-user diagnostic flow：发现更高层的 reusable capability bundle；只产出 candidates。 |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,6 +4,10 @@ Agent Foundry is local-first. Core tooling, User Vault records, generated output
 
 Agent Foundry 是 local-first 系统。Core tooling、User Vault records、generated output、runtime receipts 和已安装的 runtime files 是不同层。
 
+Use this as the complete deployment/runtime/status/repair guide. For ordinary daily operation, start with [Usage](usage.md) and [Commands](commands.md); return here when you need full install, runtime target changes, Trae setup, repair, or cross-machine restore.
+
+本文件是完整 deployment/runtime/status/repair guide。普通日常操作先看 [Usage](usage.md) 和 [Commands](commands.md)；需要完整安装、runtime target changes、Trae setup、repair 或 cross-machine restore 时再回到这里。
+
 ## Layers / 分层
 
 - Core checkout: public repo with `workflows/`, `schemas/`, `scripts/`, `templates/`, `docs/`, adapter profiles, runtime templates, and validation tooling.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -328,6 +328,25 @@ Runtime files still need the normal publish, dry-run install, status, and review
 
 Runtime files 仍然需要走正常的 publish、dry-run install、status 和 reviewed apply path。ChatGPT 仍然是 manual import。
 
+## Complete And Power-User References / 完整与高级参考
+
+Use these references when ordinary daily operation is not enough. They are discoverable from normal docs, but they are not prerequisites for the beginner README path.
+
+当普通日常操作不够用时，再使用这些 reference。它们可以从普通 docs 找到，但不是 beginner README path 的前置要求。
+
+| Need | Reference | Boundary / 边界 |
+| --- | --- | --- |
+| Fresh install, runtime target changes, Trae setup, status repair, cross-machine restore | [Deployment](deployment.md) | Full deployment/runtime guide. Runtime writes still require reviewed dry-run/status and approval where needed.<br>完整 deployment/runtime guide。Runtime writes 仍需要 reviewed dry-run/status，并在需要时取得 approval。 |
+| Runtime adapter framework and Trae details | [Runtime Adapter Framework And Trae](runtime-adapter-framework-and-trae.md) | Specialized runtime reference; do not use it as beginner onboarding.<br>专门 runtime reference；不要当作 beginner onboarding。 |
+| Capability-pack maintenance, candidate discovery, export/import, split, merge, or lifecycle review | [Capability pack workflows](../workflows/discover-capability-packs.md), [Lifecycle](../workflows/manage-capability-pack-lifecycle.md), [Export/Import](../workflows/export-import-capability-packs.md) | Maintainer/reference material. Normal pack use stays in the Skill-facing requests above.<br>Maintainer/reference material。普通 pack 使用仍留在上方 Skill-facing requests。 |
+| GitHub issue, PR, Project, and role handoff helper adoption | [GitHub Collaboration Helper](../workflows/github-collaboration-helper.md), [Coordinate Agent Work](../workflows/coordinate-agent-work.md) | Adopter/power-user reference. It is not part of the first-value path.<br>Adopter/power-user reference。它不是 first-value path 的一部分。 |
+| Architecture, source-of-truth boundaries, lifecycle, governance, standards | [System Design](system-design.md), [Lifecycle Compatibility](lifecycle-compatibility.md), [Standards and Sources](standards-and-sources.md) | Complete reference/spec material.<br>完整 reference/spec material。 |
+| Roadmap, stage history, and future memory-system planning evidence | [Roadmap](roadmap.md), [Roadmap details](roadmap/), [Memory System Handoff Dump](memory-system-handoff-dump.md) | Planning/evidence docs. They should not be treated as current operating instructions or memory-system implementation authorization.<br>Planning/evidence docs。不要把它们当作当前 operating instructions 或 memory-system implementation authorization。 |
+
+Final AF12 readiness evidence should trace the beginner README path, this ordinary-user daily path, runtime/generated status and repair boundaries, normal capability-pack consumption, GitHub helper adopter reference path, and bilingual spot-checks for touched user-facing docs. That readiness evidence belongs to the final walkthrough gate, not to ordinary daily operation.
+
+最终 AF12 readiness evidence 应能追踪 beginner README path、这里的 ordinary-user daily path、runtime/generated status 和 repair boundaries、normal capability-pack consumption、GitHub helper adopter reference path，以及 touched user-facing docs 的 bilingual spot-check。该 readiness evidence 属于 final walkthrough gate，不属于普通日常操作。
+
 ## Harvest Practices / 沉淀 Practices
 
 Use this after coding, design, debugging, or coordination work when reusable lessons should become durable practices.


### PR DESCRIPTION
## Summary

Implements #247 by placing complete/power-user references and cleaning up docs navigation while preserving the #243 three-tier IA.

Changed surfaces:
- `README.md`: replaces the flat documentation list with a Beginner / Ordinary / Complete-power-user navigation table and keeps planning/evidence docs out of beginner/ordinary operation.
- `docs/usage.md`: adds a complete/power-user reference map covering deployment/runtime, capability-pack maintenance, GitHub helper adoption, architecture/spec, roadmap, and planning/evidence docs.
- `docs/commands.md`: marks advanced/debug commands as secondary and points to the complete reference map.
- `docs/deployment.md`: clarifies this is the complete deployment/runtime/status/repair guide, not the ordinary daily starting point.

## #244 readiness inputs

The docs now make the final walkthrough inputs traceable: beginner README path, ordinary-user daily path, runtime/generated status and repair boundaries, normal capability-pack consumption, GitHub helper adopter reference path, and bilingual spot-checks for touched user-facing docs. This PR does not claim final readiness or implement #244.

## Verification

- `python3 scripts/check_consistency.py`
- `git diff --check origin/codex/af12-docs-ux`
- targeted grep/read-through for complete/power-user reference discoverability, beginner path not polluted, #243 IA preservation, #244 traceability, and no final readiness claim

## Boundaries

No new docs site or separate repository, generated Skill/adapter publish, live Vault/private-state/runtime/generated mutation, final `main` integration, #244 implementation, #226/#227 closure, memory-system work, or destructive action.

Next owner: Reviewer.