### PR TITLE
Mark AF14 complete in roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -150,7 +150,7 @@ Agent Foundry `v1.0.0` is published. The active planning area is now V2.0 local-
 | Milestone | GitHub records | User-facing reason | Status |
 | --- | --- | --- | --- |
 | Agent Foundry `v1.0.0` release | #267 | First downloadable public Core release for external users. | Completed; GitHub Release and tag published |
-| AF-14 Tester Role And Test Planning Workflow | #302 Epic; #303 through #308 | Users need test planning and evidence that answer what was tested, why it is enough, which risks remain, and when human trial is still needed. | Active; #306/#307 implementation |
+| AF-14 Tester Role And Test Planning Workflow | #302 Epic; #303 through #308; PR #311 | Users need test planning and evidence that answer what was tested, why it is enough, which risks remain, and when human trial is still needed. | Completed; integrated into `main` as V1.x maintenance |
 | V2.0 Local-First Orchestration And Foundry Board | #292 Epic; #293 through #299; #266 telemetry window | Users need a local source of truth for multi-agent orchestration that can still sync to GitHub Project, plus migration from the current GitHub-first workflow. | Planning and decomposition; first milestone held |
 
 V2.0 does not authorize memory-system work, automatic token capture, live Vault/private/runtime/generated mutation, generated adapter publish, or broad implementation outside reviewed child issues. It must preserve the V1 Core/User Vault/Generated/Runtime/Local Private boundaries.
@@ -237,7 +237,7 @@ Expected scope will be defined by MS-01 and MS-02. AF-10 may optimize the collab
 
 ## Immediate Next Planning Tasks
 
-1. Complete AF-14 #303 Tester role and workflow-gate design using tiny-ipa #230 plus independent web research.
-2. Keep V2 #293 and #266 held while AF-14 proceeds as V1.x maintenance.
+1. Keep V2 #293 and #266 held until the next explicit V2 kickoff decision.
+2. Treat V1.x maintenance work, including harvest-compatible Core/docs/workflow/test improvements, as `main`-targeted unless it changes V2-only orchestration behavior.
 3. Keep memory-system planning on the MS milestone axis: MS-01 for readiness design and MS-02 for implementation-home decision. MS work remains gated on explicit human authorization.
 4. Do not create memory directories, schemas, MCP write tools, or automatic memory writing before explicit user authorization.

--- a/docs/roadmap/milestones-af14.md
+++ b/docs/roadmap/milestones-af14.md
@@ -47,13 +47,13 @@ AF-14 is V1.x maintenance.
 
 | Milestone | GitHub records | Purpose | Status |
 | --- | --- | --- | --- |
-| AF-14 Epic | #302 | Coordinate Tester role and test planning workflow. | Active |
+| AF-14 Epic | #302 | Coordinate Tester role and test planning workflow. | Done |
 | AF-14 A Tester role and workflow gates | #303 | Define role boundaries, routing gates, test evidence taxonomy, and research-backed design. | Done |
 | AF-14 B Testing Contract and evidence taxonomy | #304 | Define test plan/test matrix fields and evidence categories. | Done |
 | AF-14 C Scheduler and Project workflow support | #305 | Decide `needs:tester`, Project Owner Role=Tester, and Execution Contract validation shape. | Done |
-| AF-14 D Workflow docs and templates | #306 | Implement accepted docs and templates. | Active; Implementer |
-| AF-14 E Helper validation and fixtures | #307 | Implement accepted helper/schema/test validation. | Active; Implementer |
-| AF-14 F Readiness and pilot review | #308 | Run bounded pilot and readiness review. | Dependency-gated |
+| AF-14 D Workflow docs and templates | #306 | Implement accepted docs and templates. | Done |
+| AF-14 E Helper validation and fixtures | #307 | Implement accepted helper/schema/test validation. | Done |
+| AF-14 F Readiness and pilot review | #308 | Run bounded pilot and readiness review. | Done |
 
 ## Non-Goals
 


### PR DESCRIPTION
## Scope

Roadmap cleanup after AF14 completion.

This updates stale AF14 planning text after PR #311 was merged and #302/#308 were closed completed:
- marks AF14 as completed/integrated into `main` as V1.x maintenance;
- marks #302/#306/#307/#308 rows as Done in `docs/roadmap/milestones-af14.md`;
- updates immediate next planning tasks so they no longer point at completed AF14 work.

## Verification

- `python3 scripts/check_consistency.py`
- `git diff --check`

## Boundaries

Docs-only cleanup. No runtime/Vault/private/generated mutation, no generated Skill publish, no V2/#293 work, no release/tag work.
