### PR TITLE
Finalize AF15 collaboration readiness

### DIFF
--- a/catalog/capability-packs/index.yaml
+++ b/catalog/capability-packs/index.yaml
@@ -27,9 +27,9 @@ entries:
     title: Optional GitHub Collaboration Starter Pack
     channel: official
     catalog_status: available
-    latest_version: 0.2.0
+    latest_version: 0.3.0
     manifest_path: fixtures/capability-packs/optional-multi-agent/manifest.yaml
-    manifest_sha256: ea14748cdf10142f37c46c9357019e162a3991afe623b20708cc7ef2a618ed58
+    manifest_sha256: e5a92fffe31c3065564ce43aae6daa0b029ba3a4e2490061cfd7fc0d4d1d8cb6
     compatibility_summary: "Core schema 1; Vault layout [1]; bootstrap required; selected Vault review required."
     compatibility_metadata:
       core_schema_version_min: 1

--- a/catalog/capability-packs/pack.multi-agent.optional/CHANGELOG.md
+++ b/catalog/capability-packs/pack.multi-agent.optional/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.3.0
+
+- Added AF15 collaboration readiness guidance for new-project setup and
+  existing-project drift audit.
+- Added dry-run repair planning and degraded GitHub/Project access reporting
+  to the optional starter contract while keeping all repair/apply behavior
+  disabled.
+- Kept member records as manual-review candidate records and preserved selected
+  User Vault authority after deployment.
+- No live Project repair/apply, generated Skill publish, runtime install,
+  Vault mutation, adapter publish, release artifact publishing, or private/local
+  evidence export is authorized by this catalog entry.
+
 ## 0.2.0
 
 - Cataloged as an official first-party optional GitHub collaboration starter

--- a/catalog/capability-packs/pack.multi-agent.optional/README.md
+++ b/catalog/capability-packs/pack.multi-agent.optional/README.md
@@ -33,6 +33,28 @@ dependency-gated queues、review handoffs，以及 write automation 前的 read-
 来进行 GitHub issue/PR 协作。当工作需要在多个 role sessions 之间流转，并且 GitHub
 仍然是 durable source of truth 时，它最有用。
 
+## Collaboration Readiness / 协作就绪检查
+
+The current starter guidance includes the AF15 collaboration readiness model:
+new projects can check whether role labels, routing templates, Execution
+Contracts, Testing Contracts, and optional Project/Kanban mirrors are present
+before they start multi-agent work. Existing projects can audit drift and get a
+dry-run repair plan without changing GitHub or Project state.
+
+当前 starter guidance 包含 AF15 collaboration readiness model：新项目可以先检查
+role labels、routing templates、Execution Contracts、Testing Contracts 和可选的
+Project/Kanban mirrors 是否齐备；已有项目可以 audit drift，并获得 dry-run repair
+plan，而不会修改 GitHub 或 Project state。
+
+Readiness reports are expected to stay read-only. They should show
+`mutation_performed: false`, use REST-first GitHub access, query Project v2 only
+when configured and needed, avoid default full Project scans, and report
+degraded GitHub or Project access instead of hiding it.
+
+Readiness reports 应保持 read-only。它们应显示 `mutation_performed: false`，
+优先使用 REST 访问 GitHub，仅在配置且必要时查询 Project v2，避免默认 full Project
+scan，并在 GitHub 或 Project 访问 degraded 时明确报告。
+
 ## What Remains Manual Or Review-Gated / 仍需手动或 Review-Gated 的内容
 
 People or delegated workflow roles still decide scope, architecture direction,
@@ -49,12 +71,13 @@ closure，以及任何修改 protected branches 或跨越 privacy/security bound
 ## What It Does Not Automate / 不自动化什么
 
 This pack does not merge PRs, close issues, create hidden access control, apply
-runtime helpers, publish generated Skills, mutate Project v2 by default, export
-private Vault content, or treat local helper receipts as authority.
+runtime helpers, publish generated Skills, mutate Project v2 by default, execute
+dry-run repair plans, export private Vault content, or treat local helper
+receipts as authority.
 
 这个 pack 不会 merge PRs、close issues、创建隐藏 access control、apply runtime
