### PR TITLE
v1.1 #338 add capability pack impact release gate

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -121,6 +121,15 @@ Suggested mapping:
 
 `v2.0` is the next product development target. It should not start by building board features in isolation. It starts with end-to-end user journeys, then telemetry evidence, then local ledger, board model, migration, read-only MVP, controlled GitHub sync, and readiness review.
 
+Every public release or V1.x maintenance release-readiness gate must include a
+Capability Pack impact check. The gate reviews changed workflows, docs,
+templates, scripts, and generated Skill-facing behavior against affected Core
+capability packs. The release packet must record either `CP impact: none` with
+specific reasons, or accepted capability-pack update issue(s) with pack version,
+manifest hash, catalog hash, and verification evidence. Capability-pack
+implementation, generated/runtime publishing, real deploy/apply, release tags,
+and GitHub Release publishing remain separate reviewed gates.
+
 ## Branch and Release Lines
 
 Use `main` as the stable V1.x maintenance line until V2 is accepted and ready to become the default product line.


### PR DESCRIPTION
## Scope
- Adds a release-readiness rule requiring a Capability Pack impact check for public releases and V1.x maintenance releases.
- Requires either CP impact: none with reasons, or accepted CP update issue(s) with version/hash/verification evidence.
- Keeps CP implementation, generated/runtime publish, deploy/apply, tags, and GitHub Release publishing as separate reviewed gates.

## Changed files
- docs/roadmap.md

## Verification
- python3 scripts/check_consistency.py
- git diff --check origin/main...HEAD
- targeted rg/read-through for Capability Pack impact check, CP impact: none, version/hash verification, and separate reviewed gates

## Safety
- Docs/readiness gate update only.
- No CP artifact implementation.
- No capability-pack deploy/apply.
- No runtime/Vault/private/generated mutation.
- No generated Skill/adapter publish.
- No release/tag work.
- #339 not started; #335/#339 not closed.

## Residual risks
- #337 owns the actual v1.1 CP artifact updates.
- #339 remains the final v1.1 readiness/release gate.