### PR TITLE
Restore RUNTIME-005 bootstrap fixture consistency

### DIFF
--- a/catalog/capability-packs/index.yaml
+++ b/catalog/capability-packs/index.yaml
@@ -8,7 +8,7 @@ entries:
     catalog_status: available
     latest_version: 0.2.0
     manifest_path: fixtures/capability-packs/bootstrap-minimal/manifest.yaml
-    manifest_sha256: 8cb8e4495cd5cc04c9390ce9ec616d5cd3edf3cadf258891d600e8acaf7141ef
+    manifest_sha256: a9c940d7ed56759b70082b973f1fd1591f27dcc6e8b6f7354ce91c297e97240e
     compatibility_summary: "Core schema 1; Vault layout [1]; bootstrap not required."
     compatibility_metadata:
       core_schema_version_min: 1

--- a/fixtures/capability-packs/bootstrap-minimal/manifest.yaml
+++ b/fixtures/capability-packs/bootstrap-minimal/manifest.yaml
@@ -258,6 +258,16 @@ included_records:
     membership_role: bootstrap_required
     activation_default: active
     import_action: create_or_review_update
+  - id: RUNTIME-005
+    kind: practice
+    lifecycle_status: active
+    path: records/practices/RUNTIME-005-treat-tmp-as-preapproved-scratch-space.md
+    source_version: 2
+    content_sha256: "6892eb161e1412ebf5fc5716229b85f900da7ae74fa3a181817f4243a41f572e"
+    destination_layer: canonical_vault_record
+    membership_role: bootstrap_required
+    activation_default: active
+    import_action: create_or_review_update
   - id: ASSET-BOOT-001
     kind: asset
     lifecycle_status: active

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/RUNTIME-005-treat-tmp-as-preapproved-scratch-space.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/RUNTIME-005-treat-tmp-as-preapproved-scratch-space.md
@@ -1,0 +1,68 @@
+---
+id: RUNTIME-005
+title: Treat /tmp as preapproved scratch space
+domain: runtime
+type: principle
+status: active
+version: 2
+created: 2026-06-23
+updated: 2026-06-23
+tags: [runtime, approvals, sandbox, tmp, scratch-space, safety]
+aliases:
+  - RUNTIME-005
+  - tmp is preapproved scratch space
+  - no approval needed for ordinary /tmp file operations
+  - temporary scratch files do not need explicit approval
+related: [RUNTIME-001, RUNTIME-002, GOV-004, IMPL-003]
+applies_when:
+  - creating temporary files for command input, diagnostics, patches, comments, reports, or test artifacts
+  - reading or writing files wholly inside /tmp, /private/tmp, or the current process temporary directory
+  - using temporary body files for CLI commands
+review_required: false
+provenance: "Added from the user's explicit global rule on 2026-06-23: file operations within /tmp do not require separate explicit approval."
+---
+
+## Principle
+
+Treat ordinary file operations wholly inside `/tmp`, `/private/tmp`, or the current process temporary directory as preapproved scratch-space activity. Do not ask for separate explicit approval merely to create, read, update, or use temporary files there.
+
+## Rationale
+
+Temporary scratch files are often the safest way to avoid shell quoting mistakes, preserve bounded command input, capture transient diagnostics, or stage review text before a durable write. Requiring approval for every `/tmp` scratch file creates ceremony without protecting canonical records, runtime configuration, or user-owned project files.
+
+## Guidance
+
+Agents may use `/tmp` for ordinary scratch-space work without an additional approval round when all of the following are true:
+
+- every file path written or modified is wholly inside `/tmp`, `/private/tmp`, or the current process temporary directory;
+- the operation is temporary support for the current task, such as body files, logs, diagnostics, generated previews, local test artifacts, or patch staging;
+- the operation does not write secrets, private raw evidence, credentials, or user data that should not be stored even temporarily;
+- the operation does not affect runtime/global configuration, canonical Agent Foundry records, Git state, remote services, or non-temporary project outputs.
+
+This rule does not override the user's current filesystem sandbox or platform approval mechanism. If the environment requires an explicit tool approval to access `/tmp`, request that approval accurately; do not reinterpret this practice as technical capability.
+
+## Watch Out For
+
+Do not use `/tmp` approval to hide risky work. Broad destructive deletes, recursive cleanup outside a task-owned temporary directory, data migration, private data export, network downloads, runtime installs, GitHub mutations, permission changes, or writes that cross out of `/tmp` still follow the normal approval and risk gates.
+
+Do not persist important project state only in `/tmp`. Durable decisions belong in canonical project records, issues, PRs, commits, or selected Vault entries.
+
+## Example
+
+Creating `/tmp/pr-comment.md` and passing it to `gh pr comment --body-file /tmp/pr-comment.md` does not need a separate approval just because the body file is in `/tmp`. Posting the comment may still require the normal GitHub mutation permission.
+
+Creating `/tmp/agent-foundry-check/report.txt` for a validation summary is ordinary scratch work. Removing the task-owned directory afterward is acceptable if the command is narrowly scoped to that directory; deleting broad patterns such as `/tmp/*` is not covered by this rule.
+
+## Activation
+
+- Tier: task_router
+- Phases: before_file_write, before_command_approval, verification
+- Signals: tool approval is requested only because a command writes or reads a temporary file; body-file, diagnostic, report, or patch staging paths under `/tmp`
+- Evidence: final report names any meaningful temporary artifact only when it affected verification, durable comments, or follow-up work
+
+## Related Practices
+
+- [[RUNTIME-001]]
+- [[RUNTIME-002]]
+- [[GOV-004]]
+- [[IMPL-003]]

