### PR TITLE
Plan V2 local-first orchestration roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 # Agent Foundry Roadmap
 
 Status: planning document
-Updated: 2026-07-01
-Scope: Agent Foundry productization, runtime adapter framework, Trae support, capability-system hardening, repository hygiene, role-orchestration optimization, V1.0 release readiness, and memory-system readiness.
+Updated: 2026-07-03
+Scope: Agent Foundry productization, runtime adapter framework, Trae support, capability-system hardening, repository hygiene, role-orchestration optimization, V1.0 public release baseline, V2 local-first orchestration planning, and memory-system readiness.
 
 ## Purpose
 
@@ -83,10 +83,11 @@ Agent Foundry should use maturity stages for planning and release versions for d
 | AF-11 | GitHub Collaboration Helper Migration | Placeholder for migrating the GitHub-based collaboration workflow helper incubated in Tiny IPA into Agent Foundry as an interleaved pilot after AF10 foundation work and before AF10 final optimization closeout. | Migration scope, ownership boundary, reusable asset shape, user-facing workflow, validation path, and telemetry evidence are defined without importing Tiny IPA project-local assumptions. |
 | AF-12 | End-to-End UX, Documentation, And Core Starter Packs | Final pre-V1 user experience consolidation across onboarding, daily operation, capability packs, runtime/generated adapters, GitHub collaboration helpers, documentation tiers, and first-party Core starter packs. | README, user docs, workflow docs, capability-pack UX, Core-hosted starter packs, and readiness evidence are coherent enough for a public V1 release path. |
 | AF-13 | External Skills Import And Reference Workflow | Users can evaluate external skills, prompt packs, articles, repositories, and local skill folders through a reviewed import/reference workflow before anything becomes active Agent Foundry behavior. | External sources have clear outcomes, reference-only semantics, review packets, user-facing docs, fixture validation, and readiness evidence without treating external material as authority. |
+| V2.0 | Local-First Orchestration And Foundry Board | Agent Foundry becomes a local-first orchestration system with GitHub Project as a remote sync surface, not the source of truth. The work must cover new projects and migration/backfill for existing issue-driven projects. | Users can understand, control, resume, and audit multi-agent work from local durable state, see it in a Foundry Board, sync safely with GitHub Project, and migrate existing GitHub issue/project workflows without losing provenance or review gates. |
 
-Current planning stage: Agent Foundry `v1.0.0` release gate.
+Current planning stage: V2.0 planning and decomposition.
 
-AF-0 explains the existing mixed history. AF-1 starts the stricter planning and multi-agent coordination era. AF-2 designs the productization boundary. AF-3 executes the local Core/Vault split. AF-4 proves the split system works for the current real user across existing deployments and establishes the migration discipline needed for later major upgrades. AF-5 makes onboarding humane and reliable for new users. AF-6 closes the current Foundry product lifecycle so install, pack deployment, refresh, status, and rollback are usable beyond a one-off maintainer path. AF-7 upgrades runtime adapters and adds Trae CN support around a verified global Skill path. AF-8 hardens the capability system under realistic multi-user, multi-machine, multi-runtime, long-running-agent, and drift scenarios. AF-9 adds advanced capability-pack discovery, lifecycle, privacy-safe transfer planning, and user-facing Skill workflow packaging. AF-10 optimizes the Coordinator-driven role workflow using AF9 evidence, then pauses for an AF11 pilot migration, then resumes to analyze real telemetry and harden the workflow model. AF-11 is reserved for the Tiny IPA-incubated GitHub collaboration workflow helper migration pilot. AF-12 closes the V1 user-facing UX/docs/starter-pack surface. AF-13 adds the independent external-skills import/reference workflow. Memory-system planning now uses the separate MS milestone axis.
+AF-0 explains the existing mixed history. AF-1 starts the stricter planning and multi-agent coordination era. AF-2 designs the productization boundary. AF-3 executes the local Core/Vault split. AF-4 proves the split system works for the current real user across existing deployments and establishes the migration discipline needed for later major upgrades. AF-5 makes onboarding humane and reliable for new users. AF-6 closes the current Foundry product lifecycle so install, pack deployment, refresh, status, and rollback are usable beyond a one-off maintainer path. AF-7 upgrades runtime adapters and adds Trae CN support around a verified global Skill path. AF-8 hardens the capability system under realistic multi-user, multi-machine, multi-runtime, long-running-agent, and drift scenarios. AF-9 adds advanced capability-pack discovery, lifecycle, privacy-safe transfer planning, and user-facing Skill workflow packaging. AF-10 optimizes the Coordinator-driven role workflow using AF9 evidence, then pauses for an AF11 pilot migration, then resumes to analyze real telemetry and harden the workflow model. AF-11 is reserved for the Tiny IPA-incubated GitHub collaboration workflow helper migration pilot. AF-12 closes the V1 user-facing UX/docs/starter-pack surface. AF-13 adds the independent external-skills import/reference workflow. V2.0 moves the orchestration source of truth local-first, with GitHub Project as a sync target. Memory-system planning now uses the separate MS milestone axis.
 
 Memory-system milestones are tracked separately as MS-01 and MS-02 so repeated AF roadmap changes do not keep renumbering memory planning. MS milestones do not authorize memory-system implementation unless an explicit human decision does so.
 
