### PR TITLE
Align Execution Contract role validation across helper surfaces

### DIFF
--- a/scripts/github_collaboration_helper.py
+++ b/scripts/github_collaboration_helper.py
@@ -188,7 +188,28 @@ def scalar_in_block(block_text: str, key: str) -> str | None:
     return match.group(1).strip().strip('"')
 
 
+def strip_markdown_fenced_blocks(text: str) -> str:
+    output: list[str] = []
+    fence: tuple[str, int] | None = None
+    for line in text.splitlines(keepends=True):
+        if fence:
+            char, length = fence
+            if re.match(rf"^\s*{re.escape(char)}{{{length},}}\s*$", line.rstrip("\n\r")):
+                fence = None
+            output.append("\n" if line.endswith(("\n", "\r")) else "")
+            continue
+        match = re.match(r"^\s*(`{3,}|~{3,})", line)
+        if match:
+            marker = match.group(1)
+            fence = (marker[0], len(marker))
+            output.append("\n" if line.endswith(("\n", "\r")) else "")
+            continue
+        output.append(line)
+    return "".join(output)
+
+
 def extract_execution_contract(body: str) -> tuple[str | None, str]:
+    body = strip_markdown_fenced_blocks(body or "")
     sections: list[tuple[str, str]] = []
     pattern = re.compile(
         r"^##\s+(Final Execution Contract|Execution Contract|Draft Execution Contract)\s*$"

--- a/scripts/github_collaboration_helper.py
+++ b/scripts/github_collaboration_helper.py
@@ -50,6 +50,17 @@ DRY_RUN_ACTIONS = {
     "comparison-draft",
 }
 REMOTE_RE = re.compile(r"(?:github\.com[:/])([^/]+)/([^/.]+)(?:\.git)?$")
+CONTRACT_HEADINGS = ("Final Execution Contract", "Execution Contract", "Draft Execution Contract")
+ROLE_FIELDS = ("Owner role", "Review role", "Acceptance role")
+VALID_ROLE_VALUES = {"none", "implementer", "reviewer", "architect"}
+VALID_COMPLETION_HANDOFFS = {
+    "none",
+    "to:implementer",
+    "to:reviewer",
+    "to:architect",
+    "to:human",
+    "batch checkpoint",
+}
 
 
 def fail(code: str, detail: str, exit_code: int = 2) -> None:
@@ -175,6 +186,120 @@ def scalar_in_block(block_text: str, key: str) -> str | None:
     if not match:
         return None
     return match.group(1).strip().strip('"')
+
+
+def extract_execution_contract(body: str) -> tuple[str | None, str]:
+    sections: list[tuple[str, str]] = []
+    pattern = re.compile(
+        r"^##\s+(Final Execution Contract|Execution Contract|Draft Execution Contract)\s*$"
+        r"(?P<body>.*?)(?=^##\s+|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    for match in pattern.finditer(body or ""):
+        sections.append((match.group(1), match.group("body")))
+    if not sections:
+        return None, ""
+    for preferred in CONTRACT_HEADINGS:
+        for heading, text in reversed(sections):
+            if heading == preferred:
+                return heading, text
+    return sections[-1]
+
+
+def markdown_field(text: str, field: str) -> str | None:
+    match = re.search(rf"^\s*{re.escape(field)}:\s*(.+?)\s*$", text, re.MULTILINE)
+    if not match:
+        return None
+    return match.group(1).strip()
+
+
+def contract_error(field: str, code: str, message: str, expected: Any = None, actual: Any = None, hint: str | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {"field": field, "code": code, "message": message}
+    if expected is not None:
+        payload["expected"] = expected
+    if actual is not None:
+        payload["actual"] = actual
+    if hint:
+        payload["hint"] = hint
+    return payload
+
+
+def validate_execution_contract(body: str) -> dict[str, Any]:
+    heading, contract = extract_execution_contract(body)
+    if not heading:
+        return {"status": "missing", "heading": None, "fields": {}, "errors": []}
+    fields = {field: markdown_field(contract, field) for field in (*ROLE_FIELDS, "Completion handoff")}
+    reviewer_target = markdown_field(contract, "Reviewer target")
+    human_prompt = markdown_field(contract, "Human review prompt")
+    human_verification = markdown_field(contract, "Human verification needed")
+    errors: list[dict[str, Any]] = []
+
+    for field in ("Owner role", "Completion handoff"):
+        if not fields.get(field):
+            errors.append(
+                contract_error(
+                    field,
+                    "missing_contract_field",
+                    f"{field} is required for pickup-ready Execution Contracts.",
+                    actual=None,
+                )
+            )
+    if reviewer_target and not fields.get("Review role"):
+        errors.append(
+            contract_error(
+                "Review role",
+                "missing_contract_field",
+                "Reviewer target is present but Review role is missing.",
+                expected=sorted(VALID_ROLE_VALUES),
+                actual=None,
+                hint="Use `Review role: reviewer` and keep natural-language reviewer details in `Reviewer target:`.",
+            )
+        )
+
+    for field in ROLE_FIELDS:
+        value = fields.get(field)
+        if value is None:
+            continue
+        if value not in VALID_ROLE_VALUES:
+            hint = "Use a single lowercase machine role token: none, implementer, reviewer, or architect."
+            if field == "Acceptance role" and "/" in value:
+                hint = "Use `Acceptance role: architect` and keep human gates in `Human verification needed:` or `Human review prompt:`."
+            errors.append(
+                contract_error(
+                    field,
+                    "malformed_role_field",
+                    f"{field} must be a single lowercase machine role token.",
+                    expected=sorted(VALID_ROLE_VALUES),
+                    actual=value,
+                    hint=hint,
+                )
+            )
+
+    handoff = fields.get("Completion handoff")
+    if handoff is not None and handoff not in VALID_COMPLETION_HANDOFFS:
+        errors.append(
+            contract_error(
+                "Completion handoff",
+                "malformed_completion_handoff",
+                "Completion handoff must be a machine-readable handoff value.",
+                expected=sorted(VALID_COMPLETION_HANDOFFS),
+                actual=handoff,
+                hint="Use `Completion handoff: to:reviewer` for ordinary review handoff.",
+            )
+        )
+
+    natural_fields = {
+        "Reviewer target": reviewer_target,
+        "Human review prompt": human_prompt,
+        "Human verification needed": human_verification,
+    }
+    return {
+        "status": "ok" if not errors else "invalid",
+        "heading": heading,
+        "fields": {key: value for key, value in fields.items() if value is not None},
+        "natural_language_fields_present": sorted(key for key, value in natural_fields.items() if value),
+        "errors": errors,
+    }
 
 
 def parse_simple_yaml(path: Path) -> dict[str, Any]:
@@ -325,7 +450,7 @@ def cmd_inbox(args: argparse.Namespace) -> None:
                 "--search",
                 search,
                 "--json",
-                "number,title,labels,updatedAt",
+                "number,title,labels,updatedAt,body",
             ]
         )
     rows = []
@@ -338,6 +463,7 @@ def cmd_inbox(args: argparse.Namespace) -> None:
                     "title": issue.get("title"),
                     "labels": issue_labels,
                     "updatedAt": issue.get("updatedAt"),
+                    "contract_validation": validate_execution_contract(issue.get("body") or ""),
                 }
             )
     print_json_or_text({"repo": repo, "issues": rows, "mutation_performed": False}, args.json)