--- a/scripts/test_advanced_capability_workflow_surface.py
+++ b/scripts/test_advanced_capability_workflow_surface.py
@@ -487,7 +487,7 @@ def main() -> int:
         )
 
         basic_plan = run([str(PLAN), str(BOOTSTRAP_PACK), "--core-root", str(ROOT), "--vault-root", str(vault)])
-        errors.extend(expect("advanced-basic-pack-flow-still-works", basic_plan, True, "add: 24"))
+        errors.extend(expect("advanced-basic-pack-flow-still-works", basic_plan, True, "add: 25"))
         errors.extend(expect("advanced-basic-pack-writes-none", basic_plan, True, "writes: none"))
 
         candidate_pack = write_candidate_as_manifest(base)

--- a/scripts/test_bootstrap_pack_deployment.py
+++ b/scripts/test_bootstrap_pack_deployment.py
@@ -252,7 +252,7 @@ def main() -> int:
         errors.extend(expect("optional-pack-refused", optional_result, False, "only mandatory_bootstrap packs are supported"))
 
         deploy_result = deploy_bootstrap(vault)
-        errors.extend(expect("deploy-bootstrap", deploy_result, True, "added: 24"))
+        errors.extend(expect("deploy-bootstrap", deploy_result, True, "added: 25"))
         errors.extend(expect("deploy-bootstrap-validates", deploy_result, True, "selected Vault validated"))
         for expected in [
             vault / "practices" / "meta" / "BOOT-001-bootstrap-orientation.md",
@@ -289,7 +289,7 @@ def main() -> int:
                 "--apply",
             ]
         )
-        errors.extend(expect("publish-bootstrap-vault", publish, True, "Active practices selected: 22"))
+        errors.extend(expect("publish-bootstrap-vault", publish, True, "Active practices selected: 23"))
         errors.extend(expect("publish-bootstrap-skill", publish, True, "Active assets selected: 2"))
         generated_text = "\n".join(path.read_text(encoding="utf-8") for path in generated.rglob("*") if path.is_file())
         for expected in ["BOOT-001", "META-001", "ASSET-BOOT-001", "ASSET-META-001", "Generated from the selected Agent Foundry Vault."]:
@@ -297,7 +297,7 @@ def main() -> int:
                 errors.append(f"publish-bootstrap-vault: generated output missing {expected}")
 
         rerun = deploy_bootstrap(vault)
-        errors.extend(expect("deploy-bootstrap-rerun-skip", rerun, True, "skipped: 24"))
+        errors.extend(expect("deploy-bootstrap-rerun-skip", rerun, True, "skipped: 25"))
         errors.extend(expect("deploy-bootstrap-rerun-no-add", rerun, True, "added: 0"))
 
         errors.extend(exercise_restore_rollback_boundaries(base, vault))