-helpers、publish generated Skills、默认 mutate Project v2、export private Vault
-content，也不会把 local helper receipts 当成 authority。
+helpers、publish generated Skills、默认 mutate Project v2、执行 dry-run repair
+plans、export private Vault content，也不会把 local helper receipts 当成 authority。
 
 ## When To Accept / 何时接受安装
 
@@ -80,7 +103,9 @@ labels 和 issue comments 作为 workflow record，可以跳过它。
 
 The pack covers a base GitHub collaboration workflow: role labels, durable
 issue/PR comments, explicit Execution Contract fields, dependency-gated queues,
-and read-only audit before write automation.
+Testing Contract evidence when needed, collaboration readiness audit, dry-run
+repair planning, degraded GitHub/Project access reporting, and read-only audit
+before write automation.
 
 Project v2 status may be a configured visual mirror, but it is not the scheduler
 source of truth. Runtime helper install, generated Skill publish, and mutating
@@ -99,9 +124,10 @@ receipts remain downstream status surfaces, not catalog or pack authority.
 
 ## Versioning
 
-Pack version `0.2.0` identifies the reviewed GitHub collaboration starter
-contract. Core git tags and releases identify repository snapshots. These are
-related but independent axes.
+Pack version `0.3.0` identifies the reviewed GitHub collaboration readiness
+starter contract. Pack version `0.2.0` identified the earlier GitHub
+collaboration starter contract. Core git tags and releases identify repository
+snapshots. These are related but independent axes.
 
 ## Review
 
@@ -109,3 +135,8 @@ Review evidence:
 
 - https://github.com/farmerhunter/agent-foundry/issues/252
 - https://github.com/farmerhunter/agent-foundry/issues/253
+- https://github.com/farmerhunter/agent-foundry/issues/315
+- https://github.com/farmerhunter/agent-foundry/issues/316
+- https://github.com/farmerhunter/agent-foundry/issues/317
+- https://github.com/farmerhunter/agent-foundry/issues/318
+- https://github.com/farmerhunter/agent-foundry/issues/319

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -284,7 +284,7 @@ The official Core catalog currently exposes:
 | Pack | Normal-user use / 普通用户用途 |
 | --- | --- |
 | `pack.bootstrap.minimal` | Minimal bootstrap capability and prerequisite for optional starter packs. / 最小 bootstrap capability，也是 optional starter packs 的前置条件。 |
-| `pack.multi-agent.optional` | GitHub issue/PR collaboration starter with durable comments, role labels, and review handoff habits. / GitHub issue/PR 协作 starter，覆盖 durable comments、role labels 和 review handoff habits。 |
+| `pack.multi-agent.optional` | GitHub issue/PR collaboration starter with durable comments, role labels, review handoff habits, collaboration readiness audit, and dry-run repair planning. / GitHub issue/PR 协作 starter，覆盖 durable comments、role labels、review handoff habits、collaboration readiness audit 和 dry-run repair planning。 |
 
 Architecture-boundary, source-of-truth, Generated/Runtime downstream, and Local
 Private evidence-exclusion guidance belongs in `pack.bootstrap.minimal` at the

--- a/fixtures/capability-packs/optional-multi-agent/manifest.yaml
+++ b/fixtures/capability-packs/optional-multi-agent/manifest.yaml
@@ -1,10 +1,10 @@
 manifest_schema_version: 1
 pack_id: pack.multi-agent.optional
 title: Optional Multi-Agent Collaboration Pack
-description: Reviewed optional first-party starter pack for role-generic GitHub issue and PR collaboration helpers.
+description: Reviewed optional first-party starter pack for role-generic GitHub issue and PR collaboration helpers, collaboration readiness, and dry-run repair planning.
 lifecycle_status: reviewed
-version: 0.2.0
-exported_at: 2026-06-12
+version: 0.3.0
+exported_at: 2026-07-06
 distribution_type: optional_capability
 source_provenance: "Agent Foundry public Core fixture reviewed through AF12-3 issue #253."
 maintainer_contact: "https://github.com/farmerhunter/agent-foundry"
