### PR TITLE
Document hybrid GitHub operation policy

### DIFF
--- a/scripts/test_github_collaboration_helper.py
+++ b/scripts/test_github_collaboration_helper.py
@@ -14,6 +14,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 HELPER = ROOT / "scripts" / "github_collaboration_helper.py"
 TEMPLATE = ROOT / "templates" / "github-role-routing.template.yaml"
+WORKFLOW = ROOT / "workflows" / "github-collaboration-helper.md"
 
 
 def run(args: list[str], cwd: Path, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
@@ -52,8 +53,53 @@ def expect_fail(name: str, result: subprocess.CompletedProcess[str], expected: s
     return [f"{name}: expected failure containing {expected!r}, got {result.returncode}\n{output}"]
 
 
+def expect_text_contains(name: str, text: str, snippets: list[str]) -> list[str]:
+    missing = [snippet for snippet in snippets if snippet not in text]
+    if not missing:
+        print(f"{name}: ok")
+        return []
+    return [f"{name}: missing {missing!r}"]
+
+
 def main() -> int:
     errors: list[str] = []
+    workflow_text = WORKFLOW.read_text(encoding="utf-8")
+    template_text = TEMPLATE.read_text(encoding="utf-8")
+    errors.extend(
+        expect_text_contains(
+            "github-operation-policy-workflow",
+            workflow_text,
+            [
+                "GitHub Operation Policy",
+                "Each role/session must discover",
+                "GitHub connector or structured tools",
+                "repo-local helper paths first",
+                "controlled `gh api` with a body-file or structured JSON payload",
+                "bare `gh issue comment --body` only as a last resort",
+                "permission-smoke agent-comment",
+                "Do not document or imply that `agent-comment --apply`",
+                "Project v2 was not meaningfully evaluated",
+                "Workflow authorization does not override product/runtime approval prompts",
+            ],
+        )
+    )
+    errors.extend(
+        expect_text_contains(
+            "github-operation-policy-template",
+            template_text,
+            [
+                "operation_policy: \"hybrid_runtime_discovery_then_connector_helper_api_bare_gh\"",
+                "runtime_discovery_required_per_session: true",
+                "connector_preferred_for_low_risk:",
+                "helper_first_for:",
+                "current_helper_comment_write_apply: false",
+                "controlled_gh_api_fallback: \"body_file_or_structured_json_when_connector_unavailable_or_unclear\"",
+                "bare_gh_last_resort: \"short_low_risk_comments_only_with_bounded_retry_and_failure_recording\"",
+                "project_v2_policy: \"optional_visual_mirror_only_no_generalized_write_policy\"",
+                "runtime_approval_prompt_boundary: \"workflow_authorization_does_not_override_app_level_approval_prompts\"",
+            ],
+        )
+    )
     with tempfile.TemporaryDirectory(prefix="agent-foundry-gh-helper-") as tmp:
         base = Path(tmp)
         fixture = base / "issue.json"

--- a/templates/github-role-routing.template.yaml
+++ b/templates/github-role-routing.template.yaml
@@ -56,6 +56,28 @@ github:
   retry_policy: "bounded_retry_for_transient_network_or_rate_limit_only"
   markdown_comment_mode: "body_file_or_api_safe"
   mutation_default: "preview"
+  operation_policy: "hybrid_runtime_discovery_then_connector_helper_api_bare_gh"
+  runtime_discovery_required_per_session: true
+  connector_preferred_for_low_risk:
+    - issue_pr_reads
+    - top_level_comments
+    - issue_create_update
+    - label_add_remove
+    - pr_metadata
+  helper_first_for:
+    - scheduler_semantics
+    - issue_context
+    - handoff_shaping
+    - dispatch_evidence
+    - telemetry
+    - audit
+    - dry_run_preview
+    - fail_closed_permission_checks
+  current_helper_comment_write_apply: false
+  controlled_gh_api_fallback: "body_file_or_structured_json_when_connector_unavailable_or_unclear"
+  bare_gh_last_resort: "short_low_risk_comments_only_with_bounded_retry_and_failure_recording"
+  project_v2_policy: "optional_visual_mirror_only_no_generalized_write_policy"
+  runtime_approval_prompt_boundary: "workflow_authorization_does_not_override_app_level_approval_prompts"
 
 project_v2:
   mode: "optional_visual_mirror"

--- a/workflows/github-collaboration-helper.md
+++ b/workflows/github-collaboration-helper.md
@@ -116,6 +116,48 @@ state:
 Retry behavior must not hide permission failures or convert a preview into an
 apply. Mutation helpers remain out of scope for Unit A.
 
+## GitHub Operation Policy
+
+Use a hybrid GitHub operation policy. Each role/session must discover the
+current GitHub connector or structured tool surface before choosing a write
+path; do not assume Architect, Coordinator, Reviewer, Implementer, Harvester, or
+future runtime sessions expose identical tools.
+
+Preferred routing order:
+
+1. Use GitHub connector or structured tools when the current session exposes a
+   clear, bounded path for straightforward low-risk issue/PR reads, top-level
+   comments, issue create/update, label add/remove, and PR metadata reads.
+   Record observed connector behavior as session evidence, not a universal
+   runtime guarantee.
+2. Use repo-local helper paths first when scheduler semantics, issue context,
+   handoff shaping, dispatch evidence, telemetry, audit, dry-run previews, or
+   fail-closed permission checks matter.
+3. Use controlled `gh api` with a body-file or structured JSON payload when
+   connector tools are unavailable, incomplete, unclear, or failing and the
+   write is still inside the authorized workflow.
+4. Use bare `gh issue comment --body` only as a last resort for short
+   low-risk comments. Apply bounded retry or fallback and record TLS, EOF,
+   timeout, or rate-limit-like failures explicitly.
+
+Current Agent Foundry helper behavior:
+
+- `scripts/github_collaboration_helper.py` remains read-only, dry-run, or
+  fail-closed for GitHub comment writes.
+- `permission-smoke agent-comment` must remain forbidden until a later reviewed
+  mutation-helper gate adds a comment-write apply path.
+- Do not document or imply that `agent-comment --apply` or an equivalent
+  comment-write helper exists in the current helper.
+
+Project v2 was not meaningfully evaluated by the #272 pilot. Treat Project v2
+as an optional visual mirror and scheduler metadata surface only; do not derive
+a generalized Project v2 connector or mutation policy from this workflow.
+
+Workflow authorization does not override product/runtime approval prompts. If a
+runtime asks for shell approval despite a workflow-approved action, stop for the
+user or switch to an already available approved connector/helper path. Do not
+claim workflow policy suppresses app-level prompts.
+
 ## Scheduler Audit
 
 Use `scheduler-audit` only for transition-gated scheduler readback, such as an


### PR DESCRIPTION
## Scope

Implements #273 bounded GitHub operation policy updates after the accepted #272 evidence pilot.

Changed files:
- `workflows/github-collaboration-helper.md`
- `templates/github-role-routing.template.yaml`
- `scripts/test_github_collaboration_helper.py`

Policy summary:
- Adds a hybrid GitHub operation policy: runtime discovery per role/session, connector-preferred low-risk structured operations, helper-first semantic/dry-run/audit paths, controlled `gh api` body-file/JSON fallback, and bare `gh` only as a bounded last resort.
- Documents that the current Agent Foundry helper remains read-only/dry-run/fail-closed for comment writes and must not be described as supporting `agent-comment --apply`.
- Keeps Project v2 out of generalized write-policy scope because #272 did not meaningfully evaluate Project connector/mutation operations.
- Documents that workflow authorization does not override app-level/runtime approval prompts.
- Extends the repo-neutral role-routing template with inert `github:` policy fields only; no runtime behavior is added.

## Verification

- `python3 -m py_compile scripts/test_github_collaboration_helper.py`
- `python3 scripts/test_github_collaboration_helper.py`
- `python3 scripts/check_consistency.py`
- `git diff --check origin/main...HEAD`
- Targeted grep/read-through confirmed:
  - no `agent-comment --apply` availability claim was introduced;
  - `permission-smoke agent-comment` remains fail-closed;
  - no generalized Project v2 write policy was introduced.

## Safety Confirmations

- No comment-write mutation helper added.
- No Project v2 write helper added.
- No merge helper or closure automation added.
- No generated Skill publish.
- No Vault/private/runtime/generated mutation.
- No memory-system work.
- No Foundry Board or Local Collaboration Ledger implementation.
- No final merge or issue closure.

## Residual Risks

- Runtime `agent-collaboration` guidance was not directly changed; if this Core policy should become generated runtime Skill guidance, route it through harvest / canonical asset update after review.
- Connector availability remains session-specific; the policy intentionally requires runtime discovery per role/session.
