### PR TITLE
Publish harvested practice activation updates

### DIFF
--- a/adapters/chatgpt/custom-instructions.md
+++ b/adapters/chatgpt/custom-instructions.md
@@ -6,7 +6,7 @@ Use the project/custom GPT knowledge files for full fidelity. Do not rely only o
 
 When the work happens in another project, that project is evidence source only. Locate the Agent Foundry Vault through `AGENT_FOUNDRY_HOME`, `~/.agent-foundry/config.yaml`, or validated project knowledge before proposing canonical changes.
 
-Published assets include ASSET-META-001 Practice Harvester, ASSET-ARCH-001 Architecture Design, ASSET-COLLAB-001 Agent Collaboration, and ASSET-IMPL-001 Provider Integration Playbook. Core Foundry practices include META-001 through META-013. Cross-project governance practices include GOV-001 through GOV-006. Runtime practices include RUNTIME-001 through RUNTIME-004.
+Published assets include ASSET-META-001 Practice Harvester, ASSET-ARCH-001 Architecture Design, ASSET-COLLAB-001 Agent Collaboration, and ASSET-IMPL-001 Provider Integration Playbook. Core Foundry practices include META-001 through META-013. Cross-project governance practices include GOV-001 through GOV-006. Runtime practices include RUNTIME-001 through RUNTIME-005.
 
 ## Routing (META-008)
 
@@ -24,7 +24,6 @@ Before substantial changes, check:
 - Transient memory or chat summary used as fact? Apply GOV-003.
 - Writing into user-owned runtime or agent configuration? Apply GOV-004 and RUNTIME-001.
 - Syncing, publishing, or installing adapters? Apply RUNTIME-003.
-- Producing rendered or converted output? Apply TEST-001.
 - Producing packaged desktop/runtime artifacts? Apply TEST-003.
 - Building a background, tray, menu bar, or ambient app? Apply PROD-001.
 - Designing diagnostics for a fragile integration, parser, capture, import, or local automation flow? Apply DEBUG-001.
@@ -71,6 +70,8 @@ When publishing adapters, apply META-009: verify executable adapter fidelity sig
 When reviewing assets, apply META-010: use lifecycle state, usage evidence, overlap, canonical coverage, stale triggers, and published targets before recommending keep, revise, deprecate, archive, split, or merge.
 
 When recording or reviewing usage evidence, apply RUNTIME-004: keep raw logs local, sync sanitized aggregate usage rows for cross-machine review, and do not let missed activation or other review-only signals inflate usage counts.
+
+For ordinary scratch file operations wholly inside `/tmp`, `/private/tmp`, or the current process temporary directory, apply RUNTIME-005: do not request separate approval for that reason alone. This does not cover broad destructive deletes, secrets/private data export, runtime/global config writes, network/downloads, GitHub mutations, data migration, permission changes, or paths outside temporary scratch space.
 
 For GitHub and multi-agent collaboration, use the Agent Collaboration asset ASSET-COLLAB-001. It applies COLLAB-001 through COLLAB-012 and COLLAB-014:
 

--- a/adapters/claude-code/CLAUDE.md
+++ b/adapters/claude-code/CLAUDE.md
@@ -10,7 +10,7 @@ Before acting on a request, classify user intent:
 
 - If the user asks to **execute a repeatable workflow** (harvest, design architecture, collaborate on a PR), match the request to an asset trigger and invoke the asset. During execution, reference the canonical practices the asset lists.
 - If the user asks to **apply a constraint or change behavior** ("stop doing X", "always do Y"), match the request to a canonical practice and apply its Principle and Guidance. Do not invoke an asset for a one-off behavioral correction.
-- If the user asks to **update or govern agent knowledge**, invoke the Practice Harvester asset (ASSET-META-001, META-001 through META-013, GOV-001 through GOV-006, RUNTIME-001 through RUNTIME-004).
+- If the user asks to **update or govern agent knowledge**, invoke the Practice Harvester asset (ASSET-META-001, META-001 through META-013, GOV-001 through GOV-006, RUNTIME-001 through RUNTIME-005).
 
 Assets perform work; practices govern rules. Do not conflate them.
 
@@ -23,7 +23,6 @@ Before substantial changes, check:
 - Transient memory or chat summary used as fact? Apply GOV-003.
 - Writing into user-owned runtime or agent configuration? Apply GOV-004 and RUNTIME-001.
 - Syncing, publishing, or installing adapters? Apply RUNTIME-003.
-- Producing rendered or converted output? Apply TEST-001.
 - Producing packaged desktop/runtime artifacts? Apply TEST-003.
 - Building a background, tray, menu bar, or ambient app? Apply PROD-001.
 - Designing diagnostics for a fragile integration, parser, capture, import, or local automation flow? Apply DEBUG-001.
@@ -96,6 +95,8 @@ Apply META-010 when reviewing assets: use lifecycle state, usage evidence, overl
 Apply META-011 through META-013 during harvest: route artifacts before abstracting practices, treat user method corrections as process evidence before domain content, require insights to pass a generalization gate before they become practice candidates, and do not convert approval of a direction into approval to bypass an unshown review list.
 
 Apply RUNTIME-004 when recording or reviewing usage evidence: raw logs stay local under `usage/local/`; shared review uses sanitized aggregate rows in `usage/usage-aggregate.yaml`; missed activation and other review-only signals must not inflate shared usage counts.
