### PR TITLE
Document V1 external skills readiness milestone

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 # Agent Foundry Roadmap
 
 Status: planning document
-Updated: 2026-06-20
-Scope: Agent Foundry productization, runtime adapter framework, Trae support, capability-system hardening, repository hygiene, role-orchestration optimization, and memory-system readiness.
+Updated: 2026-07-01
+Scope: Agent Foundry productization, runtime adapter framework, Trae support, capability-system hardening, repository hygiene, role-orchestration optimization, V1.0 release readiness, and memory-system readiness.
 
 ## Purpose
 
@@ -81,10 +81,11 @@ Agent Foundry should use maturity stages for planning and release versions for d
 | AF-9 | Advanced Capability Pack Discovery and Lifecycle | Capability packs can be recognized, maintained, exported, and optimized as higher-level reusable bundles after the basic pack lifecycle is stable and hardened. | Emergent capability-pack discovery and export/update automation can be designed without weakening Core/Vault authority, runtime freshness, or reviewed pack deployment. |
 | AF-10 | Coordinator Workflow Optimization | Multi-thread role orchestration, rehydration, GitHub state synchronization, Human Decision Contracts, and Project/Roadmap coherence are measured and optimized before memory-system planning expands the workflow surface. AF10 is intentionally phased: foundation and telemetry first, an AF11 pilot in the middle, then analysis, policy, and implementation closeout. | Coordinator and role-thread workflows have measurable overhead, compact handoff patterns, durable state ledgers, and clear guidance for when to use multi-thread orchestration versus single-thread serial work. |
 | AF-11 | GitHub Collaboration Helper Migration | Placeholder for migrating the GitHub-based collaboration workflow helper incubated in Tiny IPA into Agent Foundry as an interleaved pilot after AF10 foundation work and before AF10 final optimization closeout. | Migration scope, ownership boundary, reusable asset shape, user-facing workflow, validation path, and telemetry evidence are defined without importing Tiny IPA project-local assumptions. |
+| AF-12 | End-to-End UX, Documentation, And Core Starter Packs | Final pre-V1 user experience consolidation across onboarding, daily operation, capability packs, runtime/generated adapters, GitHub collaboration helpers, documentation tiers, and first-party Core starter packs. | README, user docs, workflow docs, capability-pack UX, Core-hosted starter packs, and readiness evidence are coherent enough for a public V1 release path. |
 
-Current planning stage: MS-01 readiness design preparation.
+Current planning stage: V1.0 release readiness.
 
-AF-0 explains the existing mixed history. AF-1 starts the stricter planning and multi-agent coordination era. AF-2 designs the productization boundary. AF-3 executes the local Core/Vault split. AF-4 proves the split system works for the current real user across existing deployments and establishes the migration discipline needed for later major upgrades. AF-5 makes onboarding humane and reliable for new users. AF-6 closes the current Foundry product lifecycle so install, pack deployment, refresh, status, and rollback are usable beyond a one-off maintainer path. AF-7 upgrades runtime adapters and adds Trae CN support around a verified global Skill path. AF-8 hardens the capability system under realistic multi-user, multi-machine, multi-runtime, long-running-agent, and drift scenarios. AF-9 adds advanced capability-pack discovery, lifecycle, privacy-safe transfer planning, and user-facing Skill workflow packaging. AF-10 optimizes the Coordinator-driven role workflow using AF9 evidence, then pauses for an AF11 pilot migration, then resumes to analyze real telemetry and harden the workflow model. AF-11 is reserved for the Tiny IPA-incubated GitHub collaboration workflow helper migration pilot. Memory-system planning now uses the separate MS milestone axis.
+AF-0 explains the existing mixed history. AF-1 starts the stricter planning and multi-agent coordination era. AF-2 designs the productization boundary. AF-3 executes the local Core/Vault split. AF-4 proves the split system works for the current real user across existing deployments and establishes the migration discipline needed for later major upgrades. AF-5 makes onboarding humane and reliable for new users. AF-6 closes the current Foundry product lifecycle so install, pack deployment, refresh, status, and rollback are usable beyond a one-off maintainer path. AF-7 upgrades runtime adapters and adds Trae CN support around a verified global Skill path. AF-8 hardens the capability system under realistic multi-user, multi-machine, multi-runtime, long-running-agent, and drift scenarios. AF-9 adds advanced capability-pack discovery, lifecycle, privacy-safe transfer planning, and user-facing Skill workflow packaging. AF-10 optimizes the Coordinator-driven role workflow using AF9 evidence, then pauses for an AF11 pilot migration, then resumes to analyze real telemetry and harden the workflow model. AF-11 is reserved for the Tiny IPA-incubated GitHub collaboration workflow helper migration pilot. AF-12 closes the V1 user-facing UX/docs/starter-pack surface. Memory-system planning now uses the separate MS milestone axis.
 
 Memory-system milestones are tracked separately as MS-01 and MS-02 so repeated AF roadmap changes do not keep renumbering memory planning. MS milestones do not authorize memory-system implementation unless an explicit human decision does so.
 
