### PR TITLE
Classify external skills as AF13 milestone

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -82,10 +82,11 @@ Agent Foundry should use maturity stages for planning and release versions for d
 | AF-10 | Coordinator Workflow Optimization | Multi-thread role orchestration, rehydration, GitHub state synchronization, Human Decision Contracts, and Project/Roadmap coherence are measured and optimized before memory-system planning expands the workflow surface. AF10 is intentionally phased: foundation and telemetry first, an AF11 pilot in the middle, then analysis, policy, and implementation closeout. | Coordinator and role-thread workflows have measurable overhead, compact handoff patterns, durable state ledgers, and clear guidance for when to use multi-thread orchestration versus single-thread serial work. |
 | AF-11 | GitHub Collaboration Helper Migration | Placeholder for migrating the GitHub-based collaboration workflow helper incubated in Tiny IPA into Agent Foundry as an interleaved pilot after AF10 foundation work and before AF10 final optimization closeout. | Migration scope, ownership boundary, reusable asset shape, user-facing workflow, validation path, and telemetry evidence are defined without importing Tiny IPA project-local assumptions. |
 | AF-12 | End-to-End UX, Documentation, And Core Starter Packs | Final pre-V1 user experience consolidation across onboarding, daily operation, capability packs, runtime/generated adapters, GitHub collaboration helpers, documentation tiers, and first-party Core starter packs. | README, user docs, workflow docs, capability-pack UX, Core-hosted starter packs, and readiness evidence are coherent enough for a public V1 release path. |
+| AF-13 | External Skills Import And Reference Workflow | Users can evaluate external skills, prompt packs, articles, repositories, and local skill folders through a reviewed import/reference workflow before anything becomes active Agent Foundry behavior. | External sources have clear outcomes, reference-only semantics, review packets, user-facing docs, fixture validation, and readiness evidence without treating external material as authority. |
 
-Current planning stage: V1.0 release readiness.
+Current planning stage: AF-13 external skills import/reference workflow.
 
-AF-0 explains the existing mixed history. AF-1 starts the stricter planning and multi-agent coordination era. AF-2 designs the productization boundary. AF-3 executes the local Core/Vault split. AF-4 proves the split system works for the current real user across existing deployments and establishes the migration discipline needed for later major upgrades. AF-5 makes onboarding humane and reliable for new users. AF-6 closes the current Foundry product lifecycle so install, pack deployment, refresh, status, and rollback are usable beyond a one-off maintainer path. AF-7 upgrades runtime adapters and adds Trae CN support around a verified global Skill path. AF-8 hardens the capability system under realistic multi-user, multi-machine, multi-runtime, long-running-agent, and drift scenarios. AF-9 adds advanced capability-pack discovery, lifecycle, privacy-safe transfer planning, and user-facing Skill workflow packaging. AF-10 optimizes the Coordinator-driven role workflow using AF9 evidence, then pauses for an AF11 pilot migration, then resumes to analyze real telemetry and harden the workflow model. AF-11 is reserved for the Tiny IPA-incubated GitHub collaboration workflow helper migration pilot. AF-12 closes the V1 user-facing UX/docs/starter-pack surface. Memory-system planning now uses the separate MS milestone axis.
+AF-0 explains the existing mixed history. AF-1 starts the stricter planning and multi-agent coordination era. AF-2 designs the productization boundary. AF-3 executes the local Core/Vault split. AF-4 proves the split system works for the current real user across existing deployments and establishes the migration discipline needed for later major upgrades. AF-5 makes onboarding humane and reliable for new users. AF-6 closes the current Foundry product lifecycle so install, pack deployment, refresh, status, and rollback are usable beyond a one-off maintainer path. AF-7 upgrades runtime adapters and adds Trae CN support around a verified global Skill path. AF-8 hardens the capability system under realistic multi-user, multi-machine, multi-runtime, long-running-agent, and drift scenarios. AF-9 adds advanced capability-pack discovery, lifecycle, privacy-safe transfer planning, and user-facing Skill workflow packaging. AF-10 optimizes the Coordinator-driven role workflow using AF9 evidence, then pauses for an AF11 pilot migration, then resumes to analyze real telemetry and harden the workflow model. AF-11 is reserved for the Tiny IPA-incubated GitHub collaboration workflow helper migration pilot. AF-12 closes the V1 user-facing UX/docs/starter-pack surface. AF-13 adds the independent external-skills import/reference workflow. Memory-system planning now uses the separate MS milestone axis.
 
 Memory-system milestones are tracked separately as MS-01 and MS-02 so repeated AF roadmap changes do not keep renumbering memory planning. MS milestones do not authorize memory-system implementation unless an explicit human decision does so.
 
