### PR TITLE
v1.1 update starter packs and docs layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ work session
 
 The goal is not to maintain a pile of prompts. The goal is to make hard-won working judgment portable across sessions, agents, machines, and projects without losing human review or source-of-truth discipline.
 
-Actually a lot of thoughts came out as I work on this project. For more detailed explanation of my motivation, see [docs/philosophy.md](docs/philosophy.md).
+For the motivation and collaboration philosophy behind this project, see [docs/philosophy.md](docs/philosophy.md).
+
+**中文要点：** 项目的动机和人-agent 协作反思主要写在 [docs/philosophy.md](docs/philosophy.md)。
 
 ## What It Does
 
@@ -82,37 +84,32 @@ Use short commands instead of remembering internal workflows:
 
 Detailed prompts and Chinese equivalents are in [docs/usage.md](docs/usage.md) and [docs/commands.md](docs/commands.md).
 
-## Optional Starter Packs / 可选 Starter Packs
+## Optional Starter Packs
 
 After the first-value path above works, you can ask Agent Foundry to list or
 preview optional first-party starter packs. They are not required setup choices.
 
-完成上面的 first-value path 后，可以让 Agent Foundry list 或 preview 可选 first-party starter packs。它们不是必选 setup 选项。
+**中文要点：** Starter packs 是 first-value path 之后的可选项，不是新用户必须先做的安装选择。
 
-Current official starter packs:
-
-当前 official starter packs：
-
-| Pack | What you get / 获得什么 | Choose it when / 适合什么情况 |
+| Pack | What you get | Choose it when |
 | --- | --- | --- |
-| `pack.bootstrap.minimal` | A small baseline for safe harvest, review, refresh, status, and source-of-truth boundaries. / 用于安全 harvest、review、refresh、status 和 source-of-truth boundaries 的小型 baseline。 | Accept it for a new selected Vault or before any optional pack; it does not install runtimes or publish generated adapters by itself. / 新 selected Vault 或安装 optional pack 前接受它；它本身不会安装 runtimes 或发布 generated adapters。 |
-| `pack.multi-agent.optional` | GitHub issue/PR collaboration habits: role labels, durable comments, Execution Contracts, and review handoff. / GitHub issue/PR 协作习惯：role labels、durable comments、Execution Contracts 和 review handoff。 | Install it when you coordinate work through GitHub issues and PRs; skip it for solo local usage or projects without GitHub collaboration. / 当你通过 GitHub issues 和 PRs 协调工作时安装；纯本地单人使用或没有 GitHub 协作的项目可以跳过。 |
+| `pack.bootstrap.minimal` | A small baseline for safe harvest, review, refresh, status, source-of-truth boundaries, and external-skill import/reference review. | Accept it for a new selected Vault or before any optional pack; it does not install runtimes or publish generated adapters by itself. |
+| `pack.multi-agent.optional` | GitHub issue/PR collaboration habits: role labels, durable comments, Execution Contracts, Tester evidence routing, collaboration readiness, and action-plan guidance. | Install it when you coordinate work through GitHub issues and PRs; skip it for solo local usage or projects without GitHub collaboration. |
+
+**中文要点：** `pack.bootstrap.minimal` 是最小基础包；`pack.multi-agent.optional`
+适合需要 GitHub issue/PR 协作、Tester evidence、collaboration readiness 和 action plan 的项目。
 
 Use Skill-facing requests first: `list capability packs`, `recommend capability packs for my setup`, `preview capability pack deployment <pack-path>`, `apply reviewed capability pack <pack-path>`, `verify capability pack <pack-id>`, `update capability pack <pack-id-or-path>`, and `disable capability pack <pack-id>`.
 
-优先使用 Skill-facing 请求：`list capability packs`、`recommend capability packs for my setup`、`preview capability pack deployment <pack-path>`、`apply reviewed capability pack <pack-path>`、`verify capability pack <pack-id>`、`update capability pack <pack-id-or-path>` 和 `disable capability pack <pack-id>`。
-
-Architecture-boundary and source-of-truth orientation is folded into `pack.bootstrap.minimal`; it is not a standalone current-stage starter pack.
-
-Architecture-boundary 和 source-of-truth orientation 已并入 `pack.bootstrap.minimal`；它不是当前阶段的 standalone starter pack。
+Architecture-boundary and source-of-truth orientation is folded into `pack.bootstrap.minimal`.
 
 Core catalog entries make packs discoverable, but the selected User Vault remains canonical after accepted deployment. Generated adapters, runtime installs, local receipts, and Local Private evidence remain downstream or excluded surfaces.
 
-Core catalog entries 负责 discoverability；accepted deployment 后 selected User Vault 仍然是 canonical。Generated adapters、runtime installs、local receipts 和 Local Private evidence 仍是 downstream 或 excluded surfaces。
+**中文要点：** architecture-boundary guidance 由 `pack.bootstrap.minimal` 承载；accepted deployment 后 selected User Vault 仍是 canonical，Generated/Runtime 只是 downstream surfaces。
 
 For ordinary and complete details, see [docs/usage.md](docs/usage.md), [docs/commands.md](docs/commands.md), and the catalog pages under `catalog/capability-packs/`.
 
-普通和完整细节见 [docs/usage.md](docs/usage.md)、[docs/commands.md](docs/commands.md)，以及 `catalog/capability-packs/` 下的 catalog pages。
+**中文要点：** 完整细节见 [docs/usage.md](docs/usage.md)、[docs/commands.md](docs/commands.md)，以及 `catalog/capability-packs/` 下的 catalog pages。
 
 ## Design Principles
 

--- a/catalog/capability-packs/index.yaml
+++ b/catalog/capability-packs/index.yaml
@@ -6,9 +6,9 @@ entries:
     title: Minimal Agent Foundry Bootstrap Pack
     channel: official
     catalog_status: available
-    latest_version: 0.2.0
+    latest_version: 0.2.1
     manifest_path: fixtures/capability-packs/bootstrap-minimal/manifest.yaml
-    manifest_sha256: a9c940d7ed56759b70082b973f1fd1591f27dcc6e8b6f7354ce91c297e97240e
+    manifest_sha256: 63a0923121ba9bb428d22c7777cbc642fc777d3d8f98342770b6958f828be4a3
     compatibility_summary: "Core schema 1; Vault layout [1]; bootstrap not required."
     compatibility_metadata:
       core_schema_version_min: 1
@@ -27,9 +27,9 @@ entries:
     title: Optional GitHub Collaboration Starter Pack
     channel: official
     catalog_status: available
-    latest_version: 0.3.0
+    latest_version: 0.3.1
     manifest_path: fixtures/capability-packs/optional-multi-agent/manifest.yaml
-    manifest_sha256: e5a92fffe31c3065564ce43aae6daa0b029ba3a4e2490061cfd7fc0d4d1d8cb6
+    manifest_sha256: ccb7ec67df17ed05e56fdcdd4f47486eee41549c67dde7200a337ad6ff957819
     compatibility_summary: "Core schema 1; Vault layout [1]; bootstrap required; selected Vault review required."
     compatibility_metadata:
       core_schema_version_min: 1