--- a/scripts/test_capability_pack_plan.py
+++ b/scripts/test_capability_pack_plan.py
@@ -419,7 +419,7 @@ def main() -> int:
         errors.extend(expect("init-blank-vault", init_blank(vault), True, "Blank Vault initialized and validated."))
 
         bootstrap_plan = plan_pack(BOOTSTRAP_PACK, vault)
-        errors.extend(expect("plan-bootstrap-add", bootstrap_plan, True, "add: 24"))
+        errors.extend(expect("plan-bootstrap-add", bootstrap_plan, True, "add: 25"))
         errors.extend(expect("plan-bootstrap-no-writes", bootstrap_plan, True, "writes: none"))
 
         optional_without_bootstrap = plan_pack(OPTIONAL_PACK, vault)
@@ -435,7 +435,7 @@ def main() -> int:
         errors.extend(expect("deploy-bootstrap", deploy_bootstrap(vault), True, "selected Vault validated"))
 
         bootstrap_after_deploy = plan_pack(BOOTSTRAP_PACK, vault)
-        errors.extend(expect("plan-bootstrap-skip-after-deploy", bootstrap_after_deploy, True, "skip: 24"))
+        errors.extend(expect("plan-bootstrap-skip-after-deploy", bootstrap_after_deploy, True, "skip: 25"))
 
         optional_after_bootstrap = plan_pack(OPTIONAL_PACK, vault)
         errors.extend(expect("plan-optional-adds-records", optional_after_bootstrap, True, "add: 2"))
@@ -611,7 +611,7 @@ def main() -> int:
             sha256(target),
         )
         reordered = plan_pack(BOOTSTRAP_PACK, vault)
-        errors.extend(expect("plan-reordered-metadata-parses", reordered, True, "skip: 24"))
+        errors.extend(expect("plan-reordered-metadata-parses", reordered, True, "skip: 25"))
 
         write_advanced_deployed_index(
             vault,
@@ -622,7 +622,7 @@ def main() -> int:
             sha256(target),
         )
         advanced_deployed_index = plan_pack(BOOTSTRAP_PACK, vault)
-        errors.extend(expect("plan-advanced-deployed-index-parses", advanced_deployed_index, True, "skip: 24"))
+        errors.extend(expect("plan-advanced-deployed-index-parses", advanced_deployed_index, True, "skip: 25"))
 
         write_malformed_deployed_index(vault)
         malformed_metadata = plan_pack(BOOTSTRAP_PACK, vault)


### PR DESCRIPTION
## Summary

Fixes #270.

Restores public Core consistency after PR #268 published adapter references for the approved `RUNTIME-005` / `TEST-001` harvest update.

Changes:
- add `RUNTIME-005` to the bootstrap capability-pack fixture records;
- include `RUNTIME-005` in `fixtures/capability-packs/bootstrap-minimal/manifest.yaml`;
- update the official catalog manifest hash for `pack.bootstrap.minimal`;
- update capability-pack tests for the bootstrap pack growing from 24 to 25 records and active practice count from 22 to 23.

## Verification

Passed:

- `python3 -m py_compile scripts/test_advanced_capability_workflow_surface.py scripts/test_capability_pack_plan.py scripts/test_bootstrap_pack_deployment.py`
- `python3 scripts/check_capability_pack_fixtures.py`
- `python3 scripts/test_advanced_capability_workflow_surface.py`
- `python3 scripts/test_capability_pack_plan.py`
- `python3 scripts/test_bootstrap_pack_deployment.py`
- `git diff --check`
- temporary-HOME verification against a fresh clone of merged Vault PR state:
  - `HOME=$tmp_home python3 scripts/check_consistency.py`
  - `HOME=$tmp_home python3 scripts/check_activation.py`

## Notes

The local selected Vault checkout on this machine is not force-synced by this PR. Plain `git fetch` in `~/.agent-foundry/vault/agent-foundry-vault-farmerhunter` currently fails due local HTTPS credential setup, but a fresh `gh repo clone farmerhunter/agent-foundry-vault-farmerhunter` confirms the merged Vault state contains `RUNTIME-005` and `TEST-001` as `task_router`.

## Boundaries

- No private Vault mutation.
- No generated adapter publish.
- No runtime install/apply.
- No memory-system work.
- No release tag or GitHub Release action.
