### PR TITLE
[AF15] Harden collaboration readiness dry-run degraded access

### DIFF
--- a/scripts/github_collaboration_helper.py
+++ b/scripts/github_collaboration_helper.py
@@ -729,6 +729,71 @@ def normalize_project_items(data: Any) -> list[dict[str, Any]]:
     return [item for item in data if isinstance(item, dict)]
 
 
+def project_metadata_from_fixture(data: Any, items: list[dict[str, Any]]) -> dict[str, Any]:
+    fields_seen: set[str] = set()
+    options_seen: set[str] = set()
+    explicit_metadata = False
+    if isinstance(data, dict):
+        fields = data.get("fields")
+        if isinstance(fields, list):
+            explicit_metadata = True
+            for field in fields:
+                if isinstance(field, dict):
+                    name = field.get("name")
+                    if name:
+                        fields_seen.add(str(name))
+                    for option in field.get("options") or []:
+                        if isinstance(option, dict):
+                            option_name = option.get("name")
+                        else:
+                            option_name = option
+                        if field.get("name") == "Owner Role" and option_name:
+                            options_seen.add(str(option_name))
+                elif field:
+                    fields_seen.add(str(field))
+        options = data.get("options")
+        if isinstance(options, dict):
+            explicit_metadata = True
+            for option in options.get("Owner Role") or options.get("owner_role") or []:
+                if isinstance(option, dict):
+                    option = option.get("name")
+                if option:
+                    options_seen.add(str(option))
+        elif isinstance(options, list):
+            explicit_metadata = True
+            for option in options:
+                if isinstance(option, dict):
+                    option = option.get("name")
+                if option:
+                    options_seen.add(str(option))
+    for item in items:
+        for field in READINESS_PROJECT_FIELDS:
+            if project_field_value(item, field):
+                fields_seen.add(field)
+        field_values = item.get("fieldValues") or item.get("field_values")
+        if isinstance(field_values, list):
+            for value in field_values:
+                if not isinstance(value, dict):
+                    continue
+                name = value.get("fieldName") or value.get("name")
+                if name:
+                    fields_seen.add(str(name))
+                if name == "Owner Role":
+                    raw = value.get("value") or value.get("text") or value.get("name")
+                    if isinstance(raw, dict):
+                        raw = raw.get("name") or raw.get("text") or raw.get("title")
+                    if raw:
+                        options_seen.add(str(raw))
+        owner = project_field_value(item, "Owner Role")
+        if owner:
+            options_seen.add(owner)
+    return {
+        "fields_seen": sorted(fields_seen),
+        "options_seen": sorted(options_seen),
+        "explicit_metadata": explicit_metadata,
+    }
+
+
 def normalize_label_collection(data: Any) -> list[str]:
     if data is None:
         return []