@@ -109,22 +110,23 @@ Suggested mapping:
 | AF-10 | `v0.10.0`: Coordinator workflow optimization and role-orchestration evidence baseline. |
 | AF-11 | `v0.11.0`: GitHub collaboration workflow helper migration baseline. |
 | AF-12 | `v0.12.0`: end-to-end UX, documentation, and first-party Core starter pack baseline. |
-| V1.0 readiness | `v1.0.0`: public Core release after AF-1 through AF-12 plus release-critical hardening milestones are accepted. |
+| AF-13 | `v0.13.0`: external skills import/reference workflow baseline. |
+| V1.0 readiness | `v1.0.0`: public Core release after AF-1 through AF-13 and the release checklist are accepted. |
 
-`v1.0` is the first public release target. It should include the accepted AF-1 through AF-12 baseline plus V1.0 readiness milestones needed for external users to rely on Agent Foundry without understanding this repository's personal history.
+`v1.0` is the first public release target. It should include the accepted AF-1 through AF-13 baseline plus release notes, verification, tag, and GitHub Release work needed for external users to rely on Agent Foundry without understanding this repository's personal history.
 
-## V1.0 Release Readiness Milestones
+## Active Milestone
 
-V1.0 release readiness is tracked separately from AF stage numbering so late release-critical polish does not renumber the AF roadmap.
+AF-13 is an independent user-facing capability milestone, not release-readiness polish.
 
 | Milestone | GitHub records | User-facing reason | Status |
 | --- | --- | --- | --- |
-| Agent Foundry `v1.0.0` release | #267 | Define the first downloadable public Core release, release notes, verification, tag, and GitHub Release gate. | Open |
-| External Skills Import and Reference Hardening | #276 through #281 | Users need a clear, safe path to evaluate public skills, prompt packs, articles, repos, and local skill folders before anything becomes a practice, asset, reference-only material, adapter output, or rejected input. | Active; #277 released |
+| AF-13 External Skills Import and Reference Workflow | #286 Epic; #276 through #281 | Users need a clear, safe path to evaluate public skills, prompt packs, articles, repos, and local skill folders before anything becomes a practice, asset, reference-only material, adapter output, or rejected input. | Active; #277 released |
+| Agent Foundry `v1.0.0` release | #267 | Define the first downloadable public Core release, release notes, verification, tag, and GitHub Release gate after AF-13 is accepted. | Open |
 
-External skills are V1.0-relevant because Agent Foundry already exposes `import skill <source>` and already treats external skills as evidence sources. Before public release, this path needs a complete lifecycle, reference-only semantics, user-facing decision support, review templates, fixture-backed validation, and a readiness walkthrough.
+External skills are an independent use case because Agent Foundry already exposes `import skill <source>` and already treats external skills as evidence sources. This path needs a complete lifecycle, reference-only semantics, user-facing decision support, review templates, fixture-backed validation, and a readiness walkthrough.
 
-V1.0 readiness milestones do not authorize memory-system work, automatic token capture, live Vault/private/runtime/generated mutation, generated adapter publish, external script execution, or broad docs rewrites outside reviewed child issues.
+AF-13 does not authorize memory-system work, automatic token capture, live Vault/private/runtime/generated mutation, generated adapter publish, external script execution, or broad docs rewrites outside reviewed child issues.
 
 ## GitHub Project and Epic Workflow
 
@@ -141,7 +143,7 @@ Minimal fields:
 | Field | Values | Purpose |
 | --- | --- | --- |
 | Status | Inbox, Ready, In Progress, Review, Done, Blocked | Human-visible work state. |
-| Stage | AF-1 through AF-12, V1.0, V2.0, MS-01, MS-02 | Maturity, release-readiness, product-version, or memory-system planning stage the item serves. |
+| Stage | AF-1 through AF-13, V1.0, V2.0, MS-01, MS-02 | Maturity, release-readiness, product-version, or memory-system planning stage the item serves. |
 | Epic | Free text or single-select | Groups issues by roadmap epic. |
 | Owner Role | Architect, Implementer, Reviewer, Harvester | Clarifies expected agent/human role. |
 | Depends On | Issue or PR references | Prevents ready queues from bypassing dependencies. |
@@ -160,7 +162,7 @@ Issue types:
 Recommended labels:
 
 - `stage:AF-1` through `stage:AF-12`
-- `stage:v1.0`, `stage:v2.0`
+- `stage:AF-13`, `stage:v1.0`, `stage:v2.0`
 - `stage:MS-01`, `stage:MS-02`
 - `type:epic`, `type:task`, `type:decision`, `type:review`, `type:evidence`
 - `area:core`, `area:vault`, `area:generated`, `area:runtime`, `area:privacy`, `area:memory-readiness`, `area:adapters`