@@ -13,7 +13,7 @@ sensitivity: public
 review_state: reviewed
 
 pack_contract:
-  promised_use_case: "Help a project operate GitHub issues, PRs, labels, comments, and optional visual status mirrors as a lightweight multi-agent scheduler."
+  promised_use_case: "Help a project operate GitHub issues, PRs, labels, comments, collaboration readiness reports, dry-run repair plans, and optional visual status mirrors as a lightweight multi-agent scheduler."
   deployment_role: "optional user-selected capability after bootstrap"
   source_authority_after_deployment: "selected User Vault records"
   non_authority_boundaries: [generated adapters are downstream only, runtime installs are downstream only, pack staging is transfer evidence only, Core fixtures are schema and test evidence only]
@@ -21,6 +21,8 @@ pack_contract:
 evidence_sources:
   - "Agent Foundry issue 252 public starter-pack selection decision"
   - "Agent Foundry issue 253 public starter-pack implementation review"
+  - "Agent Foundry issue 315 collaboration readiness model decision"
+  - "Agent Foundry issues 316-319 AF15 helper, docs, dry-run repair, and dogfood review"
   - "Agent Foundry public first-party starter-pack review"
 
 export_policy:
@@ -46,20 +48,27 @@ starter_contents:
     - "role-generic needs:<role> routing"
     - "durable pickup and handoff comments"
     - "explicit Execution Contract role fields"
+    - "Testing Contract evidence routing when explicit testing is needed"
     - "dependency-gated ready queues"
+    - "collaboration readiness before new project adoption"
+    - "existing project drift audit and dry-run repair planning"
+    - "degraded GitHub/Project access reporting"
     - "read-only audit before write automation"
   assets:
     - "role-generic GitHub scheduler helper set"
   docs_templates:
     - "role routing config example"
     - "Execution Contract template"
+    - "Testing Contract template"
     - "pickup and handoff comment templates"
+    - "collaboration readiness adoption guidance"
   executable_payload_candidates:
     - "agent-inbox"
     - "agent-ready-queue"
     - "agent-pickup"
     - "agent-handoff"
     - "agent-audit"
+    - "agent-collaboration-readiness"
     - "agent-issue-context"
     - "agent-pr-context"
     - "agent-label"
@@ -80,6 +89,7 @@ rejected_as_pack:
   - "mutating apply behavior before managed helper install exists"
   - "execution from product project paths, pack staging, or canonical Vault payload paths"
   - "active Agent Foundry practices without separate harvest review"
+  - "live Project repair/apply behavior without later reviewed gate"
 
 compatibility:
   core_schema_version_min: 1
@@ -92,8 +102,8 @@ included_records:
     kind: practice
     lifecycle_status: candidate
     path: records/practices/COLLAB-PACK-001-review-handoff.md
-    source_version: 2
-    content_sha256: "3d68186c067db71927fd4861842c8c7f446e435c1dc0f17176cfdc18222a2116"
+    source_version: 3
+    content_sha256: "463e006672c02dcc98a7e606ddb76fecd8a29539b7720e8d26c4cb2839942c18"
     destination_layer: canonical_vault_record
     membership_role: optional_member
     activation_default: manual_review
@@ -102,8 +112,8 @@ included_records:
     kind: asset
     lifecycle_status: candidate
     path: records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
-    source_version: 2
-    content_sha256: "e43c1f9205a51ccf796eba87ec16dc15f9a70255ad83e31322ffdd92f9495eb4"
+    source_version: 3
+    content_sha256: "fc2e79c4696d519af319a070fbbccd11d6f860ae932bd6b6956391066981e6ea"
     destination_layer: canonical_vault_record
     membership_role: optional_member
     activation_default: manual_review

--- a/fixtures/capability-packs/optional-multi-agent/records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
+++ b/fixtures/capability-packs/optional-multi-agent/records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
@@ -2,12 +2,12 @@ id: ASSET-COLLAB-PACK-001
 title: Role-Generic GitHub Scheduler Helper Set
 asset_type: skill
 status: candidate
