### PR TITLE
Add AF10 pilot workflow instrumentation fields

### DIFF
--- a/scripts/github_collaboration_helper.py
+++ b/scripts/github_collaboration_helper.py
@@ -918,6 +918,27 @@ def comparison_telemetry_block(args: argparse.Namespace) -> str:
     user_visible_scope: {str(args.user_visible_scope).lower()}
     risk_class: {args.risk_class}
     human_gate_count: {args.human_gate_count}
+  instrumentation:
+    observed_counter_available: {str(args.observed_counter_available).lower()}
+    observed_counter_source: "{args.observed_counter_source}"
+    elapsed_time_available: {str(args.elapsed_time_available).lower()}
+    elapsed_time_source: "{args.elapsed_time_source}"
+    github_api_read_attempts: "{args.github_api_read_attempts}"
+    github_api_failures: "{args.github_api_failures}"
+    project_read_attempts: "{args.project_read_attempts}"
+    project_write_attempts: "{args.project_write_attempts}"
+    fallback_review_used: {str(args.fallback_review_used).lower()}
+    fallback_review_reason: "{args.fallback_review_reason}"
+    hdc_superseded_count: {args.hdc_superseded_count}
+    label_cleanup_count: {args.label_cleanup_count}
+    source_threads_count: "{args.source_threads_count}"
+    dispatch_mechanisms: "{args.dispatch_mechanisms}"
+    durable_links_count:
+      issues: "{args.durable_issue_links}"
+      pull_requests: "{args.durable_pr_links}"
+      comments: "{args.durable_comment_links}"
+    closure_sync_passes: {args.closure_sync_passes}
+    stale_state_repairs: {args.stale_state_repairs}
   single_agent_baseline:
     source: {args.single_agent_source}
     transitions: {single_agent_transitions}
@@ -1163,6 +1184,25 @@ def add_comparison_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--user-visible-scope", action="store_true")
     parser.add_argument("--risk-class", choices=["low", "medium", "high", "mixed"], default="medium")
     parser.add_argument("--human-gate-count", type=int, default=0)
+    parser.add_argument("--observed-counter-available", action="store_true")
+    parser.add_argument("--observed-counter-source", default="not_available")
+    parser.add_argument("--elapsed-time-available", action="store_true")
+    parser.add_argument("--elapsed-time-source", default="not_available")
+    parser.add_argument("--github-api-read-attempts", default="unknown")
+    parser.add_argument("--github-api-failures", default="unknown")
+    parser.add_argument("--project-read-attempts", default="unknown")
+    parser.add_argument("--project-write-attempts", default="unknown")
+    parser.add_argument("--fallback-review-used", action="store_true")
+    parser.add_argument("--fallback-review-reason", default="not_available")
+    parser.add_argument("--hdc-superseded-count", type=int, default=0)
+    parser.add_argument("--label-cleanup-count", type=int, default=0)
+    parser.add_argument("--source-threads-count", default="unknown")
+    parser.add_argument("--dispatch-mechanisms", default="unknown")
+    parser.add_argument("--durable-issue-links", default="unknown")
+    parser.add_argument("--durable-pr-links", default="unknown")
+    parser.add_argument("--durable-comment-links", default="unknown")
+    parser.add_argument("--closure-sync-passes", type=int, default=0)
+    parser.add_argument("--stale-state-repairs", type=int, default=0)
     parser.add_argument("--single-agent-source", choices=["observed", "estimated", "unavailable"], default="estimated")
     parser.add_argument("--single-agent-transitions", type=int, default=1)
     parser.add_argument("--single-agent-none-rehydrates", type=int, default=1)