--- a/catalog/capability-packs/pack.bootstrap.minimal/CHANGELOG.md
+++ b/catalog/capability-packs/pack.bootstrap.minimal/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.2.1
+
+- Added AF13 external-skill import/reference baseline semantics to bootstrap.
+- Clarified import outcomes, `reference_only` selected Vault `imports/inbox/`
+  evidence, and post-approval publish boundaries.
+- Preserved runtime/generated publishing, real deploy/apply, and private/local
+  evidence as separate reviewed gates outside pack authority.
+
 ## 0.2.0
 
 - Cataloged as the first minimal official Core-hosted capability pack entry.

--- a/catalog/capability-packs/pack.bootstrap.minimal/README.md
+++ b/catalog/capability-packs/pack.bootstrap.minimal/README.md
@@ -13,9 +13,8 @@ baseline before optional packs are considered. It helps users keep harvest,
 review, refresh, status, and source-of-truth behavior consistent instead of
 learning those boundaries one script at a time.
 
-`pack.bootstrap.minimal` 为新的 Agent Foundry setup 提供一个小型、reviewed 的
-baseline，然后再考虑 optional packs。它帮助用户保持 harvest、review、refresh、
-status 和 source-of-truth behavior 一致，而不是逐个脚本学习这些 boundaries。
+**中文要点：** 这是新 Vault 的最小 reviewed baseline，用来先建立 harvest、
+review、refresh、status 和 source-of-truth 边界，再考虑 optional packs。
 
 ## Concrete Function / 具体功能
 
@@ -25,10 +24,9 @@ deployment target, Core as public catalog/tooling, Generated and Runtime as
 downstream status or install surfaces, and Local Private evidence as excluded
 from pack authority.
 
-这个 pack 携带 bootstrap capability 和 `ASSET-META-001` governance baseline。
-它让用户明确 selected User Vault 是 accepted deployment target，Core 是 public
-catalog/tooling，Generated 和 Runtime 是 downstream status 或 install surfaces，
-Local Private evidence 不属于 pack authority。
+**中文要点：** 它携带 bootstrap capability、`ASSET-META-001` governance
+baseline，并明确 Core、selected User Vault、Generated、Runtime、Local Private
+各自的权威边界。
 
 ## What It Enables Next / 接下来能启用什么
 
@@ -37,9 +35,20 @@ verify deployed pack state, compare updates, disable a pack through a reviewed
 path, and inspect generated/runtime follow-up without treating those downstream
 surfaces as source of truth.
 
-接受 bootstrap 后，用户可以安全 preview optional starter packs、verify deployed
-pack state、compare updates、通过 reviewed path disable pack，并查看 generated/runtime
-follow-up，同时不会把这些 downstream surfaces 当成 source of truth。
+**中文要点：** 接受 bootstrap 后，用户可以安全 preview、verify、update、disable
+optional packs，同时不会把 generated/runtime downstream surfaces 当成 source of
+truth。
+
+It also carries the AF13 external-skill import/reference baseline. External
+sources are reviewed inputs with explicit outcomes: `discard`, `reference_only`,
+`defer`, `merge_into_existing`, `propose_practice`, or `propose_asset`.
+`reference_only` stays selected Vault `imports/inbox/` evidence only; publishing
+adapters or generated Skills is a later post-approval action after canonical
+records are approved.
+
+**中文要点：** 它也包含 AF13 external-skill import/reference baseline：外部来源只
+能先成为 reviewed input；`reference_only` 只是 `imports/inbox/` 证据，不会激活、
+publish 或成为 pack authority。
 
 ## What It Does Not Do / 不做什么
 
@@ -48,10 +57,9 @@ runtime files, publish generated adapters, export a private Vault, or make
 project-specific governance decisions. It does not duplicate `ASSET-META-001`;
 it preserves that baseline in the bootstrap path.
 
-这个 pack 不会创建单独的 architecture-boundary starter pack，不会安装 runtime
-files、发布 generated adapters、export private Vault，也不会替项目做 project-specific
-governance decisions。它不会复制 `ASSET-META-001`；它在 bootstrap path 中保留该
-baseline。
+**中文要点：** 它不安装 runtime files、不发布 generated adapters、不 export
+private Vault、不替项目做 governance decision，也不会把 external/reference-only
+材料变成 active authority。
 
 ## When To Accept / 何时接受安装
 
@@ -59,8 +67,8 @@ Accept or install this pack when you are setting up a selected User Vault for
 normal Agent Foundry use, before installing optional packs, or when you need to
 restore the baseline boundary guidance for harvest/review/status workflows.
 
-当你为正常 Agent Foundry 使用设置 selected User Vault、准备安装 optional packs，
-或需要恢复 harvest/review/status workflows 的 baseline boundary guidance 时，接受或安装这个 pack。
+**中文要点：** 新建 selected Vault、安装 optional packs 前，或需要恢复
+harvest/review/status baseline 时接受它。
 
 ## Authority
 
@@ -96,7 +104,7 @@ authority.
 
 ## Versioning
 
-Pack version `0.2.0` identifies the reviewed bootstrap pack contract. Core git
+Pack version `0.2.1` identifies the reviewed bootstrap pack contract. Core git
 tags and releases identify repository snapshots. These are related but
 independent axes.
 

--- a/catalog/capability-packs/pack.multi-agent.optional/CHANGELOG.md
+++ b/catalog/capability-packs/pack.multi-agent.optional/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.3.1
+
+- Added AF15 user-facing readiness action-plan semantics to the optional
+  collaboration starter contract.
+- Clarified recommended next-action categories, unknown/degraded source
+  reporting, forbidden actions, and telemetry-compatible readiness evidence.
+- Kept live repair/apply, Project v2 mutation, generated Skill publish,
+  runtime install, Vault mutation, and private/local evidence export outside
+  pack authority.
+
 ## 0.3.0
 
 - Added AF15 collaboration readiness guidance for new-project setup and

--- a/catalog/capability-packs/pack.multi-agent.optional/README.md
+++ b/catalog/capability-packs/pack.multi-agent.optional/README.md
@@ -16,9 +16,8 @@ and pull requests without losing handoff context between Implementer, Reviewer,
 Architect, Coordinator, and Human decision points. Its value is repeatable
 collaboration discipline, not automatic project management.
 
-`pack.multi-agent.optional` 帮助团队把 Agent Foundry 用在 GitHub issues 和 pull
-requests 上，并在 Implementer、Reviewer、Architect、Coordinator 和 Human decision
-points 之间保留 handoff context。它的价值是可重复的协作纪律，而不是自动项目管理。
+**中文要点：** 这个 pack 帮团队在 GitHub issue/PR 协作中保留 handoff context。
+它提供可重复的协作纪律，不是自动项目管理。
 
 ## Supported Workflow / 支持的协作流程
 
@@ -28,10 +27,9 @@ handoffs, and read-only audit before write automation. It is useful when work
 must move between multiple role sessions while GitHub remains the durable source
 of truth.
 
-这个 pack 支持使用 role labels、durable issue comments、explicit Execution Contracts、
-dependency-gated queues、review handoffs，以及 write automation 前的 read-only audit
-来进行 GitHub issue/PR 协作。当工作需要在多个 role sessions 之间流转，并且 GitHub
-仍然是 durable source of truth 时，它最有用。
+**中文要点：** 它覆盖 role labels、durable comments、Execution Contracts、
+dependency-gated queues、review handoffs，以及 write automation 前的 read-only
+audit。
 
 ## Collaboration Readiness / 协作就绪检查
 
@@ -41,19 +39,32 @@ Contracts, Testing Contracts, and optional Project/Kanban mirrors are present
 before they start multi-agent work. Existing projects can audit drift and get a
 dry-run repair plan without changing GitHub or Project state.
 