-version: 2
+version: 3
 created: 2026-06-11
-updated: 2026-06-12
-purpose: Provide reviewed helper surfaces for role-generic GitHub issue and PR coordination.
-responsibility: Support inbox, ready-queue, pickup, handoff, audit, label routing, issue context, PR context, and retry wrappers after managed install.
-non_responsibility: Does not decide product scope, override issue contracts, make Project v2 the scheduler authority, install helpers, or execute from pack staging.
+updated: 2026-07-06
+purpose: Provide reviewed helper surfaces for role-generic GitHub issue/PR coordination and collaboration readiness reporting.
+responsibility: Support inbox, ready-queue, pickup, handoff, audit, collaboration readiness, dry-run repair planning, degraded GitHub/Project access reporting, label routing, issue context, PR context, and retry wrappers after managed install.
+non_responsibility: Does not decide product scope, override issue contracts, make Project v2 the scheduler authority, install helpers, execute from pack staging, apply dry-run repairs, publish generated Skills, or mutate Project v2 by default.
 inputs:
   - issue number
   - PR number
@@ -18,7 +18,12 @@ inputs:
 process:
   - Read durable GitHub issue, PR, label, and comment state.
   - Resolve role labels and completion handoff from explicit configuration and contracts.
+  - Report collaboration readiness for new or existing projects before multi-agent work relies on the setup.
+  - Include Execution Contract validation and Testing Contract validation where the workflow asks for explicit test evidence.
   - Print dry-run plans before any mutating helper behavior is allowed.
+  - Keep dry-run repair entries report-only with mutation_performed false and apply_supported_now false.
+  - Prefer REST-first GitHub reads and targeted Project v2 GraphQL only when configured and needed.
+  - Report Project v2 TLS, EOF, timeout, rate-limit-like, unavailable, or config-missing states as degraded sources instead of blocking unrelated checks.
   - Keep Project status updates optional and project-configured.
   - Leave installation and runtime exposure to managed Agent Foundry tooling.
 outputs:
@@ -26,6 +31,9 @@ outputs:
   - ready queue report
   - pickup or handoff dry-run
   - audit report
+  - collaboration readiness report
+  - dry-run repair plan
+  - degraded-source summary
   - issue or PR context summary
 canonical_practices:
   - COLLAB-PACK-001
@@ -35,7 +43,12 @@ usage_triggers:
   - role handoff
   - GitHub issue scheduler
   - multi-agent ready queue
+  - collaboration readiness
+  - dry-run repair plan
+  - degraded GitHub access
 success_criteria:
   - The helper set can be reviewed as source without being executed from the pack snapshot.
   - Project-specific defaults are represented as overlays rather than reusable pack defaults.
   - Mutating actions remain disabled until managed install, permissions, and receipts exist.
+  - Readiness reports identify missing or drifted setup without mutating GitHub or Project state.
+  - Degraded GitHub or Project access is visible in reports instead of hidden by inferred success.

--- a/fixtures/capability-packs/optional-multi-agent/records/practices/COLLAB-PACK-001-review-handoff.md
+++ b/fixtures/capability-packs/optional-multi-agent/records/practices/COLLAB-PACK-001-review-handoff.md
@@ -4,10 +4,10 @@ title: Role-Generic GitHub Handoff Routing
 domain: agent-collaboration
 type: checklist
 status: candidate
-version: 2
+version: 3
 created: 2026-06-11
-updated: 2026-06-12
-tags: [multi-agent, review, handoff, scheduler]
+updated: 2026-07-06
+tags: [multi-agent, review, handoff, scheduler, readiness, dry-run-repair]
 aliases: [COLLAB-PACK-001]
 review_required: true
 ---
@@ -26,6 +26,16 @@ Multi-agent work loses continuity when completion evidence lives only in a chat 
 - Put pickup and handoff evidence on durable issue and PR surfaces when a PR exists.
 - Include scope, verification commands and outcomes, residual risks, and the expected next role.
 - Parse explicit Execution Contract fields for owner role, review role, acceptance role, dependency gates, branch strategy, and completion handoff.