--- a/scripts/test_github_collaboration_helper.py
+++ b/scripts/test_github_collaboration_helper.py
@@ -503,6 +503,43 @@ def main() -> int:
         )
         errors.extend(
             expect_ok(
+                "comparison-draft-instrumentation-defaults",
+                run(["comparison-draft", "--subject", "AF10 #264 instrumentation defaults"], base),
+                "github_api_read_attempts: \"unknown\"",
+            )
+        )
+        errors.extend(
+            expect_ok(
+                "comparison-draft-instrumentation-boundaries",
+                run(["comparison-draft", "--subject", "AF10 #264 instrumentation defaults"], base),
+                "observed_counter_source: \"not_available\"",
+            )
+        )
+        errors.extend(
+            expect_ok(
+                "comparison-draft-fallback-review",
+                run(
+                    [
+                        "comparison-draft",
+                        "--subject",
+                        "AF10 #264 fallback review",
+                        "--fallback-review-used",
+                        "--fallback-review-reason",
+                        "reviewer_thread_unavailable",
+                        "--project-read-attempts",
+                        "3",
+                        "--github-api-failures",
+                        "2",
+                        "--durable-comment-links",
+                        "5",
+                    ],
+                    base,
+                ),
+                "fallback_review_reason: \"reviewer_thread_unavailable\"",
+            )
+        )
+        errors.extend(
+            expect_ok(
                 "comparison-draft-three-modes",
                 run(["comparison-draft", "--subject", "AF10 #215"], base),
                 "unoptimized_collaboration_counterfactual:",

--- a/templates/github-role-routing.template.yaml
+++ b/templates/github-role-routing.template.yaml
@@ -68,10 +68,30 @@ telemetry:
   required_for_meaningful_transitions: true
   workflow: "workflows/coordinate-agent-work.md"
   supports_workflow_comparison: true
+  supports_improved_pilot_instrumentation: true
   comparison_modes:
     - single_agent_baseline
     - unoptimized_collaboration_counterfactual
     - optimized_collaboration_observed
+  next_pilot_fields:
+    observed_counter_available: optional
+    observed_counter_source: optional
+    elapsed_time_available: optional
+    elapsed_time_source: optional
+    github_api_read_attempts: optional
+    github_api_failures: optional
+    project_read_attempts: optional
+    project_write_attempts: optional
+    fallback_review_used: optional
+    fallback_review_reason: optional
+    hdc_superseded_count: optional
+    label_cleanup_count: optional
+    source_threads_count: optional
+    dispatch_mechanism: optional
+    durable_links_count: optional
+    closure_sync_passes: optional
+    stale_state_repairs: optional
+  unknown_value_policy: "use unknown or not_available instead of guessing"
   ledger_parent_issue: "<parent-issue-number>"
   skip_rule: "only trivial comments may skip telemetry with an explicit reason"
 

--- a/workflows/coordinate-agent-work.md
+++ b/workflows/coordinate-agent-work.md
@@ -63,6 +63,30 @@ workflow_telemetry:
     labels_added: 1
     labels_removed: 1
     project_writes: 0
+  retry_and_fallback:
+    github_api_read_attempts: 1
+    github_api_failures: 0
+    project_read_attempts: 1
+    project_write_attempts: 0
+    fallback_review_used: false
+    fallback_review_reason: null
+  workflow_state_corrections:
+    hdc_superseded_count: 0
+    label_cleanup_count: 0
+    closure_sync_passes: 0
+    stale_state_repairs: 0
+  dispatch_and_links:
+    source_threads_count: 1
+    dispatch_mechanism: live_thread_dispatch | github_comment | generated_note | portable_prompt | none
+    durable_links_count:
+      issues: 1
+      pull_requests: 1
+      comments: 2
+  observed_counters:
+    observed_counter_available: false
+    observed_counter_source: null
+    elapsed_time_available: false
+    elapsed_time_source: null
   estimated_tokens:
     input: 8000-12000
     output: 1000-2500
@@ -89,9 +113,15 @@ Use these fields whenever telemetry is included:
 Use these when the information is reasonably available:
 
 - `rehydration_sources`
+- `retry_and_fallback`
+- `workflow_state_corrections`
+- `dispatch_and_links`
+- `observed_counters`
 - `estimated_tokens`
 - `reason_full_rehydrate_required`
 - `notes`
+
+Use `unknown` or `not_available` rather than guessing when a counter cannot be observed in the current runtime. `observed_counters` are calibration evidence only; they do not replace `estimated_tokens` and must not be added to estimate totals unless a later reviewed workflow defines a compatible accounting unit.
 
 ## Transition Types
 
@@ -287,6 +317,27 @@ workflow_cost_ledger:
     value: unknown
     source: null
     notes: "Optional observed thread/goal counter; do not add to estimate totals."
+  instrumentation:
+    observed_counter_available: false
+    observed_counter_source: null
+    elapsed_time_available: false
+    elapsed_time_source: null
+    github_api_read_attempts: unknown
+    github_api_failures: unknown
+    project_read_attempts: unknown
+    project_write_attempts: unknown
+    fallback_review_used: false
+    fallback_review_reason: null
+    hdc_superseded_count: 0
+    label_cleanup_count: 0
+    source_threads_count: unknown
+    dispatch_mechanisms: []
+    durable_links_count:
+      issues: unknown
+      pull_requests: unknown
+      comments: unknown
+    closure_sync_passes: 0
+    stale_state_repairs: 0
   overhead_notes: []
 ```
 
@@ -304,6 +355,27 @@ workflow_comparison_telemetry:
     user_visible_scope: false
     risk_class: low | medium | high | mixed
     human_gate_count: 0
+  instrumentation:
+    observed_counter_available: false
+    observed_counter_source: null
+    elapsed_time_available: false
+    elapsed_time_source: null
+    github_api_read_attempts: unknown
+    github_api_failures: unknown
+    project_read_attempts: unknown
+    project_write_attempts: unknown
+    fallback_review_used: false
+    fallback_review_reason: null
+    hdc_superseded_count: 0
+    label_cleanup_count: 0
+    source_threads_count: unknown
+    dispatch_mechanisms: []
+    durable_links_count:
+      issues: unknown
+      pull_requests: unknown
+      comments: unknown
+    closure_sync_passes: 0
+    stale_state_repairs: 0
   single_agent_baseline:
     source: observed | estimated | unavailable
     transitions: 0
@@ -376,6 +448,8 @@ workflow_comparison_telemetry:
     confidence: low | medium | high
     notes: "Decision-support estimate, not billing-grade accounting."
 ```
+
+The `instrumentation` block is intentionally separate from `ledger_estimated_tokens` and `observed_goal_tokens`. It records whether the workflow captured enough operational evidence to compare routes later. `unknown` means the workflow did not capture that value; `not_available` means the runtime or tool surface did not expose it; `0` means it was measured and did not occur.
 
 ### Comparison Rules
 


### PR DESCRIPTION
## Summary

Closes #264.

Adds the improved workflow instrumentation fields requested by #263/#264 so the next substantial pilot can record more meaningful coordination telemetry before any local collaboration ledger / Foundry Board decision.

## Changes

- Extends `workflow_telemetry`, `workflow_cost_ledger`, and `workflow_comparison_telemetry` guidance with:
  - observed counter availability/source;
  - elapsed time availability/source;
  - GitHub API and Project read/write attempt/failure counters;
  - fallback review and HDC supersession counts;
  - label cleanup, source thread, durable link, closure sync, and stale repair counters.
- Updates `templates/github-role-routing.template.yaml` to advertise improved pilot instrumentation support and unknown/not_available policy.
- Updates `comparison-draft` to emit the instrumentation block with conservative defaults.
- Adds regression coverage for default unknown/not_available values and fallback-review fields.

## Verification

- `python3 -m py_compile scripts/github_collaboration_helper.py scripts/test_github_collaboration_helper.py`
- `python3 scripts/test_github_collaboration_helper.py`
- `python3 scripts/check_consistency.py`
- `git diff --check HEAD~1..HEAD`

## Boundaries

- No local collaboration ledger / Foundry Board implementation.
- No memory-system work.
- No runtime/global/Vault/private/generated mutation.
- No generated adapter publish.
- No Project v2 write helper.
- No billing-grade token accounting claim.
- Existing roadmap local changes were not included in this PR.