-当前 starter guidance 包含 AF15 collaboration readiness model：新项目可以先检查
-role labels、routing templates、Execution Contracts、Testing Contracts 和可选的
-Project/Kanban mirrors 是否齐备；已有项目可以 audit drift，并获得 dry-run repair
-plan，而不会修改 GitHub 或 Project state。
+**中文要点：** 新项目先检查 role labels、routing templates、Execution Contracts、
+Testing Contracts 和可选 Project/Kanban mirrors；老项目 audit drift 并得到安全
+action plan。
 
 Readiness reports are expected to stay read-only. They should show
 `mutation_performed: false`, use REST-first GitHub access, query Project v2 only
 when configured and needed, avoid default full Project scans, and report
 degraded GitHub or Project access instead of hiding it.
 
-Readiness reports 应保持 read-only。它们应显示 `mutation_performed: false`，
-优先使用 REST 访问 GitHub，仅在配置且必要时查询 Project v2，避免默认 full Project
-scan，并在 GitHub 或 Project 访问 degraded 时明确报告。
+Normal users should read the action-plan layer before raw JSON evidence:
+`readiness_status`, summary, blocking gaps, unknown/degraded sources,
+recommended next actions, forbidden actions, and telemetry. Recommended actions
+are informational-only, handled through existing workflow, explicit human gate,
+or unsupported/deferred repair/apply.
+
+**中文要点：** 普通用户先看 action-plan layer：status、summary、blocking gaps、
+unknown/degraded sources、recommended next actions、forbidden actions 和 telemetry。
+Raw JSON 是 evidence/debug output。
+
+Readiness reports stay read-only. They show `mutation_performed: false`,
+use REST-first GitHub access, query Project v2 only when configured and needed,
+avoid default full Project scans, and report degraded GitHub or Project access
+instead of hiding it.
+
+**中文要点：** Readiness report 仍是 read-only：不执行 repair/apply，不默认扫全量
+Project，访问 degraded 时明确报告。
 
 ## What Remains Manual Or Review-Gated / 仍需手动或 Review-Gated 的内容
 
@@ -63,10 +74,8 @@ changes protected branches or crosses privacy/security boundaries. Project v2
 may mirror status when configured, but labels and durable comments remain the
 handoff mechanism.
 
-Scope、architecture direction、dependency release、merge authorization、issue
-closure，以及任何修改 protected branches 或跨越 privacy/security boundaries 的动作，
-仍由人或被委托的 workflow roles 决定。Project v2 可在配置后 mirror status，但 labels
-和 durable comments 仍是 handoff mechanism。
+**中文要点：** scope、architecture、release、merge、closure 和隐私/安全边界仍由
+人或被委托的 workflow roles 决定；Project v2 只是可选 mirror。
 
 ## What It Does Not Automate / 不自动化什么
 
@@ -75,9 +84,8 @@ runtime helpers, publish generated Skills, mutate Project v2 by default, execute
 dry-run repair plans, export private Vault content, or treat local helper
 receipts as authority.
 
-这个 pack 不会 merge PRs、close issues、创建隐藏 access control、apply runtime
-helpers、publish generated Skills、默认 mutate Project v2、执行 dry-run repair
-plans、export private Vault content，也不会把 local helper receipts 当成 authority。
+**中文要点：** 它不 merge/close、不执行 live repair/apply、不 mutate Project v2、
+不 publish generated Skills、不 export private Vault。
 
 ## When To Accept / 何时接受安装
 
@@ -86,9 +94,8 @@ review through GitHub issues/PRs and needs durable role handoffs. Skip it when a
 project is single-user, local-only, or not ready to use GitHub labels and issue
 comments as the workflow record.
 
-当项目通过 GitHub issues/PRs 协调 implementation 和 review，并需要 durable role
-handoffs 时，接受或安装这个 pack。若项目是单人、本地-only，或尚未准备好把 GitHub
-labels 和 issue comments 作为 workflow record，可以跳过它。
+**中文要点：** 项目通过 GitHub issues/PRs 协调并需要 durable handoffs 时安装；
+纯本地单人项目可跳过。
 
 ## Authority
 
@@ -124,7 +131,7 @@ receipts remain downstream status surfaces, not catalog or pack authority.
 
 ## Versioning
 
-Pack version `0.3.0` identifies the reviewed GitHub collaboration readiness
+Pack version `0.3.1` identifies the reviewed GitHub collaboration readiness
 starter contract. Pack version `0.2.0` identified the earlier GitHub
 collaboration starter contract. Core git tags and releases identify repository
 snapshots. These are related but independent axes.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,47 +1,36 @@
-# Deployment / 部署
+# Deployment
 
 Agent Foundry is local-first. Core tooling, User Vault records, generated output, runtime receipts, and installed runtime files are separate layers.
 
-Agent Foundry 是 local-first 系统。Core tooling、User Vault records、generated output、runtime receipts 和已安装的 runtime files 是不同层。
+**中文要点：** Agent Foundry 是 local-first。Core、User Vault、generated output、runtime receipt 和 installed runtime files 是不同层。
 
-## Layers / 分层
+## Layers
 
 - Core checkout: public repo with `workflows/`, `schemas/`, `scripts/`, `templates/`, `docs/`, adapter profiles, runtime templates, and validation tooling.
-- Core checkout：public repo，包含 `workflows/`、`schemas/`、`scripts/`、`templates/`、`docs/`、adapter profiles、runtime templates 和 validation tooling。
 - selected User Vault: canonical `practices/`, `assets/`, `indexes/`, `imports/`, and shared sanitized usage aggregate.
-- selected User Vault：canonical `practices/`、`assets/`、`indexes/`、`imports/` 和 shared sanitized usage aggregate。
 - generated output: selected-Vault adapter output, usually under a machine-local generated root.
-- generated output：从 selected Vault 生成的 adapter output，通常位于本机 generated root。
 - runtime manifest: `runtime/local/runtime_manifest.yaml`, machine-local and ignored by git.
-- runtime manifest：`runtime/local/runtime_manifest.yaml`，machine-local，且被 git ignore。
 - runtime receipt: `runtime/local/adapter-install-receipt.yaml`, machine-local evidence of what generated output was installed.
-- runtime receipt：`runtime/local/adapter-install-receipt.yaml`，记录本机安装了哪些 generated output。
 - installed runtimes: downstream copies under paths such as `~/.codex`, `~/.claude`, `~/.hermes`, and `~/.trae-cn`.
-- installed runtimes：`~/.codex`、`~/.claude`、`~/.hermes`、`~/.trae-cn` 等路径下的下游副本。
 - ChatGPT: manual import target, not a managed local runtime.
-- ChatGPT：manual import target，不是 managed local runtime。
 
 Do not copy another machine's `runtime/local/`, `~/.agent-foundry/config.yaml`, runtime directories, or ChatGPT project files as canonical truth.
 
-不要把另一台机器的 `runtime/local/`、`~/.agent-foundry/config.yaml`、runtime directories 或 ChatGPT project files 当作 canonical truth 复制。
+**中文要点：** 不要把另一台机器的 `runtime/local/`、config、runtime directories 或 ChatGPT project files 当作 canonical truth。
 
-## Fresh Install / 首次安装
+## Fresh Install
 
 Use this on a new machine after cloning or unpacking the Agent Foundry Core checkout.
 