@@ -107,8 +108,23 @@ Suggested mapping:
 | AF-9 | `v0.9.0`: advanced capability-pack discovery and lifecycle design baseline. |
 | AF-10 | `v0.10.0`: Coordinator workflow optimization and role-orchestration evidence baseline. |
 | AF-11 | `v0.11.0`: GitHub collaboration workflow helper migration baseline. |
+| AF-12 | `v0.12.0`: end-to-end UX, documentation, and first-party Core starter pack baseline. |
+| V1.0 readiness | `v1.0.0`: public Core release after AF-1 through AF-12 plus release-critical hardening milestones are accepted. |
 
-`v1.0` should wait until the reusable core, user vault story, generated artifact policy, and runtime adapter behavior are stable enough that external users can rely on them without understanding this repository's personal history.
+`v1.0` is the first public release target. It should include the accepted AF-1 through AF-12 baseline plus V1.0 readiness milestones needed for external users to rely on Agent Foundry without understanding this repository's personal history.
+
+## V1.0 Release Readiness Milestones
+
+V1.0 release readiness is tracked separately from AF stage numbering so late release-critical polish does not renumber the AF roadmap.
+
+| Milestone | GitHub records | User-facing reason | Status |
+| --- | --- | --- | --- |
+| Agent Foundry `v1.0.0` release | #267 | Define the first downloadable public Core release, release notes, verification, tag, and GitHub Release gate. | Open |
+| External Skills Import and Reference Hardening | #276 through #281 | Users need a clear, safe path to evaluate public skills, prompt packs, articles, repos, and local skill folders before anything becomes a practice, asset, reference-only material, adapter output, or rejected input. | Held until explicitly resumed |
+
+External skills are V1.0-relevant because Agent Foundry already exposes `import skill <source>` and already treats external skills as evidence sources. Before public release, this path needs a complete lifecycle, reference-only semantics, user-facing decision support, review templates, fixture-backed validation, and a readiness walkthrough.
+
+V1.0 readiness milestones do not authorize memory-system work, automatic token capture, live Vault/private/runtime/generated mutation, generated adapter publish, external script execution, or broad docs rewrites outside reviewed child issues.
 
 ## GitHub Project and Epic Workflow
 
@@ -125,7 +141,7 @@ Minimal fields:
 | Field | Values | Purpose |
 | --- | --- | --- |
 | Status | Inbox, Ready, In Progress, Review, Done, Blocked | Human-visible work state. |
-| Stage | AF-1 through AF-11, MS-01, MS-02 | Maturity or memory-system planning stage the item serves. |
+| Stage | AF-1 through AF-12, V1.0, V2.0, MS-01, MS-02 | Maturity, release-readiness, product-version, or memory-system planning stage the item serves. |
 | Epic | Free text or single-select | Groups issues by roadmap epic. |
 | Owner Role | Architect, Implementer, Reviewer, Harvester | Clarifies expected agent/human role. |
 | Depends On | Issue or PR references | Prevents ready queues from bypassing dependencies. |
@@ -143,7 +159,8 @@ Issue types:
 
 Recommended labels:
 