@@ -112,21 +113,22 @@ Suggested mapping:
 | AF-12 | `v0.12.0`: end-to-end UX, documentation, and first-party Core starter pack baseline. |
 | AF-13 | `v0.13.0`: external skills import/reference workflow baseline. |
 | V1.0 readiness | `v1.0.0`: public Core release after AF-1 through AF-13 and the release checklist are accepted. |
+| V2.0 | `v2.0.0`: local-first orchestration, Foundry Board, migration/backfill, GitHub Project sync, and readiness evidence after V2 milestones are accepted. |
 
-`v1.0` is the first public release target. It should include the accepted AF-1 through AF-13 baseline plus release notes, verification, tag, and GitHub Release work needed for external users to rely on Agent Foundry without understanding this repository's personal history.
+`v1.0` is the first public release target. It includes the accepted AF-1 through AF-13 baseline plus release notes, verification, tag, and GitHub Release work needed for external users to rely on Agent Foundry without understanding this repository's personal history.
+
+`v2.0` is the next product development target. It should not start by building board features in isolation. It starts with end-to-end user journeys, then telemetry evidence, then local ledger, board model, migration, read-only MVP, controlled GitHub sync, and readiness review.
 
 ## Active Milestone
 
-AF-13 is complete as an independent user-facing capability milestone, not release-readiness polish. The active milestone is now the `v1.0.0` release gate.
+Agent Foundry `v1.0.0` is published. The active planning area is now V2.0 local-first orchestration, but the first V2 implementation milestone is not released yet.
 
 | Milestone | GitHub records | User-facing reason | Status |
 | --- | --- | --- | --- |
-| AF-13 External Skills Import and Reference Workflow | #286 Epic; #276 through #281 | Users need a clear, safe path to evaluate public skills, prompt packs, articles, repos, and local skill folders before anything becomes a practice, asset, reference-only material, adapter output, or rejected input. | Completed; accepted as part of the V1 baseline |
-| Agent Foundry `v1.0.0` release | #267 | Define the first downloadable public Core release, release notes, verification, tag, and GitHub Release gate after AF-13 acceptance. | Active |
+| Agent Foundry `v1.0.0` release | #267 | First downloadable public Core release for external users. | Completed; GitHub Release and tag published |
+| V2.0 Local-First Orchestration And Foundry Board | #292 Epic; #293 through #299; #266 telemetry window | Users need a local source of truth for multi-agent orchestration that can still sync to GitHub Project, plus migration from the current GitHub-first workflow. | Planning and decomposition; first milestone held |
 
-External skills are an independent use case because Agent Foundry already exposes `import skill <source>` and already treats external skills as evidence sources. This path needs a complete lifecycle, reference-only semantics, user-facing decision support, review templates, fixture-backed validation, and a readiness walkthrough.
-
-AF-13 does not authorize memory-system work, automatic token capture, live Vault/private/runtime/generated mutation, generated adapter publish, external script execution, or broad docs rewrites outside reviewed child issues.
+V2.0 does not authorize memory-system work, automatic token capture, live Vault/private/runtime/generated mutation, generated adapter publish, or broad implementation outside reviewed child issues. It must preserve the V1 Core/User Vault/Generated/Runtime/Local Private boundaries.
 
 ## GitHub Project and Epic Workflow
 
@@ -187,6 +189,7 @@ Detailed milestone plans are split out of this overview so the roadmap stays rea
 | AF-0 through AF-6 | [roadmap/milestones-af0-af6.md](roadmap/milestones-af0-af6.md) | Planning context, repository hygiene, productization, Core/Vault split, current-user deployment migration, onboarding, and existing Foundry lifecycle completion. |
 | AF-7 through AF-13 | [roadmap/milestones-af7-af11.md](roadmap/milestones-af7-af11.md) | Runtime adapter framework, capability hardening, advanced capability-pack discovery, Coordinator workflow optimization, GitHub collaboration helper migration, end-to-end UX/docs/starter-pack completion, and external skills import/reference workflow support. |
 | V1.0 release | GitHub issue #267 | Public release definition, release notes, verification, tag, and GitHub Release gate after AF-13 acceptance. |