-在新机器 clone 或 unpack Agent Foundry Core checkout 后，使用此流程。
+**中文要点：** 新机器 clone 或 unpack Core checkout 后，按下面流程设置。
 
 1. Initialize or select a User Vault.
-
-   初始化或选择 User Vault。
 
    ```bash
    python3 scripts/init_vault.py ~/.agent-foundry/vault/my-agent-foundry-vault --core-root . --apply
    ```
 
 2. Write and verify the machine-local Core/Vault locator.
-
-   写入并验证本机 Core/Vault locator。
 
    ```bash
    python3 scripts/foundry_config.py write --core-root . --vault-root ~/.agent-foundry/vault/my-agent-foundry-vault
@@ -50,8 +39,6 @@ Use this on a new machine after cloning or unpacking the Agent Foundry Core chec
 
 3. Initialize and inspect the runtime manifest.
 
-   初始化并检查 runtime manifest。
-
    ```bash
    python3 scripts/runtime_manifest.py init
    python3 scripts/runtime_manifest.py detect
@@ -59,8 +46,6 @@ Use this on a new machine after cloning or unpacking the Agent Foundry Core chec
    ```
 
 4. Enable only the runtimes that should receive Agent Foundry content.
-
-   只启用应该接收 Agent Foundry content 的 runtimes。
 
    ```bash
    python3 scripts/runtime_manifest.py enable codex
@@ -71,8 +56,6 @@ Use this on a new machine after cloning or unpacking the Agent Foundry Core chec
 
 5. Dry-run install, then read status.
 
-   先 dry-run install，再读取 status。
-
    ```bash
    python3 scripts/install_foundry.py
    python3 scripts/sync_status.py
@@ -80,26 +63,24 @@ Use this on a new machine after cloning or unpacking the Agent Foundry Core chec
 
    In split Core/Vault mode, `install_foundry.py` defaults to the selected generated adapter root and refuses Core reference adapters as a runtime source. When in doubt, pass the generated root printed by `publish_adapters.py` explicitly with `--adapter-root`.
 
-   在 Core/Vault split 模式下，`install_foundry.py` 默认使用 selected generated adapter root，并拒绝把 Core reference adapters 当作 runtime 来源。不确定时，显式传入 `publish_adapters.py` 打印的 generated root：`--adapter-root`。
+   **中文要点：** split Core/Vault 模式下不要把 Core reference adapters 当作 runtime source；不确定时显式传 `--adapter-root`。
 
 6. Apply only after the dry-run and status report identify the expected Core, selected Vault, generated output, manual targets, receipt state, and runtime-write approval needs.
-
-   只有当 dry-run 和 status report 明确 expected Core、selected Vault、generated output、manual targets、receipt state 和 runtime-write approval needs 后，才 apply。
 
    ```bash
    python3 scripts/install_foundry.py --apply
    python3 scripts/sync_status.py
    ```
 
-## Cross-Machine Restore / 跨机器恢复
+   **中文要点：** 只有 dry-run/status 明确 Core、Vault、generated output、receipt 和 runtime-write approval 后才 apply。
+
+## Cross-Machine Restore
 
 Restore local state from public Core plus the selected Vault. Do not restore by copying runtime directories from another machine.
 
-从 public Core 加 selected Vault 恢复本机状态。不要通过复制另一台机器的 runtime directories 来恢复。
+**中文要点：** 跨机器恢复时，从 public Core + selected Vault 重建；不要复制另一台机器的 runtime directories。
 
 1. Clone or update Core.
-
-   Clone 或 update Core。
 
    ```bash
    git clone <public-core-url> agent-foundry-core
@@ -109,15 +90,11 @@ Restore local state from public Core plus the selected Vault. Do not restore by 
 
 2. Clone, pull, or initialize the selected Vault through the private channel you control.
 
-   通过你控制的 private channel clone、pull 或 initialize selected Vault。
-
    ```bash
    git clone <private-vault-url> ~/.agent-foundry/vault/agent-foundry-vault-<account>
    ```
 
 3. Write and verify the locator.
-
-   写入并验证 locator。
 
    ```bash
    python3 scripts/foundry_config.py write \
@@ -130,8 +107,6 @@ Restore local state from public Core plus the selected Vault. Do not restore by 
 
 4. Publish selected-Vault generated output into a machine-local generated root.
 
-   将 selected Vault 的 generated output 发布到本机 generated root。
-
    ```bash
    python3 scripts/publish_adapters.py \
      --core-root <public-core-path> \
@@ -141,8 +116,6 @@ Restore local state from public Core plus the selected Vault. Do not restore by 
    ```
 
 5. Dry-run install and read status before applying.
-
-   Apply 前先 dry-run install 并读取 status。
 
    ```bash
    python3 scripts/install_foundry.py \
@@ -157,8 +130,6 @@ Restore local state from public Core plus the selected Vault. Do not restore by 
 
 6. Apply only after status confirms the intended selected Vault, generated output, manual targets, receipt state, and runtime-write approval requirements.
 
-   只有当 status 确认 selected Vault、generated output、manual targets、receipt state 和 runtime-write approval requirements 符合预期后，才 apply。
-
    ```bash
    python3 scripts/install_foundry.py \
      --core-root <public-core-path> \
@@ -167,15 +138,15 @@ Restore local state from public Core plus the selected Vault. Do not restore by 
      --apply
    ```
 
-## Daily Update / 日常更新
+   **中文要点：** publish、dry-run、status 都确认后才 apply runtime writes。
+
+## Daily Update
 
 Use this after practices, assets, generated output, or runtime adapters may have changed.
 
-当 practices、assets、generated output 或 runtime adapters 可能变化后，使用此流程。
-
 Preserve the same selected adapter root across publish, selected-output quality check, install dry-run/apply, and sync status. Do not refresh managed runtimes from Core reference adapters in split mode.
 
-在 publish、selected-output quality check、install dry-run/apply 和 sync status 中保持同一个 selected adapter root。split 模式下不要从 Core reference adapters 刷新 managed runtimes。
+**中文要点：** practices/assets/generated output/runtime adapters 变化后使用此流程；整个流程保持同一个 selected adapter root。
 
 ```bash
 python3 scripts/check_consistency.py
@@ -185,8 +156,6 @@ python3 scripts/sync_status.py
 
 Apply only after the status report names the expected generated output, receipt state, manual targets, and any Trae/runtime write approval requirement.
 
-只有当 status report 明确 expected generated output、receipt state、manual targets 以及 Trae/runtime write approval requirement 后，才 apply。
-
 ```bash
 python3 scripts/install_foundry.py --apply
 python3 scripts/sync_status.py
@@ -194,7 +163,7 @@ python3 scripts/sync_status.py
 
 For ChatGPT, manually update project/custom GPT instructions and knowledge files from reviewed selected-Vault generated output, not from Core adapter templates.
 
-对 ChatGPT，从 reviewed selected-Vault generated output 手动更新 project/custom GPT instructions 和 knowledge files，不要从 Core adapter templates 更新。
+**中文要点：** ChatGPT 是 manual target，应从 reviewed selected-Vault generated output 更新，不要从 Core adapter templates 更新。
 
 ## Status And Drift / Status 和 Drift
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,14 +1,12 @@
-# Usage Guide / 使用指南
+# Usage Guide
 
 This guide is for day-to-day Agent Foundry use. You do not need to remember the internal workflows.
 