@@ -367,6 +493,7 @@ def cmd_issue_context(args: argparse.Namespace) -> None:
     for marker in ("Execution Contract", "Depends On", "Acceptance Criteria", "Forbidden actions"):
         if marker.lower() in body.lower():
             contract_hints.append(marker)
+    contract_validation = validate_execution_contract(body)
     print_json_or_text(
         {
             "repo": repo,
@@ -375,6 +502,7 @@ def cmd_issue_context(args: argparse.Namespace) -> None:
             "state": issue.get("state"),
             "labels": labels,
             "contract_hints": contract_hints,
+            "contract_validation": contract_validation,
             "comment_count_returned": len(comments),
             "summary_is_authority": False,
             "mutation_performed": False,
@@ -557,7 +685,7 @@ def read_live_issues(repo: str, args: argparse.Namespace) -> tuple[list[dict[str
                 "--label",
                 stage_label,
                 "--json",
-                "number,title,state,labels",
+                "number,title,state,labels,body",
             ]
         )
         if not result["ok"]:
@@ -657,6 +785,20 @@ def audit_issue(
             finding("no_next_owner_label", number, "warning", "Open transition-routable issue lacks a next-owner needs:* label.", expected=sorted(needs_labels), actual=labels)
         )
         repairs.append(repair("adjust_label", number, "needs:*", "add the intended next-owner label"))
+    contract_validation = validate_execution_contract(issue.get("body") or "")
+    if contract_validation["status"] == "invalid":
+        for error in contract_validation["errors"]:
+            issue_findings.append(
+                finding(
+                    "execution_contract_invalid",
+                    number,
+                    "error",
+                    error["message"],
+                    expected={error["field"]: error.get("expected")},
+                    actual={error["field"]: error.get("actual")},
+                )
+            )
+        repairs.append(repair("fix_execution_contract", number, "Execution Contract", "use lowercase role tokens and machine-readable handoff values"))
     if project_requested and item is None:
         issue_findings.append(
             finding("missing_project_item", number, "error", "Issue is not present in the requested Project v2 item list.")

--- a/scripts/test_github_collaboration_helper.py
+++ b/scripts/test_github_collaboration_helper.py
@@ -132,7 +132,32 @@ def main() -> int:
                     "title": "Unit B",
                     "state": "OPEN",
                     "labels": [{"name": "needs:implementer"}, {"name": "stage:AF-11"}],
-                    "body": "## Execution Contract\n\n## Acceptance Criteria\n\n## Depends On",
+                    "body": "\n".join(
+                        [
+                            "```markdown",
+                            "## Final Execution Contract",
+                            "",
+                            "Example only; this fenced heading must not be validated.",
+                            "```",
+                            "",
+                            "```text",
+                            "## Execution Contract",
+                            "Owner role: Implementer",
+                            "Completion handoff: move to Review",
+                            "```",
+                            "",
+                            "## Execution Contract",
+                            "",
+                            "Owner role: implementer",
+                            "Review role: reviewer",
+                            "Acceptance role: architect",
+                            "Completion handoff: to:reviewer",
+                            "",
+                            "## Acceptance Criteria",
+                            "",
+                            "## Depends On",
+                        ]
+                    ),
                     "comments": [{"body": "latest"}, {"body": "older"}],
                 }
             ),
@@ -412,13 +437,19 @@ def main() -> int:
         errors.extend(expect_ok("inbox-contract-validation-invalid", inbox_result, '"status": "invalid"'))
         errors.extend(expect_ok("inbox-contract-validation-role", inbox_result, '"actual": "Implementer"'))
         errors.extend(expect_ok("inbox-contract-validation-handoff", inbox_result, '"actual": "move to Review"'))
+        issue_context_result = run(
+            ["--repo", "farmerhunter/agent-foundry", "issue-context", "205", "--fixture-json", str(fixture)],
+            base,
+        )
         errors.extend(
             expect_ok(
                 "issue-context-fixture",
-                run(["--repo", "farmerhunter/agent-foundry", "issue-context", "205", "--fixture-json", str(fixture)], base),
+                issue_context_result,
                 "summary_is_authority: False",
             )
         )
+        errors.extend(expect_ok("issue-context-ignores-fenced-contract-heading", issue_context_result, '"status": "ok"'))
+        errors.extend(expect_ok("issue-context-real-contract-owner", issue_context_result, '"Owner role": "implementer"'))
         errors.extend(
             expect_ok(
                 "scheduler-audit-fixture",

--- a/scripts/test_github_collaboration_helper.py
+++ b/scripts/test_github_collaboration_helper.py
@@ -178,6 +178,34 @@ def main() -> int:
                             "state": "OPEN",
                             "labels": [{"name": "stage:AF-11"}, {"name": "risk:medium"}, {"name": "type:task"}],
                         },
+                        {
+                            "number": 230,
+                            "title": "Uppercase owner role",
+                            "state": "OPEN",
+                            "labels": [{"name": "stage:AF-11"}, {"name": "risk:medium"}, {"name": "needs:implementer"}],
+                            "body": "## Execution Contract\n\nOwner role: Implementer\nReview role: reviewer\nAcceptance role: architect\nCompletion handoff: to:reviewer\n",
+                        },
+                        {
+                            "number": 231,
+                            "title": "Compound acceptance role",
+                            "state": "OPEN",
+                            "labels": [{"name": "stage:AF-11"}, {"name": "risk:medium"}, {"name": "needs:implementer"}],
+                            "body": "## Execution Contract\n\nOwner role: implementer\nReview role: reviewer\nAcceptance role: architect / user\nCompletion handoff: to:reviewer\nHuman review prompt: ask user after merge\n",
+                        },
+                        {
+                            "number": 232,
+                            "title": "Reviewer target without review role",
+                            "state": "OPEN",
+                            "labels": [{"name": "stage:AF-11"}, {"name": "risk:medium"}, {"name": "needs:implementer"}],
+                            "body": "## Execution Contract\n\nOwner role: implementer\nAcceptance role: architect\nCompletion handoff: to:reviewer\nReviewer target: separate Reviewer agent\n",
+                        },
+                        {
+                            "number": 233,
+                            "title": "Legacy handoff",
+                            "state": "OPEN",
+                            "labels": [{"name": "stage:AF-11"}, {"name": "risk:medium"}, {"name": "needs:implementer"}],
+                            "body": "## Execution Contract\n\nOwner role: implementer\nReview role: reviewer\nAcceptance role: architect\nCompletion handoff: move to Review\n",
+                        },
                     ]
                 }
             ),
