### PR TITLE
Document V1 maintenance and V2 branch policy

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -119,6 +119,28 @@ Suggested mapping:
 
 `v2.0` is the next product development target. It should not start by building board features in isolation. It starts with end-to-end user journeys, then telemetry evidence, then local ledger, board model, migration, read-only MVP, controlled GitHub sync, and readiness review.
 
+## Branch and Release Lines
+
+Use `main` as the stable V1.x maintenance line until V2 is accepted and ready to become the default product line.
+
+This matters because Agent Foundry Core can keep receiving harvest-driven, user-approved, backward-compatible improvements after `v1.0.0`. Those improvements should remain available to current users and future V2 work. Therefore:
+
+- `main` receives V1.x maintenance, bug fixes, documentation improvements, workflow/template/test improvements, and generic Core harvest updates.
+- `v1.1.0`, `v1.2.0`, and other V1.x tags are cut from `main` while V2 is still under development.
+- `codex/v2-local-first-orchestration` is the V2 integration branch for ledger, Foundry Board, migration, sync, and other V2-only work.
+- V2 child branches target `codex/v2-local-first-orchestration`, not `main`, unless the change is explicitly a V1.x-compatible Core maintenance improvement.
+- V2 periodically forward-merges from `main` so V1.x maintenance and harvest improvements are not lost.
+- V2 merges back to `main` only after V2 readiness is accepted and a final human-gated release/integration decision is made.
+
+Default harvest routing:
+
+| Update type | Target |
+| --- | --- |
+| Backward-compatible Core practice/workflow/template/docs/test improvement | `main`, then forward-merge into V2 |
+| V2-only orchestration, ledger, board, migration, or sync behavior | `codex/v2-local-first-orchestration` |
+| Private or canonical User Vault practice/asset update | selected User Vault, not Core |
+| Breaking schema/runtime/source-of-truth change | V2 branch or explicit major-version gate, not default `main` maintenance |
+
 ## Active Milestone
 
 Agent Foundry `v1.0.0` is published. The active planning area is now V2.0 local-first orchestration, but the first V2 implementation milestone is not released yet.

--- a/docs/roadmap/milestones-v2.md
+++ b/docs/roadmap/milestones-v2.md
@@ -22,6 +22,23 @@ GitHub Project remains useful, but it becomes a remote sync and collaboration su
 - Keep memory-system work out of V2 unless a later explicit decision changes that.
 - Make migration and backfill first-class work, not a cleanup afterthought.
 
+## Branch Policy
+
+V2 work uses `codex/v2-local-first-orchestration` as its integration branch.
+
+Branch rules:
+
+- V2 child branches should target `codex/v2-local-first-orchestration`.
+- V2-only changes should not target `main` while V2 is incomplete.
+- `main` remains the V1.x maintenance line and default target for backward-compatible harvest-driven Core updates.
+- V2 should regularly forward-merge from `main` to absorb V1.x maintenance and harvest improvements.
+- Do not merge V2 back to `main` until V2 readiness is accepted and a final human-gated integration decision approves it.
+
+Release rules:
+
+- V1.x tags are cut from `main`.
+- V2.0.0 is cut only after V2 integration is accepted and merged through the final release gate.
+
 ## V2 Milestone Sequence
 
 | Milestone | GitHub records | Purpose | Status |


### PR DESCRIPTION
## Summary

- Documents `main` as the V1.x maintenance and default backward-compatible harvest line.
- Documents `codex/v2-local-first-orchestration` as the V2 integration branch.
- Defines how harvest-driven Core updates, V2-only work, User Vault updates, and breaking changes should be routed.
- Clarifies that V1.x tags are cut from `main`, while V2.0.0 waits for final V2 readiness and integration.

## Verification

- `python3 scripts/check_consistency.py`
- `git diff --check origin/main...HEAD`

## Boundaries

No AF14 issue creation or implementation, no V2 milestone release, no #293 start, no memory-system work, no live Vault/runtime/generated/private mutation, no generated adapter publish, and no release/tag work.