### PR TITLE
Improve starter pack user-value descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ Current official starter packs:
 
 当前 official starter packs：
 
-| Pack | Purpose / 用途 |
-| --- | --- |
-| `pack.bootstrap.minimal` | Minimal bootstrap capability; required before optional packs. / 最小 bootstrap capability；optional packs 前需要先具备它。 |
-| `pack.multi-agent.optional` | GitHub issue/PR collaboration starter. / GitHub issue/PR 协作 starter。 |
+| Pack | What you get / 获得什么 | Choose it when / 适合什么情况 |
+| --- | --- | --- |
+| `pack.bootstrap.minimal` | A small baseline for safe harvest, review, refresh, status, and source-of-truth boundaries. / 用于安全 harvest、review、refresh、status 和 source-of-truth boundaries 的小型 baseline。 | Accept it for a new selected Vault or before any optional pack; it does not install runtimes or publish generated adapters by itself. / 新 selected Vault 或安装 optional pack 前接受它；它本身不会安装 runtimes 或发布 generated adapters。 |
+| `pack.multi-agent.optional` | GitHub issue/PR collaboration habits: role labels, durable comments, Execution Contracts, and review handoff. / GitHub issue/PR 协作习惯：role labels、durable comments、Execution Contracts 和 review handoff。 | Install it when you coordinate work through GitHub issues and PRs; skip it for solo local usage or projects without GitHub collaboration. / 当你通过 GitHub issues 和 PRs 协调工作时安装；纯本地单人使用或没有 GitHub 协作的项目可以跳过。 |
 
 Use Skill-facing requests first: `list capability packs`, `recommend capability packs for my setup`, `preview capability pack deployment <pack-path>`, `apply reviewed capability pack <pack-path>`, `verify capability pack <pack-id>`, `update capability pack <pack-id-or-path>`, and `disable capability pack <pack-id>`.
 

--- a/catalog/capability-packs/pack.bootstrap.minimal/README.md
+++ b/catalog/capability-packs/pack.bootstrap.minimal/README.md
@@ -6,6 +6,62 @@ This catalog page is discoverability metadata only. The reviewed manifest is
 `fixtures/capability-packs/bootstrap-minimal/manifest.yaml`; the catalog pins
 that manifest by SHA-256 in `catalog/capability-packs/index.yaml`.
 
+## User Value / 用户价值
+
+`pack.bootstrap.minimal` gives a new Agent Foundry setup a small, reviewed
+baseline before optional packs are considered. It helps users keep harvest,
+review, refresh, status, and source-of-truth behavior consistent instead of
+learning those boundaries one script at a time.
+
+`pack.bootstrap.minimal` 为新的 Agent Foundry setup 提供一个小型、reviewed 的
+baseline，然后再考虑 optional packs。它帮助用户保持 harvest、review、refresh、
+status 和 source-of-truth behavior 一致，而不是逐个脚本学习这些 boundaries。
+
+## Concrete Function / 具体功能
+
+This pack carries the bootstrap capability and `ASSET-META-001` governance
+baseline. It orients the user around the selected User Vault as the accepted
+deployment target, Core as public catalog/tooling, Generated and Runtime as
+downstream status or install surfaces, and Local Private evidence as excluded
+from pack authority.
+
+这个 pack 携带 bootstrap capability 和 `ASSET-META-001` governance baseline。
+它让用户明确 selected User Vault 是 accepted deployment target，Core 是 public
+catalog/tooling，Generated 和 Runtime 是 downstream status 或 install surfaces，
+Local Private evidence 不属于 pack authority。
+
+## What It Enables Next / 接下来能启用什么
+
+After bootstrap is accepted, users can safely preview optional starter packs,
+verify deployed pack state, compare updates, disable a pack through a reviewed
+path, and inspect generated/runtime follow-up without treating those downstream
+surfaces as source of truth.
+
+接受 bootstrap 后，用户可以安全 preview optional starter packs、verify deployed
+pack state、compare updates、通过 reviewed path disable pack，并查看 generated/runtime
+follow-up，同时不会把这些 downstream surfaces 当成 source of truth。
+
+## What It Does Not Do / 不做什么
+
+This pack does not create a separate architecture-boundary starter pack, install
+runtime files, publish generated adapters, export a private Vault, or make
+project-specific governance decisions. It does not duplicate `ASSET-META-001`;
+it preserves that baseline in the bootstrap path.
+
+这个 pack 不会创建单独的 architecture-boundary starter pack，不会安装 runtime
+files、发布 generated adapters、export private Vault，也不会替项目做 project-specific
+governance decisions。它不会复制 `ASSET-META-001`；它在 bootstrap path 中保留该
+baseline。
+
+## When To Accept / 何时接受安装
+
+Accept or install this pack when you are setting up a selected User Vault for
+normal Agent Foundry use, before installing optional packs, or when you need to
+restore the baseline boundary guidance for harvest/review/status workflows.
+
+当你为正常 Agent Foundry 使用设置 selected User Vault、准备安装 optional packs，
+或需要恢复 harvest/review/status workflows 的 baseline boundary guidance 时，接受或安装这个 pack。
+
 ## Authority
 
 - Core hosts this official catalog entry and reviewed manifest reference.