@@ -183,8 +185,8 @@ Detailed milestone plans are split out of this overview so the roadmap stays rea
 | Range | Detail file | Contents |
 | --- | --- | --- |
 | AF-0 through AF-6 | [roadmap/milestones-af0-af6.md](roadmap/milestones-af0-af6.md) | Planning context, repository hygiene, productization, Core/Vault split, current-user deployment migration, onboarding, and existing Foundry lifecycle completion. |
-| AF-7 through AF-12 | [roadmap/milestones-af7-af11.md](roadmap/milestones-af7-af11.md) | Runtime adapter framework, capability hardening, advanced capability-pack discovery, Coordinator workflow optimization, GitHub collaboration helper migration, and end-to-end UX/docs/starter-pack completion. |
-| V1.0 readiness | GitHub milestones #267 and #276-#281 | Public release definition plus release-critical external skill import/reference hardening. |
+| AF-7 through AF-13 | [roadmap/milestones-af7-af11.md](roadmap/milestones-af7-af11.md) | Runtime adapter framework, capability hardening, advanced capability-pack discovery, Coordinator workflow optimization, GitHub collaboration helper migration, end-to-end UX/docs/starter-pack completion, and external skills import/reference workflow support. |
+| V1.0 release | GitHub issue #267 | Public release definition, release notes, verification, tag, and GitHub Release gate after AF-13 acceptance. |
 | MS-01 through MS-02 | [roadmap/memory-system-milestones.md](roadmap/memory-system-milestones.md) | Memory-system readiness design and memory implementation-home decision, tracked outside the AF stage sequence. |
 
 ## Future Memory-System Implementation
@@ -205,7 +207,7 @@ Expected scope will be defined by MS-01 and MS-02. AF-10 may optimize the collab
 
 ## Immediate Next Planning Tasks
 
-1. Complete the active V1.0 external skills import/reference hardening milestone (#276-#281), starting with #277 taxonomy and reference-only contract.
+1. Complete AF-13 external skills import/reference workflow (#286; #276-#281), starting with #277 taxonomy and reference-only contract.
 2. Complete #267 release planning, verification, release notes, and final Human Decision Contract for `v1.0.0`.
 3. Keep #266 as a V2.0 telemetry collection window, held until formal V2.0 kickoff.
 4. Keep memory-system planning on the MS milestone axis: MS-01 for readiness design and MS-02 for implementation-home decision. MS work remains gated on explicit human authorization.

--- a/docs/roadmap/milestones-af7-af11.md
+++ b/docs/roadmap/milestones-af7-af11.md
@@ -318,15 +318,15 @@ Acceptance criteria:
 - Final release notes can point to README, usage, commands, deployment, catalog docs, and readiness evidence.
 - No memory-system directories, schemas, storage, MCP tools, or automatic memory writing are introduced.
 
-### V1.0 Readiness: External Skills Import And Reference Hardening
+### AF-13: External Skills Import And Reference Workflow
 
-Goal: complete the release-critical external-skill import/reference story before the public `v1.0.0` release.
+Goal: support the independent external-skills use case before the public `v1.0.0` release.
 
-This work is tracked as GitHub milestone `V1.0: External Skills Import and Reference Hardening` with issues #276 through #281.
+This work is tracked as GitHub milestone `AF-13: External Skills Import and Reference Workflow` with Epic #286 and child issues #276 through #281.
 
 Current scheduler state: the human hold is lifted, #276 is accepted as the completed planning/decomposition record, and #277 is the active next issue.
 
-Why it is V1.0-relevant:
+Why it is an independent AF milestone:
 
 - Agent Foundry already exposes `import skill <source>` to users.
 - External skills, prompt packs, articles, repos, and local skill folders can be valuable, but they are reviewed inputs rather than authorities.


### PR DESCRIPTION
## Summary

- Corrects external skills import/reference from V1.0 release-readiness polish to independent AF-13 user-facing capability work.
- Adds AF-13 to roadmap stage and release mapping.
- Points AF-13 to Epic #286 and child issues #276-#281; keeps #277 as active next issue.
- Keeps V1.0 release (#267) as a later release/tag gate after AF-13 acceptance.

## GitHub scheduler state updated

- Created Epic #286: `[AF-13] External Skills Import and Reference Workflow Epic`.
- Renamed milestone to `AF-13: External Skills Import and Reference Workflow`.
- Moved #276-#281 from `stage:v1.0` to `stage:AF-13`.
- #276 remains closed completed; #277 remains active with `needs:architect`; #278-#281 remain dependency-gated.
- Project Epic field updated to point #276-#281/#286 to #286 where available; #286 is In Progress.

## Verification

- `python3 scripts/check_consistency.py`
- `git diff --check`

## Boundaries

No #277 implementation, real external import, external script execution, Vault/private/runtime/generated mutation, generated adapter publish, memory-system work, release/tag creation, or issue closure beyond the already-completed #276 planning issue.