+| V2.0 | [roadmap/milestones-v2.md](roadmap/milestones-v2.md) | Local-first orchestration, telemetry evidence, Local Collaboration Ledger, Foundry Board, existing project migration, GitHub Project remote sync, and V2 readiness. |
 | MS-01 through MS-02 | [roadmap/memory-system-milestones.md](roadmap/memory-system-milestones.md) | Memory-system readiness design and memory implementation-home decision, tracked outside the AF stage sequence. |
 
 ## Future Memory-System Implementation
@@ -207,7 +210,7 @@ Expected scope will be defined by MS-01 and MS-02. AF-10 may optimize the collab
 
 ## Immediate Next Planning Tasks
 
-1. Complete #267 release planning, verification, release notes, and final Human Decision Contract for `v1.0.0`.
-2. Keep #266 as a V2.0 telemetry collection window, held until formal V2.0 kickoff.
+1. Review the V2.0 Epic and child issue sequence without starting the first milestone.
+2. Keep #266 as the V2.0 telemetry collection window, held until the V2 user-journey and UX contract is accepted.
 3. Keep memory-system planning on the MS milestone axis: MS-01 for readiness design and MS-02 for implementation-home decision. MS work remains gated on explicit human authorization.
 4. Do not create memory directories, schemas, MCP write tools, or automatic memory writing before explicit user authorization.