-这份指南面向日常使用 Agent Foundry 的场景。你不需要记住内部 workflow 细节。
+**中文要点：** 这份指南面向日常使用；你不需要记住内部 workflow 细节。
 
-## How It Works / 工作方式
+## How It Works
 
 Agent Foundry is a local-first system with separate Core, selected User Vault, generated output, and runtime layers.
-
-Agent Foundry 是 local-first 系统，并区分 Core、selected User Vault、generated output 和 runtime layers。
 
 ```text
 work session or external skill
@@ -22,49 +20,35 @@ work session or external skill
 
 Core contains public workflows, schemas, scripts, templates, docs, adapter profiles, runtime templates, and validation tooling.
 
-Core 保存 public workflows、schemas、scripts、templates、docs、adapter profiles、runtime templates 和 validation tooling。
-
 The selected User Vault contains canonical `practices/`, `assets/`, `indexes/`, `imports/`, and shared sanitized usage aggregates.
-
-selected User Vault 保存 canonical `practices/`、`assets/`、`indexes/`、`imports/` 和 shared sanitized usage aggregates。
 
 Installed files under `~/.codex`, `~/.claude`, `~/.hermes`, and `~/.trae-cn` are downstream runtime copies.
 
-`~/.codex`、`~/.claude`、`~/.hermes` 和 `~/.trae-cn` 下的已安装文件是下游 runtime copies。
+**中文要点：** Agent Foundry 区分 Core、selected User Vault、generated output 和 runtime。Core 是 public tooling；selected User Vault 是 canonical records；runtime files 是 downstream copies。
 
-## Core Rule / 核心规则
+## Core Rule
 
 For daily use, prefer the short commands in `docs/commands.md`, such as `harvest practices`, `refresh practices and assets`, or `check Agent Foundry status`.
 
-日常使用时，优先使用 `docs/commands.md` 中的短命令，例如 `harvest practices`、`refresh practices and assets` 或 `check Agent Foundry status`。
-
 The agent may discover, draft, and recommend practices or assets. You approve each meaningful new item or change before it becomes active.
-
-Agent 可以发现、起草并推荐 practices 或 assets。每个重要新增项或变更都需要你批准后才能 active。
 
 After approval, the agent should apply the approved item, update the canonical Vault records, update indexes, publish relevant adapters, and report changed files.
 
-批准后，agent 应应用已批准项目，更新 canonical Vault records，更新 indexes，发布相关 adapters，并汇报 changed files。
+**中文要点：** 日常优先用短命令。Agent 可以发现和推荐 practices/assets，但重要新增或变更必须经你批准后才会 active。
 
 External skills are handled as reviewed inputs. An import outcome is one of `discard`, `reference_only`, `defer`, `merge_into_existing`, `propose_practice`, or `propose_asset`. Reference-only material stays as sanitized review evidence under the selected Vault `imports/inbox/`; it is useful for lookup or later re-review, but it is not active behavior and cannot publish adapters or mutate runtime files. Publishing is a post-approval action after an approved canonical change.
 
-外部 skills 会被当作 reviewed inputs 处理。一次 import outcome 只能是 `discard`、`reference_only`、`defer`、`merge_into_existing`、`propose_practice` 或 `propose_asset`。Reference-only material 会作为 sanitized review evidence 留在 selected Vault 的 `imports/inbox/`；它可用于查阅或后续 re-review，但不是 active behavior，也不能 publish adapters 或修改 runtime files。Publishing 是 approved canonical change 之后的 post-approval action。
+**中文要点：** 外部 skills 只是 reviewed inputs；`reference_only` 只保留在 `imports/inbox/` 作为证据，不会激活、publish 或修改 runtime。
 
 For risky user-visible or stateful changes, you can ask for Tester evidence before accepting the work. Tester plans or gathers evidence; Tester does not approve the change.
 
-对于有用户可见行为或状态风险的变更，你可以在接受工作前要求 Tester evidence。Tester 负责规划或收集 evidence；Tester 不负责批准变更。
-
 Use Tester when the question is "what did we test, why is that enough, and what remains risky?" Skip Tester when a simple docs check, static check, or unit test already answers the confidence question.
-
-当问题是“测试了什么、为什么足够、还剩什么风险”时使用 Tester。如果简单 docs check、static check 或 unit test 已经能回答信心问题，就跳过 Tester。
 
 For the full role-based issue and PR development flow, including Coordinator, Architect, Implementer, Tester, Reviewer, and Human gates, see `docs/multi-agent-collaboration.md`.
 
-完整 role-based issue 和 PR 开发流程，包括 Coordinator、Architect、Implementer、Tester、Reviewer 和 Human gates，见 `docs/multi-agent-collaboration.md`。
+**中文要点：** 有用户可见或状态风险时可以要求 Tester evidence。Tester 负责回答“测了什么、为什么够、还剩什么风险”，不替代 Reviewer/Architect/Human。
 
 For GitHub issue/PR collaboration setup, ask for a collaboration readiness check before using the repo for multi-agent work.
-
-对于 GitHub issue/PR collaboration setup，在用该 repo 做 multi-agent work 前，先要求 collaboration readiness check。
 
 ```text
 check collaboration readiness for this repo
@@ -73,11 +57,9 @@ check collaboration readiness for this repo
 
 The readiness report tells you whether role labels, routing templates, Execution Contracts, Testing Contracts, issue/PR routing, and optional Project/Kanban visibility are present or drifted. Normal users should read the action-plan layer first: `readiness_status`, a short summary, and `recommended_next_actions`. Raw JSON remains evidence/debug output for review, fixtures, and future migration.
 
-Readiness report 会告诉你 role labels、routing templates、Execution Contracts、Testing Contracts、issue/PR routing 和可选 Project/Kanban visibility 是否存在或 drift。普通用户优先阅读 action-plan layer：`readiness_status`、简短 summary 和 `recommended_next_actions`。Raw JSON 仍是 review、fixtures 和 future migration 使用的 evidence/debug output。
+**中文要点：** 用 repo 做 multi-agent work 前，先要求 collaboration readiness check。普通用户先看 `readiness_status`、summary 和 `recommended_next_actions`；raw JSON 是 evidence/debug output。
 
 For a new project, ask the agent to prepare the setup checklist first:
-
-新项目先让 agent 准备 setup checklist：
 
 ```text
 prepare this repo for multi-agent collaboration
@@ -86,11 +68,9 @@ prepare this repo for multi-agent collaboration
 
 Expected setup items are role labels, the role-routing config template, optional Project fields and role options, Execution Contract examples, Testing Contract examples, human-gate examples, residual risks, and the first safe workflow action. Project v2 is optional; missing Project setup should be visible, not guessed healthy.
 
-预期 setup items 包括 role labels、role-routing config template、可选 Project fields 和 role options、Execution Contract examples、Testing Contract examples、human-gate examples、residual risks，以及第一个安全 workflow action。Project v2 是 optional；缺少 Project setup 时应明确显示，而不是猜测为健康。
+**中文要点：** 新项目先准备 setup checklist：role labels、routing config、contracts、human-gate examples、residual risks 和第一个安全 action。Project v2 是 optional。
 
 For an existing project, use:
-
-已有项目使用：
 
 ```text
 audit existing collaboration setup
@@ -106,28 +86,24 @@ That audit should report drift, degraded GitHub or Project access, dry-run repai
 
 Raw helper commands such as `python3 scripts/github_collaboration_helper.py collaboration-readiness --json` are debug details; prefer the Skill-facing requests above during normal use.
 