-- Prefer read-only inbox, ready-queue, pickup, handoff, and audit dry-runs before write automation.
+- Prefer read-only inbox, ready-queue, pickup, handoff, audit, and collaboration readiness dry-runs before write automation.
+- For new projects, run collaboration readiness before relying on multi-agent routing. Check role labels, routing templates, Execution Contracts, Testing Contracts when needed, and optional Project/Kanban mirror fields.
+- For existing projects, use collaboration readiness to report drift and safe next actions. Dry-run repair plans may name missing labels, malformed contract values, Project item drift, or missing Project fields, but they must keep `mutation_performed: false` and `apply_supported_now: false`.
+- Treat TLS, EOF, timeout, rate-limit-like, and unavailable Project v2 responses as degraded sources. Return partial reports with `unknown` or `not_available` instead of inferring hidden state.
 - Keep Project status and roadmap status as mirrors or reports unless a project explicitly configures them as managed outputs.
 - Treat project-specific repository names, Project ids, branch names, issue numbers, and status mappings as overlays, not reusable pack defaults.
+
+## Boundaries
+
+- Do not run default full Project scans for ordinary collaboration reads.
+- Do not apply dry-run repairs from this pack.
+- Do not publish generated Skills, install runtime helpers, or mutate Project v2 from pack deployment.
+- Keep selected User Vault records canonical after deployment; generated adapters, runtime receipts, and local helper outputs remain downstream evidence.

--- a/scripts/test_capability_pack_lifecycle.py
+++ b/scripts/test_capability_pack_lifecycle.py
@@ -219,7 +219,7 @@ def main() -> int:
         newer_version = copy_optional_variant(
             base,
             "newer-version-pack",
-            {"version: 0.2.0": "version: 0.3.0"},
+            {"version: 0.3.0": "version: 0.4.0"},
         )
         errors.extend(
             expect(

--- a/scripts/test_capability_pack_plan.py
+++ b/scripts/test_capability_pack_plan.py
@@ -579,7 +579,7 @@ def main() -> int:
         write_deployed_index(
             vault,
             "pack.multi-agent.optional",
-            "0.2.0",
+            "0.3.0",
             "0" * 64,
             "COLLAB-PACK-001",
             "",


### PR DESCRIPTION
## Summary

Final AF15 integration from `codex/af15-collaboration-readiness` into `main`.

This integrates:
- read-only collaboration readiness helper behavior;
- dry-run repair planning and degraded GitHub/Project access reporting;
- Tester/Testing Contract evidence support;
- user-facing docs for new-project setup and existing-project audit;
- `pack.multi-agent.optional` 0.3.0 collaboration readiness guidance.

## Human authorization

Approved phrase received in the Coordinator thread:

`批准 AF15 final integration and closure`

Human gate context:
- #321 HDC: https://github.com/farmerhunter/agent-foundry/issues/321#issuecomment-4889647054
- #314 HDC: https://github.com/farmerhunter/agent-foundry/issues/314#issuecomment-4889647357

## Verification

Pre-merge exact-head verification at `dbf272e9e7edc4dd98ff465c0f62fc88ae1184ed` passed:
- `python3 -m py_compile scripts/github_collaboration_helper.py scripts/test_github_collaboration_helper.py scripts/import_runtime_assets.py scripts/test_import_runtime_assets.py`
- `python3 scripts/test_github_collaboration_helper.py`
- `python3 scripts/check_capability_pack_fixtures.py`
- `python3 scripts/test_advanced_capability_workflow_surface.py`
- `python3 scripts/test_capability_pack_plan.py`
- `python3 scripts/test_capability_pack_apply.py`
- `python3 scripts/test_capability_pack_update.py`
- `python3 scripts/test_capability_pack_lifecycle.py`
- `python3 scripts/check_consistency.py`
- `git diff --check origin/main...HEAD`

## Boundaries

This PR does not authorize generated Skill/adapter publish, live Vault/private/runtime/generated mutation, live repair/apply, Project v2 mutation, capability-pack deploy/apply, V2 implementation, release/tag creation, or destructive action.