--- a/catalog/capability-packs/pack.multi-agent.optional/README.md
+++ b/catalog/capability-packs/pack.multi-agent.optional/README.md
@@ -9,6 +9,64 @@ continue to exercise the same compatibility path. The pack is discoverable as a
 first-party starter, while its member records still deploy as manual-review
 candidate records in the selected User Vault.
 
+## User Value / 用户价值
+
+`pack.multi-agent.optional` helps teams use Agent Foundry with GitHub issues
+and pull requests without losing handoff context between Implementer, Reviewer,
+Architect, Coordinator, and Human decision points. Its value is repeatable
+collaboration discipline, not automatic project management.
+
+`pack.multi-agent.optional` 帮助团队把 Agent Foundry 用在 GitHub issues 和 pull
+requests 上，并在 Implementer、Reviewer、Architect、Coordinator 和 Human decision
+points 之间保留 handoff context。它的价值是可重复的协作纪律，而不是自动项目管理。
+
+## Supported Workflow / 支持的协作流程
+
+The pack supports GitHub issue/PR collaboration with role labels, durable issue
+comments, explicit Execution Contracts, dependency-gated queues, review
+handoffs, and read-only audit before write automation. It is useful when work
+must move between multiple role sessions while GitHub remains the durable source
+of truth.
+
+这个 pack 支持使用 role labels、durable issue comments、explicit Execution Contracts、
+dependency-gated queues、review handoffs，以及 write automation 前的 read-only audit
+来进行 GitHub issue/PR 协作。当工作需要在多个 role sessions 之间流转，并且 GitHub
+仍然是 durable source of truth 时，它最有用。
+
+## What Remains Manual Or Review-Gated / 仍需手动或 Review-Gated 的内容
+
+People or delegated workflow roles still decide scope, architecture direction,
+dependency release, merge authorization, issue closure, and any action that
+changes protected branches or crosses privacy/security boundaries. Project v2
+may mirror status when configured, but labels and durable comments remain the
+handoff mechanism.
+
+Scope、architecture direction、dependency release、merge authorization、issue
+closure，以及任何修改 protected branches 或跨越 privacy/security boundaries 的动作，
+仍由人或被委托的 workflow roles 决定。Project v2 可在配置后 mirror status，但 labels
+和 durable comments 仍是 handoff mechanism。
+
+## What It Does Not Automate / 不自动化什么
+
+This pack does not merge PRs, close issues, create hidden access control, apply
+runtime helpers, publish generated Skills, mutate Project v2 by default, export
+private Vault content, or treat local helper receipts as authority.
+
+这个 pack 不会 merge PRs、close issues、创建隐藏 access control、apply runtime
+helpers、publish generated Skills、默认 mutate Project v2、export private Vault
+content，也不会把 local helper receipts 当成 authority。
+
+## When To Accept / 何时接受安装
+
+Accept or install this pack when a project coordinates implementation and
+review through GitHub issues/PRs and needs durable role handoffs. Skip it when a
+project is single-user, local-only, or not ready to use GitHub labels and issue
+comments as the workflow record.
+
+当项目通过 GitHub issues/PRs 协调 implementation 和 review，并需要 durable role
+handoffs 时，接受或安装这个 pack。若项目是单人、本地-only，或尚未准备好把 GitHub
+labels 和 issue comments 作为 workflow record，可以跳过它。
+
 ## Authority
 
 - Core hosts this official catalog entry and reviewed manifest reference.


### PR DESCRIPTION
## Scope

Implements #260 by improving user-facing decision support for the current-stage first-party Core starter pack set.

Changed surfaces:
- `README.md`: replaces the thin starter-pack purpose table with concise decision support for what users get and when to choose each pack.
- `catalog/capability-packs/pack.bootstrap.minimal/README.md`: adds fuller value/function/enables-next/does-not-do/when-to-accept guidance.
- `catalog/capability-packs/pack.multi-agent.optional/README.md`: adds fuller value/supported-workflow/manual-or-review-gated/does-not-automate/when-to-accept guidance.

## Verification

- `python3 scripts/check_consistency.py`
- `python3 scripts/test_advanced_capability_workflow_surface.py`
- `python3 scripts/check_capability_pack_fixtures.py`
- `git diff --check origin/codex/af12-starter-packs...HEAD`
- Targeted grep/read-through confirmed:
  - README has concise decision support without becoming schema/reference docs.
  - Catalog README pages carry fuller value/function/does-not-do/when-to-install details.
  - `pack.architecture-boundary-review.starter` is not reintroduced.
  - selected User Vault authority and Generated/Runtime/Local Private boundaries remain safe.

## Boundaries

- No final `main` integration.
- No #255 final readiness review.
- No #226/#227 closure.
- No live Vault/runtime/generated/private mutation.
- No generated Skill/adapter publish.
- No real pack activation/export/import/deploy.
- No memory-system work.
- No destructive action.

## Residual Risks

- This is documentation/user-value clarification only; executable pack install/apply behavior is unchanged.
- Final AF12-3 readiness remains owned by #255 after review/acceptance of this correction.