-该 audit 应报告 drift、degraded GitHub 或 Project access、dry-run repair ideas 和 next safe actions。`recommended_next_actions` 使用四类：
+`recommended_next_actions` use four categories:
 
 - `informational_only`：记录 evidence 或 degraded optional mirrors；不需要 mutation。
 - `agent_handled_existing_workflow`：通过正常 Agent Foundry issue、comment、label、PR 或 role handoff workflow 路由。
 - `explicit_human_gate`：对 product、governance、privacy、final integration、closure 或有意义的 Project policy choices 使用 Human Decision Contract。
 - `unsupported_deferred_repair_apply`：描述 repair，但 AF15 不执行。
 
-`python3 scripts/github_collaboration_helper.py collaboration-readiness --json` 这类 raw helper commands 是 debug details；日常使用优先使用上面的 Skill-facing requests。
+**中文要点：** 老项目用 audit 找 drift、degraded access、dry-run repair ideas 和 next safe actions。日常使用优先看 Skill-facing output，不要从 raw JSON 开始。
 
 The action-plan report stays read-only: `mutation_performed: false`, repair entries keep `apply_supported_now: false`, and the workflow does not perform live repair/apply, Project v2 mutation, generated Skill/adapter publish, or capability-pack deploy/apply. Its telemetry-compatible shape can support future local-first or V2 backfill, but AF15 does not implement V2 and does not make GitHub Project the source of truth.
 
-Action-plan report 保持 read-only：`mutation_performed: false`，repair entries 保持 `apply_supported_now: false`，workflow 不执行 live repair/apply、Project v2 mutation、generated Skill/adapter publish 或 capability-pack deploy/apply。它的 telemetry-compatible shape 可以支持未来 local-first 或 V2 backfill，但 AF15 不实现 V2，也不把 GitHub Project 变成 source of truth。
+**中文要点：** action-plan report 是 read-only：不做 live repair/apply，不 mutate Project v2，不 publish generated Skills/adapters，也不 deploy/apply capability packs。
 
-## First-Time Setup / 首次设置
+## First-Time Setup
 
 On a new machine, use `docs/deployment.md` for the full split Core/Vault install flow.
 
-新机器上，使用 `docs/deployment.md` 中完整的 Core/Vault 分离安装流程。
-
 Short version:
-
-简版流程：
 
 ```bash
 python3 scripts/init_vault.py ~/.agent-foundry/vault/my-agent-foundry-vault --core-root . --apply
@@ -145,39 +121,27 @@ python3 scripts/sync_status.py
 
 Do not copy another machine's `runtime/local/`, `~/.agent-foundry/config.yaml`, runtime directories, or ChatGPT project files as canonical truth.
 
-不要把另一台机器的 `runtime/local/`、`~/.agent-foundry/config.yaml`、runtime directories 或 ChatGPT project files 当作 canonical truth 复制。
-
 Recreate local state from Core plus the selected Vault, then verify with `sync_status.py`.
 
-应从 Core 加 selected Vault 重建本机状态，再用 `sync_status.py` 验证。
+**中文要点：** 新机器从 Core + selected Vault 重建；不要把另一台机器的 `runtime/local/`、config 或 runtime directories 当作 canonical truth 复制。
 
-## Daily Workflow / 日常流程
+## Daily Workflow
 
 Use `refresh practices and assets` at the start of a session, after switching machines, or when local agent rules may be stale.
 
-在 session 开始、切换机器后，或本地 agent rules 可能 stale 时，使用 `refresh practices and assets`。
-
 Use `check Agent Foundry status` or `python3 scripts/sync_status.py` when you only need a read-only answer to whether this machine is current.
-
-只需要 read-only 检查这台机器是否 current 时，使用 `check Agent Foundry status` 或 `python3 scripts/sync_status.py`。
 
 Use `harvest practices` after a session when you want to preserve reusable lessons.
 
-想在一次 session 后沉淀可复用经验时，使用 `harvest practices`。
-
 Use `discover assets` when repeated manual work should become a reusable skill, subagent, automation, or extension.
-
-发现重复手工工作值得变成 reusable skill、subagent、automation 或 extension 时，使用 `discover assets`。
 
 Use `review practices` and `review assets` periodically to prevent skill rot and asset rot.
 
-定期使用 `review practices` 和 `review assets`，避免 skill rot 和 asset rot。
+**中文要点：** session 开始、切换机器或规则可能 stale 时 refresh；只读检查用 status；沉淀经验用 harvest；发现重复工作用 discover assets；定期 review 防止 skill rot。
 
-## Refresh Practices And Assets / 刷新 Practices 和 Assets
+## Refresh Practices And Assets
 
 Command:
-
-命令：
 
 ```text
 refresh practices and assets
@@ -186,24 +150,17 @@ refresh practices and assets
 
 Expected behavior:
 
-预期行为：
-
 - Check local state and avoid losing real work.
-- 检查本地状态，避免丢失真实工作。
 - Pull remote git updates when appropriate.
-- 在合适时 pull remote git updates。
 - Regenerate adapters if canonical practices or assets changed.
-- 如果 canonical practices 或 assets 发生变化，重新生成 adapters。
 - Dry-run or install to enabled local runtimes through the reviewed path.
-- 通过 reviewed path 对 enabled local runtimes 做 dry-run 或 install。
 - Report current commit, unpushed work, generated output state, runtime receipts, and updated runtimes.
-- 汇报 current commit、未 push 工作、generated output state、runtime receipts 和已更新 runtimes。
 
-## Status And Drift / Status 和 Drift
+**中文要点：** refresh 会先保护本地状态，再 pull、regenerate adapters、dry-run/install，并汇报 commit、未 push 工作、generated output 和 runtime receipts。
+
+## Status And Drift
 
 Run status before applying runtime writes, after long idle periods, after switching machines, or when a rule appears not to affect an agent.