-- `stage:AF-1` through `stage:AF-11`
+- `stage:AF-1` through `stage:AF-12`
+- `stage:v1.0`, `stage:v2.0`
 - `stage:MS-01`, `stage:MS-02`
 - `type:epic`, `type:task`, `type:decision`, `type:review`, `type:evidence`
 - `area:core`, `area:vault`, `area:generated`, `area:runtime`, `area:privacy`, `area:memory-readiness`, `area:adapters`
@@ -166,7 +183,8 @@ Detailed milestone plans are split out of this overview so the roadmap stays rea
 | Range | Detail file | Contents |
 | --- | --- | --- |
 | AF-0 through AF-6 | [roadmap/milestones-af0-af6.md](roadmap/milestones-af0-af6.md) | Planning context, repository hygiene, productization, Core/Vault split, current-user deployment migration, onboarding, and existing Foundry lifecycle completion. |
-| AF-7 through AF-11 | [roadmap/milestones-af7-af11.md](roadmap/milestones-af7-af11.md) | Runtime adapter framework, capability hardening, advanced capability-pack discovery, Coordinator workflow optimization, and GitHub collaboration helper migration. |
+| AF-7 through AF-12 | [roadmap/milestones-af7-af11.md](roadmap/milestones-af7-af11.md) | Runtime adapter framework, capability hardening, advanced capability-pack discovery, Coordinator workflow optimization, GitHub collaboration helper migration, and end-to-end UX/docs/starter-pack completion. |
+| V1.0 readiness | GitHub milestones #267 and #276-#281 | Public release definition plus release-critical external skill import/reference hardening. |
 | MS-01 through MS-02 | [roadmap/memory-system-milestones.md](roadmap/memory-system-milestones.md) | Memory-system readiness design and memory implementation-home decision, tracked outside the AF stage sequence. |
 
 ## Future Memory-System Implementation
@@ -187,10 +205,8 @@ Expected scope will be defined by MS-01 and MS-02. AF-10 may optimize the collab
 
 ## Immediate Next Planning Tasks
 