--- a/docs/roadmap/milestones-v2.md
+++ b/docs/roadmap/milestones-v2.md
@@ -1,0 +1,172 @@
+# Roadmap Milestones V2
+
+Status: planning document
+Updated: 2026-07-03
+Scope: V2 local-first orchestration, Foundry Board, Local Collaboration Ledger, GitHub Project remote sync, and migration from existing GitHub-first projects.
+
+## V2 Goal
+
+V2 makes Agent Foundry a local-first orchestration system.
+
+The user value is simple: a user should be able to see what work is happening, who owns it, what evidence supports it, what is blocked, what changed, and what should happen next without reconstructing state from scattered GitHub comments, Project columns, and Codex thread history.
+
+GitHub Project remains useful, but it becomes a remote sync and collaboration surface. The durable orchestration record should live locally first, then sync outward in a controlled way.
+
+## Product Principles
+
+- Start from end-to-end user journeys before building storage or board features.
+- Support both new projects and existing issue-driven projects.
+- Build read-only visibility before write or sync automation.
+- Preserve GitHub issue and PR evidence as durable public collaboration records.
+- Preserve Agent Foundry layer boundaries: Core, User Vault, Generated, Runtime, and Local Private.
+- Keep memory-system work out of V2 unless a later explicit decision changes that.
+- Make migration and backfill first-class work, not a cleanup afterthought.
+
+## V2 Milestone Sequence
+
+| Milestone | GitHub records | Purpose | Status |
+| --- | --- | --- | --- |
+| V2-0 User Journey And UX Contract | #293 | Define the end-to-end experience before implementation: new project setup, existing project migration, day-to-day orchestration, review, recovery, sync, and completion. | Planned; not released |
+| V2-1 Telemetry Evidence Window | #266 | Collect meaningful telemetry across selected V2 work so ledger and board design are based on real coordination overhead rather than guesses. | Held until V2-0 acceptance |
+| V2-2 Local Collaboration Ledger | #294 | Define the local durable event model for assignments, dispatches, evidence, reviews, approvals, merges, closures, blockers, and handoffs. | Dependency-gated |
+| V2-3 Foundry Board Domain Model | #295 | Define board state, columns, filters, issue/project/thread relationships, and user-visible status without binding too early to UI implementation. | Dependency-gated |
+| V2-4 Existing Project Migration And Backfill | #296 | Convert current GitHub-first projects into local-first orchestration state with provenance and conflict handling. | Dependency-gated |
+| V2-5 Foundry Board Read-Only MVP | #297 | Give users a working read-only board that explains current work, evidence, owner, next action, and blocked states from local durable data. | Dependency-gated |
+| V2-6 GitHub Project Remote Sync | #298 | Sync local orchestration state to GitHub Project safely, with conflict rules, dry-run/readback behavior, and no hidden source-of-truth reversal. | Dependency-gated |
+| V2-7 V2 Readiness And Release Gate | #299 | Verify end-to-end journeys, migration, board visibility, sync behavior, docs, and release readiness. | Dependency-gated |
+
+## V2-0 User Journey And UX Contract
+
+This milestone prevents V2 from repeating a common failure mode: implementing useful internal mechanics without first proving the user-facing workflow.
+
+It should answer:
+
+- What does a user do when starting a new local-first project?
+- What does a user do when migrating an existing GitHub issue/project workflow?
+- What does the board show when work is ready, in progress, in review, blocked, done, or stale?
+- What can the user trust as the local source of truth?
+- What is GitHub allowed to overwrite, and what is local state allowed to overwrite?
+- What are the first read-only screens or reports before write automation exists?
+- What evidence is required before an item is considered complete?
+
+V2-0 should not implement the board, ledger, sync, or migration tools. It is a design and acceptance contract.
+
+## V2-1 Telemetry Evidence Window
+
+#266 remains the telemetry evidence window. It should not run as a standalone research task disconnected from real work.
+
+It should be bound to a selected V2 slice after V2-0 is accepted. The telemetry should capture enough data to compare:
+
+- GitHub issue/PR comment overhead;
+- Project field and label churn;
+- dispatch and callback frequency;
+- review and re-review loops;
+- human gate count and delay;
+- context rehydration cost;
+- unclear owner or next-action failures;
+- places where local-first state would have reduced coordination cost.
+
+Telemetry evidence remains decision support. It is not billing-grade token accounting and does not authorize memory-system work.
+
+## V2-2 Local Collaboration Ledger
+
+The Local Collaboration Ledger is the local durable event record for orchestration.
+
+Expected event categories include:
+
+- issue or Epic creation;
+- assignment and owner-role changes;
+- dispatch;
+- callback;
+- evidence collection;
+- review;
+- requested changes;
+- acceptance;
+- human approval;
+- merge;
+- closure;
+- blocked state;
+- migration/backfill provenance;
+- GitHub sync readback.
+
+The ledger must support audit and replay before it supports automation.
+
+## V2-3 Foundry Board Domain Model
+
+The Foundry Board is the user-facing view over local orchestration state.
+
+It should help users answer:
+
+- What should I look at next?
+- What is blocked and why?
+- What is waiting on human approval?
+- What is done but not reflected in GitHub Project?
+- What has GitHub state that disagrees with local state?
+- Which thread, issue, PR, or evidence comment explains the latest state?
+
+The domain model should define states and transitions before UI implementation.
+
+## V2-4 Existing Project Migration And Backfill
+
+Existing GitHub-first projects must be supported.
+
+Migration should:
+
+- read current issues, PRs, comments, labels, milestones, and Project fields;
+- preserve provenance rather than inventing clean history;
+- identify incomplete, contradictory, or stale records;
+- create local ledger records with confidence levels;
+- avoid changing GitHub state during read-only backfill;
+- produce a migration report users can review before any write-back.
+
+This milestone is required for V2 because Agent Foundry already has substantial durable GitHub history.
+
+## V2-5 Foundry Board Read-Only MVP
+
+The first usable board should be read-only.
+
+It should display enough information for a user to operate confidently:
+
+- active work;
+- owner role;
+- Roadmap Status;
+- blocking reason;
+- latest evidence;
+- next action;
+- related issue, PR, branch, and thread;
+- local/GitHub sync status.
+
+Write automation should wait until read-only behavior is trusted.
+
+## V2-6 GitHub Project Remote Sync
+
+GitHub Project sync should treat GitHub as a collaboration mirror, not the canonical local orchestration store.
+
+The sync design must define:
+
+- dry-run plan;
+- conflict detection;
+- field mapping;
+- Roadmap Status and built-in Status behavior;
+- idempotency;
+- retry and readback behavior;
+- human gates for risky writes;
+- rollback or repair guidance.
+
+Project sync must not silently close issues, overwrite human edits, or hide discrepancies between local and remote state.
+
+## V2-7 V2 Readiness And Release Gate
+
+V2 readiness should verify:
+
+- new project journey;
+- existing project migration journey;
+- daily orchestration journey;
+- review and human approval journey;
+- blocked/recovery journey;
+- local-first source-of-truth behavior;
+- GitHub Project sync behavior;
+- docs and user-facing walkthrough;
+- telemetry evidence and residual risks.
+
+V2 release should remain separate from memory-system implementation.


### PR DESCRIPTION
## Summary

- Updates the roadmap overview for post-v1.0 V2 planning.
- Adds `docs/roadmap/milestones-v2.md` for local-first orchestration, Local Collaboration Ledger, Foundry Board, existing-project migration/backfill, GitHub Project remote sync, and V2 readiness.
- Aligns the new GitHub issue sequence: #292 Epic, #293-#299, and existing #266 as the V2 telemetry window.

## Scheduler / Project state

- #292-#299 created under milestone `v2.0: Foundry Board and Local Collaboration Ledger`.
- #266 and #292-#299 are present in `Agent Foundry Roadmap` Project.
- Project fields are aligned as `Status=Todo`, `Roadmap Status=Inbox`.
- No V2 child issue has a `needs:*` release label.
- #293 V2-0 is not started; first milestone remains held pending later human/Architect release.

## Verification

- `python3 scripts/check_consistency.py`
- `git diff --check origin/main...HEAD`

## Boundaries

No V2 implementation, no memory-system work, no live Vault/runtime/generated/private mutation, no generated adapter publish, no release/tag work, and no `main` merge authorization.