-
-在 apply runtime writes 前、长时间 idle 后、切换机器后，或某条 rule 看起来没有影响 agent 时，运行 status。
 
 ```bash
 python3 scripts/sync_status.py
@@ -211,15 +168,11 @@ python3 scripts/sync_status.py
 
 `sync_status.py` separates Core repo progress, selected Vault state, generated output, runtime receipt state, manual targets, and human-gated runtime writes.
 
-`sync_status.py` 会分开报告 Core repo progress、selected Vault state、generated output、runtime receipt state、manual targets 和 human-gated runtime writes。
-
 If generated output is missing or stale, publish adapters first. If runtime receipt is missing or drifted, review generated output, run install dry-run, read status, then apply only when the runtime write is expected.
-
-如果 generated output missing 或 stale，先 publish adapters。如果 runtime receipt missing 或 drifted，先 review generated output，运行 install dry-run，读取 status，最后只有 runtime write 符合预期时才 apply。
 
 Do not repair runtime drift by editing Vault records.
 
-不要通过编辑 Vault records 来修复 runtime drift。
+**中文要点：** status 分层报告 Core、Vault、generated output、runtime receipt 和 manual targets。Runtime drift 不要通过编辑 Vault records 修。
 
 ## Capability Pack Safety / Capability Pack 安全规则
 

--- a/fixtures/capability-packs/bootstrap-minimal/manifest.yaml
+++ b/fixtures/capability-packs/bootstrap-minimal/manifest.yaml
@@ -3,8 +3,8 @@ pack_id: pack.bootstrap.minimal
 title: Minimal Agent Foundry Bootstrap Pack
 description: Minimal public bootstrap snapshot for first-run harvest, review, refresh, publish, root, and runtime-boundary workflows.
 lifecycle_status: reviewed
-version: 0.2.0
-exported_at: 2026-06-12
+version: 0.2.1
+exported_at: 2026-07-06
 distribution_type: mandatory_bootstrap
 source_provenance: "Agent Foundry public Core fixture for issue #77"
 maintainer_contact: "https://github.com/farmerhunter/agent-foundry"
@@ -112,8 +112,8 @@ included_records:
     kind: practice
     lifecycle_status: active
     path: records/practices/META-003-borrow-external-skills-through-review.md
-    source_version: 1
-    content_sha256: "ee3c7c051f185bc3b7d3747a5dac140effb8284933f30ecb151dd25f1db2f7b7"
+    source_version: 2
+    content_sha256: "0ba4bae1a029069c543dee68f1335721a94f24eb4ff704b0829ca1f7a3a73cbb"
     destination_layer: canonical_vault_record
     membership_role: bootstrap_required
     activation_default: active

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-003-borrow-external-skills-through-review.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-003-borrow-external-skills-through-review.md
@@ -4,9 +4,9 @@ title: Borrow external skills through review
 domain: meta
 type: playbook
 status: active
-version: 1
+version: 2
 created: 2026-05-26
-updated: 2026-05-26
+updated: 2026-07-06
 tags: [external-skills, imports, security, provenance]
 aliases:
   - META-003
@@ -31,11 +31,15 @@ Public skills may be useful, but they can also be generic, stale, overbroad, ins
 
 ## Guidance
 
-Use `workflows/import-external-skills.md`. Capture provenance, check license and scripts, extract candidate practices, deduplicate against `indexes/practice_index.yaml`, then ask for human approval before activation. After approval, publish relevant adapters automatically.
+Use `workflows/import-external-skills.md`. Capture provenance, check license and scripts, extract candidate practices or assets, deduplicate against canonical indexes, then return one review outcome: `discard`, `reference_only`, `defer`, `merge_into_existing`, `propose_practice`, or `propose_asset`.
+
+Keep `post_approval_actions` separate from the import outcome. Adapter or generated Skill publishing can only happen after a specific canonical practice or asset is approved and the later publish gate is accepted.
+
+Record `reference_only` material as sanitized selected Vault `imports/inbox/` review evidence for lookup or later re-review. It must not activate behavior, publish adapters, mutate runtime files, bypass dedupe, or become practice, asset, or capability-pack authority.
 
 ## Watch Out For
 
-Never execute external scripts, install dependencies, or copy large prompt packs into active adapters without explicit approval.
+Never execute external scripts, install dependencies, `chmod` files, fetch dependencies, write canonical practices/assets, publish generated adapters, mutate runtime files, or copy large prompt packs into active adapters during import review.
 
 ## Example
 

--- a/fixtures/capability-packs/optional-multi-agent/manifest.yaml
+++ b/fixtures/capability-packs/optional-multi-agent/manifest.yaml
@@ -3,7 +3,7 @@ pack_id: pack.multi-agent.optional
 title: Optional Multi-Agent Collaboration Pack
 description: Reviewed optional first-party starter pack for role-generic GitHub issue and PR collaboration helpers, collaboration readiness, and dry-run repair planning.
 lifecycle_status: reviewed
-version: 0.3.0
+version: 0.3.1
 exported_at: 2026-07-06
 distribution_type: optional_capability
 source_provenance: "Agent Foundry public Core fixture reviewed through AF12-3 issue #253."
@@ -23,6 +23,7 @@ evidence_sources:
   - "Agent Foundry issue 253 public starter-pack implementation review"
   - "Agent Foundry issue 315 collaboration readiness model decision"
   - "Agent Foundry issues 316-319 AF15 helper, docs, dry-run repair, and dogfood review"
+  - "Agent Foundry issues 328-331 AF15 action-plan UX correction and dogfood review"
   - "Agent Foundry public first-party starter-pack review"
 
 export_policy:
@@ -52,6 +53,7 @@ starter_contents:
     - "dependency-gated ready queues"
     - "collaboration readiness before new project adoption"
     - "existing project drift audit and dry-run repair planning"
+    - "user-facing readiness action-plan output"
     - "degraded GitHub/Project access reporting"
     - "read-only audit before write automation"
   assets:
@@ -102,8 +104,8 @@ included_records:
     kind: practice
     lifecycle_status: candidate
     path: records/practices/COLLAB-PACK-001-review-handoff.md
-    source_version: 3
-    content_sha256: "463e006672c02dcc98a7e606ddb76fecd8a29539b7720e8d26c4cb2839942c18"
+    source_version: 4
+    content_sha256: "9c35b4a380ce398119175a4378625767c057cbcb222ddee9323fe21953027f13"
     destination_layer: canonical_vault_record
     membership_role: optional_member
     activation_default: manual_review
@@ -112,8 +114,8 @@ included_records:
     kind: asset
     lifecycle_status: candidate
     path: records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
-    source_version: 3
-    content_sha256: "fc2e79c4696d519af319a070fbbccd11d6f860ae932bd6b6956391066981e6ea"
+    source_version: 4
+    content_sha256: "ca4191e0d9d843a6606481edcb811e93ed01e1975a85d4811453779a23c73ef8"
     destination_layer: canonical_vault_record
     membership_role: optional_member
     activation_default: manual_review

--- a/fixtures/capability-packs/optional-multi-agent/records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
+++ b/fixtures/capability-packs/optional-multi-agent/records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
@@ -2,11 +2,11 @@ id: ASSET-COLLAB-PACK-001
 title: Role-Generic GitHub Scheduler Helper Set
 asset_type: skill
 status: candidate
-version: 3
+version: 4
 created: 2026-06-11
 updated: 2026-07-06
 purpose: Provide reviewed helper surfaces for role-generic GitHub issue/PR coordination and collaboration readiness reporting.
-responsibility: Support inbox, ready-queue, pickup, handoff, audit, collaboration readiness, dry-run repair planning, degraded GitHub/Project access reporting, label routing, issue context, PR context, and retry wrappers after managed install.
+responsibility: Support inbox, ready-queue, pickup, handoff, audit, collaboration readiness, user-facing readiness action plans, dry-run repair planning, degraded GitHub/Project access reporting, label routing, issue context, PR context, and retry wrappers after managed install.
 non_responsibility: Does not decide product scope, override issue contracts, make Project v2 the scheduler authority, install helpers, execute from pack staging, apply dry-run repairs, publish generated Skills, or mutate Project v2 by default.
 inputs:
   - issue number
@@ -19,6 +19,7 @@ process:
   - Read durable GitHub issue, PR, label, and comment state.
   - Resolve role labels and completion handoff from explicit configuration and contracts.
   - Report collaboration readiness for new or existing projects before multi-agent work relies on the setup.
+  - Present readiness status, summary, blocking gaps, unknown/degraded sources, recommended next actions, forbidden actions, and telemetry before raw debug evidence.
   - Include Execution Contract validation and Testing Contract validation where the workflow asks for explicit test evidence.
   - Print dry-run plans before any mutating helper behavior is allowed.
   - Keep dry-run repair entries report-only with mutation_performed false and apply_supported_now false.
@@ -32,6 +33,7 @@ outputs:
   - pickup or handoff dry-run
   - audit report
   - collaboration readiness report
+  - readiness action plan
   - dry-run repair plan
   - degraded-source summary
   - issue or PR context summary

--- a/fixtures/capability-packs/optional-multi-agent/records/practices/COLLAB-PACK-001-review-handoff.md
+++ b/fixtures/capability-packs/optional-multi-agent/records/practices/COLLAB-PACK-001-review-handoff.md
@@ -4,7 +4,7 @@ title: Role-Generic GitHub Handoff Routing
 domain: agent-collaboration
 type: checklist
 status: candidate
-version: 3
+version: 4
 created: 2026-06-11
 updated: 2026-07-06
 tags: [multi-agent, review, handoff, scheduler, readiness, dry-run-repair]
@@ -28,7 +28,8 @@ Multi-agent work loses continuity when completion evidence lives only in a chat 
 - Parse explicit Execution Contract fields for owner role, review role, acceptance role, dependency gates, branch strategy, and completion handoff.
 - Prefer read-only inbox, ready-queue, pickup, handoff, audit, and collaboration readiness dry-runs before write automation.
 - For new projects, run collaboration readiness before relying on multi-agent routing. Check role labels, routing templates, Execution Contracts, Testing Contracts when needed, and optional Project/Kanban mirror fields.
-- For existing projects, use collaboration readiness to report drift and safe next actions. Dry-run repair plans may name missing labels, malformed contract values, Project item drift, or missing Project fields, but they must keep `mutation_performed: false` and `apply_supported_now: false`.
+- For existing projects, use collaboration readiness to report drift and safe next actions. Read the user-facing action-plan layer first: readiness status, summary, blocking gaps, unknown/degraded sources, recommended next actions, forbidden actions, and telemetry.
+- Classify recommended next actions as informational-only, agent-handled existing workflow, explicit human gate, or unsupported/deferred repair/apply. Dry-run repair plans may name missing labels, malformed contract values, Project item drift, or missing Project fields, but they must keep `mutation_performed: false` and `apply_supported_now: false`.
 - Treat TLS, EOF, timeout, rate-limit-like, and unavailable Project v2 responses as degraded sources. Return partial reports with `unknown` or `not_available` instead of inferring hidden state.
 - Keep Project status and roadmap status as mirrors or reports unless a project explicitly configures them as managed outputs.
 - Treat project-specific repository names, Project ids, branch names, issue numbers, and status mappings as overlays, not reusable pack defaults.

--- a/scripts/test_advanced_capability_workflow_surface.py
+++ b/scripts/test_advanced_capability_workflow_surface.py
@@ -304,7 +304,7 @@ def write_deployed_index(vault: Path) -> None:
                 "updated: 2026-06-17",
                 "deployed_packs:",
                 "  - pack_id: pack.bootstrap.minimal",
-                "    version: 0.2.0",
+                "    version: 0.2.1",
                 "    lifecycle_status: active",
                 "    source:",
                 f"      manifest_sha256: {'0' * 64}",

--- a/scripts/test_bootstrap_pack_deployment.py
+++ b/scripts/test_bootstrap_pack_deployment.py
@@ -266,10 +266,10 @@ def main() -> int:
             else:
                 text = expected.read_text(encoding="utf-8")
                 for marker in [
-                    "provenance: \"Deployed from capability pack pack.bootstrap.minimal version 0.2.0",
+                    "provenance: \"Deployed from capability pack pack.bootstrap.minimal version 0.2.1",
                     "pack_membership",
                     "pack.bootstrap.minimal",
-                    "pack_source_version: \"0.2.0\"",
+                    "pack_source_version: \"0.2.1\"",
                 ]:
                     if marker not in text:
                         errors.append(f"deploy-bootstrap: {expected} missing deployment metadata marker {marker}")

--- a/scripts/test_capability_pack_lifecycle.py
+++ b/scripts/test_capability_pack_lifecycle.py
@@ -219,7 +219,7 @@ def main() -> int:
         newer_version = copy_optional_variant(
             base,
             "newer-version-pack",
-            {"version: 0.3.0": "version: 0.4.0"},
+            {"version: 0.3.1": "version: 0.4.0"},
         )
         errors.extend(
             expect(

--- a/scripts/test_capability_pack_plan.py
+++ b/scripts/test_capability_pack_plan.py
@@ -579,7 +579,7 @@ def main() -> int:
         write_deployed_index(
             vault,
             "pack.multi-agent.optional",
-            "0.3.0",
+            "0.3.1",
             "0" * 64,
             "COLLAB-PACK-001",
             "",
@@ -592,7 +592,7 @@ def main() -> int:
         write_deployed_index(
             vault,
             "pack.bootstrap.minimal",
-            "0.2.0",
+            "0.2.1",
             sha256(BOOTSTRAP_PACK / "manifest.yaml"),
             "BOOT-001",
             current_hash,
@@ -605,7 +605,7 @@ def main() -> int:
         write_reordered_deployed_index(
             vault,
             "pack.bootstrap.minimal",
-            "0.2.0",
+            "0.2.1",
             sha256(BOOTSTRAP_PACK / "manifest.yaml"),
             "BOOT-001",
             sha256(target),
@@ -616,7 +616,7 @@ def main() -> int:
         write_advanced_deployed_index(
             vault,
             "pack.bootstrap.minimal",
-            "0.2.0",
+            "0.2.1",
             sha256(BOOTSTRAP_PACK / "manifest.yaml"),
             "BOOT-001",
             sha256(target),


### PR DESCRIPTION
## Scope

- #337: update v1.1 capability-pack artifacts for accepted CP impact scope.
  - `pack.bootstrap.minimal` -> `0.2.1` with AF13 external-skill import/reference outcome and `reference_only` boundaries.
  - `pack.multi-agent.optional` -> `0.3.1` with AF15 user-facing readiness action-plan semantics and updated member record versions.
  - Recalculated record, manifest, and official catalog hashes.
- #340: apply accepted bilingual documentation layout migration to user-facing entry docs and catalog pages.
  - README starter-pack table is English-primary with short Chinese notes.
  - `docs/usage.md` and `docs/deployment.md` reduce paragraph-by-paragraph duplication in the main user path.
  - Catalog pack README pages use concise `中文要点` rather than long duplicated paragraphs.

## Verification

- `python3 -m py_compile scripts/test_advanced_capability_workflow_surface.py scripts/test_bootstrap_pack_deployment.py scripts/test_capability_pack_plan.py scripts/test_capability_pack_lifecycle.py`
- `python3 scripts/check_capability_pack_fixtures.py`
- `python3 scripts/test_advanced_capability_workflow_surface.py`
- `python3 scripts/test_capability_pack_plan.py`
- `python3 scripts/test_capability_pack_apply.py`
- `python3 scripts/test_capability_pack_update.py`
- `python3 scripts/test_capability_pack_lifecycle.py`
- `python3 scripts/test_bootstrap_pack_deployment.py`
- `python3 scripts/check_consistency.py`
- `git diff --check`
- targeted read-through/grep for bilingual layout, external-skill/reference-only boundaries, readiness action-plan semantics, and manifest/catalog hashes.

## Safety

- No capability-pack deploy/apply.
- No runtime/Vault/private/generated mutation.
- No generated Skill/adapter publish.
- No V2.0 or memory-system work.
- No release/tag work.
- No #335/#339 closure.

## Local State Note

Work was done in an isolated `/tmp` worktree to avoid touching the user's pre-existing dirty `README.md` in the main checkout.