-1. Keep this overview compact; move detailed stage execution notes into `docs/roadmap/`.
-2. Treat AF-9 as completed through its final user-facing Skill workflow packaging gate and durable GitHub closure records.
-3. Use #189 as the AF-10 evidence issue for multi-thread workflow overhead and Coordinator optimization analysis.
-4. Split AF10 into foundation, AF11 pilot, and AF10 closeout phases rather than treating token telemetry as the whole stage.
-5. Use AF-11 as the Tiny IPA-incubated GitHub collaboration workflow helper migration pilot after AF10 telemetry and routing foundations exist.
-6. Keep memory-system planning on the MS milestone axis: MS-01 for readiness design and MS-02 for implementation-home decision. MS-01 execution is gated on accepted AF10 evidence or an explicit human waiver.
-7. Do not create memory directories, schemas, MCP write tools, or automatic memory writing before explicit user authorization.
+1. Complete the V1.0 external skills import/reference hardening milestone (#276-#281) after the human hold is lifted.
+2. Complete #267 release planning, verification, release notes, and final Human Decision Contract for `v1.0.0`.
+3. Keep #266 as a V2.0 telemetry collection window, held until formal V2.0 kickoff.
+4. Keep memory-system planning on the MS milestone axis: MS-01 for readiness design and MS-02 for implementation-home decision. MS work remains gated on explicit human authorization.
+5. Do not create memory directories, schemas, MCP write tools, or automatic memory writing before explicit user authorization.

--- a/docs/roadmap/milestones-af7-af11.md
+++ b/docs/roadmap/milestones-af7-af11.md
@@ -1,4 +1,4 @@
-# Roadmap Milestones AF-7 Through AF-11
+# Roadmap Milestones AF-7 Through AF-12
 
 This file contains detailed milestone plans moved out of `docs/roadmap.md` to keep the main roadmap readable.
 
@@ -292,3 +292,58 @@ Acceptance criteria:
 - User-facing workflow entry points are named before implementation.
 - GitHub mutation permissions, dry-run behavior, review gates, and rollback or no-write modes are explicit.
 - AF10 cost/rehydration/routing findings are applied to avoid unnecessary role-thread overhead.
+
+### AF-12 / M12: End-to-End UX, Documentation, And Core Starter Packs
+
+Goal: make the accepted Core capabilities understandable and usable from a final-user point of view before the first public V1 release.
+
+AF-12 covered onboarding, daily operation, capability-pack UX, runtime/generated adapter status, GitHub collaboration helper adopter UX, documentation information architecture, first-party Core starter packs, and final walkthrough evidence. It did not authorize memory-system work.
+
+Accepted V1-facing outputs:
+
+- README first-value onboarding path and documentation tiering.
+- Ordinary-user usage and command guidance.
+- Complete/power-user reference navigation.
+- Capability-pack state taxonomy, normal-user consumption contract, power-user maintenance contract, candidate discovery review-list workflow, Core-hosted official catalog model, and readiness walkthrough.
+- Corrected first-party starter pack set:
+  - `pack.bootstrap.minimal` as mandatory/bootstrap baseline with source-of-truth, architecture-boundary, Generated/Runtime downstream, and Local Private exclusion guidance.
+  - `pack.multi-agent.optional` as the only standalone optional first-party Core starter pack.
+  - No standalone `pack.architecture-boundary-review.starter` in the current-stage official set.
+
+Acceptance criteria:
+
+- Users can understand the Core/Vault/Generated/Runtime/Local Private model without reading internal planning history.
+- Starter packs are discoverable with simple user-value descriptions.
+- Raw scripts remain implementation/debug substrate rather than the primary user interface.
+- Final release notes can point to README, usage, commands, deployment, catalog docs, and readiness evidence.
+- No memory-system directories, schemas, storage, MCP tools, or automatic memory writing are introduced.
+
+### V1.0 Readiness: External Skills Import And Reference Hardening
+
+Goal: complete the release-critical external-skill import/reference story before the public `v1.0.0` release.
+
+This work is tracked as GitHub milestone `V1.0: External Skills Import and Reference Hardening` with issues #276 through #281.
+
+Why it is V1.0-relevant:
+
+- Agent Foundry already exposes `import skill <source>` to users.
+- External skills, prompt packs, articles, repos, and local skill folders can be valuable, but they are reviewed inputs rather than authorities.
+- Users need a clear review result: discard, reference-only, defer, merge into existing, propose practice, propose asset, or publish after approval.
+- Reference-only material must be searchable or manually useful without becoming active practice/asset authority or adapter output.
+
+Planned issue sequence:
+
+1. #276 plan end-to-end import, reference, and user-facing workflow hardening.
+2. #277 define outcome taxonomy and reference-only contract.
+3. #278 harden import workflow and review packet template.
+4. #279 add user-facing import/reference workflow docs.
+5. #280 add fixture-backed validation for import outcomes.
+6. #281 run final readiness walkthrough for the import/reference workflow.
+
+Acceptance criteria:
+
+- External-skill import has a complete lifecycle from source review through approval, canonicalization, adapter publish, and verification.
+- User-facing docs explain when to import, what the report means, what approval changes, and what remains blocked.
+- Script-bearing or unsafe external material remains inert unless explicitly reviewed and approved.
+- Fixture coverage proves safe public skill, local folder, script-bearing skill, duplicate practice, reference-only material, unknown/unsafe license, and prompt-injection cases.
+- No real external skill import, external script execution, Vault/private/runtime/generated mutation, generated adapter publish, capability-pack operation, or memory-system work occurs without a later reviewed issue and explicit authorization where required.


### PR DESCRIPTION
## Summary

- Adds AF-12 and V1.0 release-readiness context to the roadmap overview.
- Adds `V1.0: External Skills Import and Reference Hardening` as a V1.0 readiness milestone covering #276-#281.
- Updates milestone navigation to include AF-12 and the external skills readiness sequence.

## User-facing review focus

Human should review whether the roadmap now clearly communicates that external skill import/reference handling is part of V1.0 readiness: users need a safe, understandable path for evaluating public skills, prompt packs, articles, repos, and local skill folders before anything becomes a practice, asset, reference-only material, adapter output, or rejected input.

## Verification

- `python3 scripts/check_consistency.py`
- `git diff --check`

## Boundaries

No implementation, real external import, external script execution, Vault/private/runtime/generated mutation, generated adapter publish, capability-pack operation, memory-system work, release/tag creation, or destructive action.