@@ -919,7 +984,17 @@ def read_project_items(args: argparse.Namespace) -> tuple[list[dict[str, Any]], 
     if args.project_items_json:
         data = load_json(args.project_items_json)
         items = normalize_project_items(data)
-        return items, {"source": "fixture", "status": "ok", "item_count": len(items)}, {"attempts": 0, "transient_failures": []}
+        metadata = project_metadata_from_fixture(data, items)
+        return (
+            items,
+            {
+                "source": "fixture",
+                "status": "ok",
+                "item_count": len(items),
+                **metadata,
+            },
+            {"attempts": 0, "transient_failures": []},
+        )
     if not args.project_owner and not args.project_number:
         return [], {"source": "skipped", "status": "config_missing", "item_count": 0}, {"attempts": 0, "transient_failures": []}
     if not args.project_owner or not args.project_number:
@@ -943,6 +1018,7 @@ def read_project_items(args: argparse.Namespace) -> tuple[list[dict[str, Any]], 
         )
         if result["ok"]:
             items = normalize_project_items(result["data"])
+            metadata = project_metadata_from_fixture(result["data"], items)
             return (
                 items,
                 {
@@ -951,6 +1027,7 @@ def read_project_items(args: argparse.Namespace) -> tuple[list[dict[str, Any]], 
                     "owner": args.project_owner,
                     "number": args.project_number,
                     "item_count": len(items),
+                    **metadata,
                 },
                 {"attempts": attempt, "transient_failures": transient_failures},
             )
@@ -965,6 +1042,8 @@ def read_project_items(args: argparse.Namespace) -> tuple[list[dict[str, Any]], 
         availability = "permission_denied"
     elif last_result and last_result["error_type"] == "auth_unavailable":
         availability = "auth_unavailable"
+    elif last_result and last_result["error_type"] == "transient":
+        availability = "degraded"
     return (
         [],
         {
@@ -1160,11 +1239,17 @@ def readiness_repair(action: str, subject: str, expected_effect: str, source_evi
     }
 
 
-def readiness_contract_summary(item: dict[str, Any], needs: set[str]) -> dict[str, Any]:
+def readiness_contract_summary(
+    item: dict[str, Any],
+    needs: set[str],
+    project_item: dict[str, Any] | None = None,
+    project_requested: bool = False,
+    default_stage: str | None = None,
+) -> dict[str, Any]:
     labels = label_names(item)
     contract = validate_execution_contract(item.get("body") or "")
     testing = validate_testing_contract(item.get("body") or "", labels)
-    findings, repairs = audit_issue(item, None, needs, project_requested=False, default_stage=None)
+    findings, repairs = audit_issue(item, project_item, needs, project_requested=project_requested, default_stage=default_stage)
     return {
         "number": issue_number(item),
         "title": item.get("title"),
@@ -1178,7 +1263,7 @@ def readiness_contract_summary(item: dict[str, Any], needs: set[str]) -> dict[st
                 repair_item.get("action", "review"),
                 f"issue:{repair_item.get('issue')}",
                 f"{repair_item.get('field', 'routing')} -> {repair_item.get('value', 'review required')}",
-                source_evidence="issue_contract_or_label_state",
+                source_evidence="issue_contract_label_or_project_state",
             )
             for repair_item in repairs
         ],
@@ -1189,6 +1274,8 @@ def project_availability(project_status: dict[str, Any]) -> str:
     status = project_status.get("status")
     if status == "ok":
         return "ok"
+    if status == "degraded":
+        return "degraded"
     if status == "config_missing":
         return "config_missing"
     if status in {"permission_denied", "auth_unavailable"}:
@@ -1205,7 +1292,7 @@ def source_status(source: str, status: dict[str, Any], attempts: dict[str, Any],
     mapped = raw_status
     if raw_status in {"config_missing", "skipped"}:
         mapped = raw_status
-    elif raw_status not in {"ok", "unavailable", "permission_denied", "auth_unavailable", "transient_failure"}:
+    elif raw_status not in {"ok", "unavailable", "degraded", "permission_denied", "auth_unavailable", "transient_failure"}:
         mapped = "unavailable" if raw_status not in {"fixture"} else "ok"
     return {
         "source": source,
@@ -1255,14 +1342,59 @@ def cmd_collaboration_readiness(args: argparse.Namespace) -> None:
             )
             repairs.append(readiness_repair("create_label", f"label:{label}", f"create missing role label {label}", "github_rest_labels"))
 
-    issue_rows = [readiness_contract_summary(issue, expected_needs) for issue in issues[: args.limit]]
+    project_requested = project_status.get("source") in ("fixture", "live_gh") and project_status.get("status") == "ok"
+    project_by_issue = {project_item_issue_number(item): item for item in project_items if project_item_issue_number(item) is not None}
+    issue_rows = [
+        readiness_contract_summary(
+            issue,
+            expected_needs,
+            project_item=project_by_issue.get(issue_number(issue)),
+            project_requested=project_requested,
+            default_stage=args.stage,
+        )
+        for issue in issues[: args.limit]
+    ]
     pr_rows = [readiness_contract_summary(pr, expected_needs) for pr in prs[: args.limit]]
     for row in (*issue_rows, *pr_rows):
         findings.extend(row["findings"])
         repairs.extend(row["repair_plan"])
 
-    project_fields_seen = sorted({field for item in project_items for field in READINESS_PROJECT_FIELDS if project_field_value(item, field)})
+    project_fields_seen = project_status.get("fields_seen") or sorted({field for item in project_items for field in READINESS_PROJECT_FIELDS if project_field_value(item, field)})
+    project_options_seen = project_status.get("options_seen") or []
     project_ok = project_status.get("status") == "ok"
+    if project_ok:
+        missing_project_fields = sorted(set(READINESS_PROJECT_FIELDS) - set(project_fields_seen))
+        for field in missing_project_fields:
+            findings.append(
+                {
+                    "severity": "error",
+                    "code": "missing_project_field",
+                    "subject": f"project_field:{field}",
+                    "expected": {"field": field},
+                    "actual": {"present": False},
+                }
+            )
+            repairs.append(readiness_repair("create_project_field", f"project_field:{field}", f"create Project mirror field {field}", "github_graphql_project_v2"))
+        if project_status.get("explicit_metadata"):
+            missing_role_options = sorted(set(READINESS_PROJECT_OPTIONS) - set(project_options_seen))
+            for option in missing_role_options:
+                findings.append(
+                    {
+                        "severity": "error",
+                        "code": "missing_project_role_option",
+                        "subject": f"project_option:Owner Role:{option}",
+                        "expected": {"Owner Role": option},
+                        "actual": {"present": False},
+                    }
+                )
+                repairs.append(
+                    readiness_repair(
+                        "create_project_option",
+                        f"project_option:Owner Role:{option}",
+                        f"create Owner Role option {option}",
+                        "github_graphql_project_v2",
+                    )
+                )
     if project_status.get("source") == "live_gh" and not project_ok:
         findings.append(
             {
@@ -1316,10 +1448,11 @@ def cmd_collaboration_readiness(args: argparse.Namespace) -> None:
             "project_v2": {
                 "availability": project_availability(project_status),
                 "fields_seen": project_fields_seen,
-                "options_seen": [],
+                "options_seen": project_options_seen,
                 "item_count": project_status.get("item_count", "unknown"),
                 "source": project_status.get("source"),
                 "error": project_status.get("error"),
+                "metadata_source": "explicit" if project_status.get("explicit_metadata") else "observed_items",
             },
         },
         "routing_state": {

--- a/scripts/test_github_collaboration_helper.py
+++ b/scripts/test_github_collaboration_helper.py
@@ -116,6 +116,7 @@ def main() -> int:
         fixture = base / "issue.json"
         audit_issues = base / "audit-issues.json"
         audit_project = base / "audit-project.json"
+        readiness_project = base / "readiness-project.json"
         readiness_labels = base / "readiness-labels.json"
         readiness_prs = base / "readiness-prs.json"
         inbox = base / "inbox.json"
@@ -308,6 +309,44 @@ def main() -> int:
                             "risk": {"name": "Medium"},
                         },
                     ]
+                }
+            ),
+        )
+        write(
+            readiness_project,
+            json.dumps(
+                {
+                    "fields": [
+                        {"name": "Status"},
+                        {"name": "Roadmap Status"},
+                        {"name": "Stage"},
+                        {
+                            "name": "Owner Role",
+                            "options": [
+                                {"name": "Architect"},
+                                {"name": "Implementer"},
+                                {"name": "Reviewer"},
+                                {"name": "Tester"},
+                                {"name": "Human"},
+                            ],
+                        },
+                    ],
+                    "items": [
+                        {
+                            "content": {"number": 225},
+                            "status": {"name": "Todo"},
+                            "roadmap Status": {"name": "Ready"},
+                            "stage": {"name": "AF-11"},
+                            "owner Role": None,
+                        },
+                        {
+                            "content": {"number": 227},
+                            "status": {"name": "Done"},
+                            "roadmap Status": {"name": "Done"},
+                            "stage": {"name": "AF-10"},
+                            "owner Role": {"name": "Reviewer"},
+                        },
+                    ],
                 }
             ),
         )
@@ -593,7 +632,7 @@ def main() -> int:
                 "--prs-json",
                 str(readiness_prs),
                 "--project-items-json",
-                str(audit_project),
+                str(readiness_project),
                 "--json",
             ],
             base,
@@ -607,8 +646,12 @@ def main() -> int:
             ("collaboration-readiness-missing-harvester", '"label:needs:harvester"'),
             ("collaboration-readiness-contract-invalid", '"code": "execution_contract_invalid"'),
             ("collaboration-readiness-testing-invalid", '"code": "testing_contract_invalid"'),
+            ("collaboration-readiness-missing-project-item", '"code": "missing_project_item"'),
+            ("collaboration-readiness-missing-project-field", '"code": "missing_project_field"'),
+            ("collaboration-readiness-missing-role-option", '"code": "missing_project_role_option"'),
             ("collaboration-readiness-pr-sampled", '"prs_sampled"'),
             ("collaboration-readiness-repair-not-supported", '"apply_supported_now": false'),
+            ("collaboration-readiness-project-option-repair", '"action": "create_project_option"'),
             ("collaboration-readiness-no-full-project-scan", '"full_project_scan_performed": false'),
             ("collaboration-readiness-v2-shape", '"local_ledger_candidate": true'),
         ):
@@ -632,7 +675,7 @@ def main() -> int:
             {"AGENT_REPO": "farmerhunter/agent-foundry", "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}"},
         )
         errors.extend(expect_ok("scheduler-audit-project-degraded", degraded, '"status": "degraded"'))