+
+Apply RUNTIME-005 for ordinary scratch file operations wholly inside `/tmp`, `/private/tmp`, or the current process temporary directory: do not request separate approval for that reason alone. This does not cover broad destructive deletes, secrets/private data export, runtime/global config writes, network/downloads, GitHub mutations, data migration, permission changes, or paths outside temporary scratch space.
 
 ## External Skills
 

--- a/adapters/codex/skills/practice-harvester/SKILL.md
+++ b/adapters/codex/skills/practice-harvester/SKILL.md
@@ -7,7 +7,7 @@ description: Use when the user says "harvest practices", "harvest skills", "harv
 
 This skill maintains Agent Foundry, the user's canonical capability system.
 
-Asset ID: ASSET-META-001. Canonical constraints include META-001 through META-013, GOV-001 through GOV-006, and RUNTIME-001 through RUNTIME-004.
+Asset ID: ASSET-META-001. Canonical constraints include META-001 through META-013, GOV-001 through GOV-006, and RUNTIME-001 through RUNTIME-005.
 
 ## Asset vs Practice
 
@@ -22,7 +22,6 @@ Before substantial changes, check:
 - Transient memory or chat summary used as fact? Apply GOV-003.
 - Writing into user-owned runtime or agent configuration? Apply GOV-004 and RUNTIME-001.
 - Syncing, publishing, or installing adapters? Apply RUNTIME-003.
-- Producing rendered or converted output? Apply TEST-001.
 
 ## Short Commands
 

--- a/adapters/hermes/skills/practice-harvester/SKILL.md
+++ b/adapters/hermes/skills/practice-harvester/SKILL.md
@@ -7,7 +7,7 @@ description: Use when the user says "harvest practices", "harvest skills", "harv
 
 This skill maintains Agent Foundry, the user's canonical capability system.
 
-Asset ID: ASSET-META-001. Canonical constraints include META-001 through META-013, GOV-001 through GOV-006, and RUNTIME-001 through RUNTIME-004.
+Asset ID: ASSET-META-001. Canonical constraints include META-001 through META-013, GOV-001 through GOV-006, and RUNTIME-001 through RUNTIME-005.
 
 ## Asset vs Practice
 
@@ -22,7 +22,6 @@ Before substantial changes, check:
 - Transient memory or chat summary used as fact? Apply GOV-003.
 - Writing into user-owned runtime or agent configuration? Apply GOV-004 and RUNTIME-001.
 - Syncing, publishing, or installing adapters? Apply RUNTIME-003.
-- Producing rendered or converted output? Apply TEST-001.
 
 ## Short Commands
 

--- a/adapters/trae/skills/agent-foundry/SKILL.md
+++ b/adapters/trae/skills/agent-foundry/SKILL.md
@@ -18,7 +18,6 @@ Before substantial changes, check:
 - Transient memory or chat summary used as fact? Apply GOV-003.
 - Writing into user-owned runtime or agent configuration? Apply GOV-004 and RUNTIME-001.
 - Syncing, publishing, or installing adapters? Apply RUNTIME-003.
-- Producing rendered or converted output? Apply TEST-001.
 
 ## Commands
 
@@ -81,4 +80,5 @@ Before substantial changes, check:
 - Use project overlays only when a project needs additional local contract text.
 - Do not write Trae private application state or custom-agent database records.
 - Before runtime writes, use dry-run output and resolve unmanaged or drifted files.
+- For ordinary scratch file operations wholly inside `/tmp`, `/private/tmp`, or the current process temporary directory, apply RUNTIME-005 and do not request separate approval for that reason alone. This does not cover broad destructive deletes, secrets/private data export, runtime/global config writes, network/downloads, GitHub mutations, data migration, permission changes, or paths outside temporary scratch space.
 - Do not start memory-system work unless the user explicitly authorizes that separate stage.


### PR DESCRIPTION
## Summary

Publishes the approved harvest activation changes into Core reference adapters.

- Updates Practice Harvester references from `RUNTIME-001 through RUNTIME-004` to `RUNTIME-001 through RUNTIME-005`.
- Removes `TEST-001` from compact preflight after its approved downgrade to `task_router`.
- Adds concise `RUNTIME-005` scratch-space guidance to relevant direct-agent adapter text.

## Formal Harvest Scope

Canonical Vault counterpart PR:
- farmerhunter/agent-foundry-vault-farmerhunter branch `codex/harvest-runtime005-project-readback`

Approved items represented by this adapter update:
- `COLLAB-008` v10: transition-gated Project enrollment/readback.
- `TEST-001` v2: render verification downgraded from `always_preflight` to `task_router`.
- `RUNTIME-005` v2: `/tmp` scratch-space operations as task-routed approval guidance.

## Verification

- `python3 scripts/check_activation.py`
- `python3 scripts/check_consistency.py`
- `python3 scripts/review_practices.py --today 2026-06-27`
- `python3 scripts/publish_adapters.py --core-root /Users/jinghuliu/Coding/agent-foundry --vault-root /Users/jinghuliu/.agent-foundry/vault/agent-foundry-vault-farmerhunter --output-root /Users/jinghuliu/.agent-foundry/generated/agent-foundry-adapters --apply`
- `python3 scripts/check_adapter_quality.py --core-root /Users/jinghuliu/Coding/agent-foundry --vault-root /Users/jinghuliu/.agent-foundry/vault/agent-foundry-vault-farmerhunter --surface selected-output --generated-root /Users/jinghuliu/.agent-foundry/generated/agent-foundry-adapters`
- `git diff --check`

## Runtime Boundary

Selected-output adapters were regenerated and quality checked. Runtime install/apply was not performed.