@@ -241,6 +269,14 @@ def main() -> int:
                             "title": "Unit B",
                             "labels": [{"name": "needs:implementer"}],
                             "updatedAt": "2026-06-18T00:00:00Z",
+                            "body": "## Execution Contract\n\nOwner role: implementer\nReview role: reviewer\nAcceptance role: architect\nCompletion handoff: to:reviewer\n",
+                        },
+                        {
+                            "number": 207,
+                            "title": "Bad contract",
+                            "labels": [{"name": "needs:implementer"}],
+                            "updatedAt": "2026-06-18T00:00:00Z",
+                            "body": "## Execution Contract\n\nOwner role: Implementer\nCompletion handoff: move to Review\nReviewer target: separate Reviewer agent\n",
                         },
                         {
                             "number": 206,
@@ -359,6 +395,23 @@ def main() -> int:
                 "needs:implementer",
             )
         )
+        inbox_result = run(
+            [
+                "--json",
+                "--repo",
+                "farmerhunter/agent-foundry",
+                "inbox",
+                "--config",
+                str(TEMPLATE),
+                "--fixture-json",
+                str(inbox),
+            ],
+            base,
+        )
+        errors.extend(expect_ok("inbox-contract-validation-surface", inbox_result, '"contract_validation"'))
+        errors.extend(expect_ok("inbox-contract-validation-invalid", inbox_result, '"status": "invalid"'))
+        errors.extend(expect_ok("inbox-contract-validation-role", inbox_result, '"actual": "Implementer"'))
+        errors.extend(expect_ok("inbox-contract-validation-handoff", inbox_result, '"actual": "move to Review"'))
         errors.extend(
             expect_ok(
                 "issue-context-fixture",
@@ -406,8 +459,16 @@ def main() -> int:
             "open_needs_label_status_mismatch",
             "multiple_needs_labels",
             "no_next_owner_label",
+            "execution_contract_invalid",
         ):
             errors.extend(expect_ok(f"scheduler-audit-{code}", scheduler_json, f'"code": "{code}"'))
+        for name, expected in (
+            ("scheduler-audit-uppercase-role", '"Owner role": "Implementer"'),
+            ("scheduler-audit-compound-acceptance", '"Acceptance role": "architect / user"'),
+            ("scheduler-audit-missing-review-role", "Reviewer target is present but Review role is missing."),
+            ("scheduler-audit-legacy-handoff", '"Completion handoff": "move to Review"'),
+        ):
+            errors.extend(expect_ok(name, scheduler_json, expected))
         errors.extend(expect_ok("scheduler-audit-json-status", scheduler_json, '"status": "findings"'))
         errors.extend(expect_ok("scheduler-audit-json-no-mutation", scheduler_json, '"mutation_performed": false'))
         degraded = run(

--- a/templates/github-dry-run-planning-examples.md
+++ b/templates/github-dry-run-planning-examples.md
@@ -29,6 +29,20 @@ before a reviewed mutation helper exists.
 Use this when a role is about to pick up an issue but no durable mutation should
 occur yet.
 
+Execution Contract examples should keep role and handoff fields
+machine-readable:
+
+```markdown
+## Execution Contract
+
+Owner role: implementer
+Review role: reviewer
+Acceptance role: architect
+Completion handoff: to:reviewer
+Reviewer target: separate Reviewer agent, focused on contract validation
+Human verification needed: no
+```
+
 ```yaml
 dry_run_planning_example:
   mode: generated_note

--- a/workflows/github-collaboration-helper.md
+++ b/workflows/github-collaboration-helper.md
@@ -100,6 +100,25 @@ Required properties:
   explains why telemetry was skipped under `workflows/coordinate-agent-work.md`.
 - `project_v2.mode` defaults to `optional_visual_mirror`.
 
+Execution Contract role fields are machine-readable. Use lowercase single-token
+role values and machine handoff values:
+
+```markdown
+## Execution Contract
+
+Owner role: implementer
+Review role: reviewer
+Acceptance role: architect
+Completion handoff: to:reviewer
+Reviewer target: separate Reviewer agent, contract-validation focused
+Human review prompt: only when a real human gate is needed
+```
+
+Keep natural-language reviewer descriptions, human prompts, and trial
+instructions in separate fields such as `Reviewer target:`, `Human verification
+needed:`, or `Human review prompt:`. Do not encode them in `Owner role:`,
+`Review role:`, `Acceptance role:`, or `Completion handoff:`.
+
 ## GitHub Auth And Retry Expectations
 
 Agents should verify GitHub readiness before making claims about available


### PR DESCRIPTION
## Scope

Implements #283 by aligning Execution Contract role/handoff validation across the Agent Foundry helper surfaces that correspond to audit, ready queue, and pickup context.

Changed files:
- `scripts/github_collaboration_helper.py`
- `scripts/test_github_collaboration_helper.py`
- `workflows/github-collaboration-helper.md`
- `templates/github-dry-run-planning-examples.md`

## Behavior

- Adds a shared Execution Contract validator for explicit `Final Execution Contract`, `Execution Contract`, and `Draft Execution Contract` sections.
- Validates machine-readable role fields: `Owner role`, `Review role`, `Acceptance role`.
- Validates `Completion handoff` machine values such as `to:reviewer` and `batch checkpoint`.
- `scheduler-audit` now emits `execution_contract_invalid` findings when malformed role/handoff fields would block pickup.
- `inbox` now includes `contract_validation` status per issue, so ready-like output does not imply malformed contracts are fully pickup-ready.
- `issue-context` now includes the same `contract_validation` payload for pickup-context readback.
- Workflow/template examples now show lowercase machine role tokens and `Completion handoff: to:reviewer`.

## Regression Coverage

Added fixture coverage for:
- uppercase role: `Owner role: Implementer`;
- compound acceptance: `Acceptance role: architect / user`;
- missing `Review role` while `Reviewer target` is present;
- legacy handoff: `Completion handoff: move to Review`.

## Verification

- `python3 -m py_compile scripts/github_collaboration_helper.py scripts/test_github_collaboration_helper.py`
- `python3 scripts/test_github_collaboration_helper.py`
- `python3 scripts/check_consistency.py`
- `git diff --check origin/main...HEAD`
- Live compatibility smoke: `gh issue list --repo farmerhunter/agent-foundry --state open --limit 1 --json number,title,labels,updatedAt,body`
- Targeted grep/read-through confirmed examples use lowercase machine role tokens and machine-readable handoff values, while invalid examples only appear in regression fixtures.

## Safety Confirmations

- No live GitHub mutation helper added.
- No Project v2 write helper added.
- No merge or closure automation added.
- No runtime/global/Vault/private/generated mutation.
- No generated adapter/Skill publish.
- No memory-system work.
- No capability-pack operation.
- No destructive action.

## Residual Risks

- Tiny IPA-specific helper commands such as `agent-ready-queue` and `agent-pickup` are not present in Agent Foundry Core; this PR fixes the equivalent Core helper surfaces (`inbox`, `issue-context`, `scheduler-audit`) and documents the Tiny IPA command-level follow-up as project-local.
- The validator is intentionally dependency-free Markdown parsing; if future contracts move to richer structured metadata, this should evolve with that schema.