-        errors.extend(expect_ok("scheduler-audit-project-unavailable", degraded, '"availability": "unavailable"'))
+        errors.extend(expect_ok("scheduler-audit-project-degraded-availability", degraded, '"availability": "degraded"'))
         errors.extend(expect_ok("scheduler-audit-project-read-once", degraded, '"attempts": 1'))
         readiness_degraded = run(
             [
@@ -655,9 +698,58 @@ def main() -> int:
             {"AGENT_REPO": "farmerhunter/agent-foundry", "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}"},
         )
         errors.extend(expect_ok("collaboration-readiness-project-degraded", readiness_degraded, '"status": "degraded"'))
-        errors.extend(expect_ok("collaboration-readiness-project-unavailable", readiness_degraded, '"availability": "unavailable"'))
+        errors.extend(expect_ok("collaboration-readiness-project-degraded-availability", readiness_degraded, '"availability": "degraded"'))
         errors.extend(expect_ok("collaboration-readiness-project-read-once", readiness_degraded, '"attempts": 1'))
+        errors.extend(expect_ok("collaboration-readiness-project-eof-recorded", readiness_degraded, "EOF while reading Project v2"))
         errors.extend(expect_ok("collaboration-readiness-no-project-write", readiness_degraded, '"apply_supported_now": false'))
+        write(fake_gh, "#!/bin/sh\nprintf '%s\\n' 'GraphQL rate limit exceeded' >&2\nexit 1\n")
+        fake_gh.chmod(0o755)
+        readiness_rate_limited = run(
+            [
+                "collaboration-readiness",
+                "--config",
+                str(TEMPLATE),
+                "--labels-json",
+                str(readiness_labels),
+                "--issues-json",
+                str(audit_issues),
+                "--project-owner",
+                "@me",
+                "--project-number",
+                "3",
+                "--project-retries",
+                "1",
+                "--json",
+            ],
+            base,
+            {"AGENT_REPO": "farmerhunter/agent-foundry", "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}"},
+        )
+        errors.extend(expect_ok("collaboration-readiness-rate-limit-degraded", readiness_rate_limited, '"availability": "degraded"'))
+        errors.extend(expect_ok("collaboration-readiness-rate-limit-recorded", readiness_rate_limited, "GraphQL rate limit exceeded"))
+        write(fake_gh, "#!/bin/sh\nprintf '%s\\n' 'TLS handshake timeout while reading Project v2' >&2\nexit 1\n")
+        fake_gh.chmod(0o755)
+        readiness_tls = run(
+            [
+                "collaboration-readiness",
+                "--config",
+                str(TEMPLATE),
+                "--labels-json",
+                str(readiness_labels),
+                "--issues-json",
+                str(audit_issues),
+                "--project-owner",
+                "@me",
+                "--project-number",
+                "3",
+                "--project-retries",
+                "1",
+                "--json",
+            ],
+            base,
+            {"AGENT_REPO": "farmerhunter/agent-foundry", "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}"},
+        )
+        errors.extend(expect_ok("collaboration-readiness-tls-degraded", readiness_tls, '"availability": "degraded"'))
+        errors.extend(expect_ok("collaboration-readiness-tls-recorded", readiness_tls, "TLS handshake timeout"))
         errors.extend(
             expect_ok(
                 "activation-report-fixture",


### PR DESCRIPTION
## Summary

Implements AF15 #317 dry-run repair planning and degraded GitHub access handling for the collaboration readiness helper.

## Scope

- Extends collaboration readiness reporting for Project field, Project item, role option, and degraded GitHub/Project access states.
- Keeps repair planning dry-run only with `mutation_performed: false` and no apply/live repair support.
- Preserves REST-first / targeted Project v2 behavior and no default full Project scan.
- Adds fixture coverage for rate limit, TLS/EOF, missing Project fields/items/options, partial/degraded reports, and no Project writes.

## Verification

- `python3 -m py_compile scripts/github_collaboration_helper.py scripts/test_github_collaboration_helper.py`
- `python3 scripts/test_github_collaboration_helper.py`
- `python3 scripts/check_consistency.py`
- `git diff --check origin/main...HEAD`

## Boundaries

No live repair/apply, Project v2 mutation, Vault/private/runtime/generated mutation, generated Skill/adapter publish, capability-pack publish, V2 implementation, release/tag work, or AF15 Epic closure.

Closes no issue directly; #317 should close only after review/acceptance and merge verification.
