### PR TITLE
v1.1 #337 update starter capability packs

### DIFF
--- a/catalog/capability-packs/index.yaml
+++ b/catalog/capability-packs/index.yaml
@@ -6,9 +6,9 @@ entries:
     title: Minimal Agent Foundry Bootstrap Pack
     channel: official
     catalog_status: available
-    latest_version: 0.2.0
+    latest_version: 0.3.0
     manifest_path: fixtures/capability-packs/bootstrap-minimal/manifest.yaml
-    manifest_sha256: a9c940d7ed56759b70082b973f1fd1591f27dcc6e8b6f7354ce91c297e97240e
+    manifest_sha256: 79d7f579c0be89eac443dce005dde4750004099505d0d3a2b677b5c1bb2809c4
     compatibility_summary: "Core schema 1; Vault layout [1]; bootstrap not required."
     compatibility_metadata:
       core_schema_version_min: 1
@@ -17,7 +17,7 @@ entries:
       requires_bootstrap_pack: false
     changelog_path: catalog/capability-packs/pack.bootstrap.minimal/CHANGELOG.md
     readme_path: catalog/capability-packs/pack.bootstrap.minimal/README.md
-    review_evidence: https://github.com/farmerhunter/agent-foundry/issues/232
+    review_evidence: https://github.com/farmerhunter/agent-foundry/issues/337
     authority_after_deployment: selected_user_vault
     private_local_evidence: excluded
     core_release_axis: independent
@@ -27,9 +27,9 @@ entries:
     title: Optional GitHub Collaboration Starter Pack
     channel: official
     catalog_status: available
-    latest_version: 0.3.0
+    latest_version: 0.4.0
     manifest_path: fixtures/capability-packs/optional-multi-agent/manifest.yaml
-    manifest_sha256: e5a92fffe31c3065564ce43aae6daa0b029ba3a4e2490061cfd7fc0d4d1d8cb6
+    manifest_sha256: 95eeae82c6836905a28c4d48e4a2ce7598d2f0c300ca1401465ec1d45f6adaff
     compatibility_summary: "Core schema 1; Vault layout [1]; bootstrap required; selected Vault review required."
     compatibility_metadata:
       core_schema_version_min: 1
@@ -38,7 +38,7 @@ entries:
       requires_bootstrap_pack: true
     changelog_path: catalog/capability-packs/pack.multi-agent.optional/CHANGELOG.md
     readme_path: catalog/capability-packs/pack.multi-agent.optional/README.md
-    review_evidence: https://github.com/farmerhunter/agent-foundry/issues/253
+    review_evidence: https://github.com/farmerhunter/agent-foundry/issues/337
     authority_after_deployment: selected_user_vault
     private_local_evidence: excluded
     core_release_axis: independent

--- a/catalog/capability-packs/pack.bootstrap.minimal/CHANGELOG.md
+++ b/catalog/capability-packs/pack.bootstrap.minimal/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.3.0
+
+- Updated `META-003` to carry the AF13 external skill import/reference outcome
+  model: `discard`, `reference_only`, `defer`, `merge_into_existing`,
+  `propose_practice`, and `propose_asset`.
+- Clarified that `publish_after_approval` is a post-approval action, not a
+  terminal import outcome.
+- Clarified that `reference_only` is sanitized selected Vault `imports/inbox/`
+  review evidence only and cannot create active behavior, generated/runtime
+  output, dedupe bypasses, or practice, asset, or capability-pack authority.
+- No capability-pack deploy/apply, generated Skill publish, runtime mutation,
+  Vault mutation, release artifact publishing, or private/local evidence export
+  is authorized by this catalog entry.
+
 ## 0.2.0
 
 - Cataloged as the first minimal official Core-hosted capability pack entry.

--- a/catalog/capability-packs/pack.bootstrap.minimal/README.md
+++ b/catalog/capability-packs/pack.bootstrap.minimal/README.md
@@ -25,6 +25,12 @@ deployment target, Core as public catalog/tooling, Generated and Runtime as
 downstream status or install surfaces, and Local Private evidence as excluded
 from pack authority.
 
+The bootstrap baseline also includes the reviewed external-skill import and
+reference safety model. External sources are reviewed with the outcomes
+`discard`, `reference_only`, `defer`, `merge_into_existing`,
+`propose_practice`, or `propose_asset`; `publish_after_approval` is a later
+post-approval action, not an import outcome.
+
 这个 pack 携带 bootstrap capability 和 `ASSET-META-001` governance baseline。
 它让用户明确 selected User Vault 是 accepted deployment target，Core 是 public
 catalog/tooling，Generated 和 Runtime 是 downstream status 或 install surfaces，
@@ -47,6 +53,11 @@ This pack does not create a separate architecture-boundary starter pack, install
 runtime files, publish generated adapters, export a private Vault, or make
 project-specific governance decisions. It does not duplicate `ASSET-META-001`;
 it preserves that baseline in the bootstrap path.
+
+`reference_only` import evidence stays sanitized selected Vault `imports/inbox/`
+review evidence for manual lookup and future re-review. It does not create
+active behavior, generated/runtime output, dedupe bypasses, or practice, asset,
+or capability-pack authority.
 
 这个 pack 不会创建单独的 architecture-boundary starter pack，不会安装 runtime
 files、发布 generated adapters、export private Vault，也不会替项目做 project-specific
@@ -96,7 +107,8 @@ authority.
 
 ## Versioning
 
-Pack version `0.2.0` identifies the reviewed bootstrap pack contract. Core git
+Pack version `0.3.0` identifies the reviewed bootstrap pack contract. Pack
+version `0.2.0` identified the AF12-3 starter-pack catalog baseline. Core git
 tags and releases identify repository snapshots. These are related but
 independent axes.
 
@@ -109,3 +121,5 @@ Review evidence:
 - https://github.com/farmerhunter/agent-foundry/issues/232#issuecomment-4787780757
 - https://github.com/farmerhunter/agent-foundry/issues/232#issuecomment-4787793177
 - https://github.com/farmerhunter/agent-foundry/issues/253
+- https://github.com/farmerhunter/agent-foundry/issues/336
+- https://github.com/farmerhunter/agent-foundry/issues/337

--- a/catalog/capability-packs/pack.multi-agent.optional/CHANGELOG.md
+++ b/catalog/capability-packs/pack.multi-agent.optional/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.4.0
+
+- Added AF14 Testing Contract routing as part of the reusable collaboration
+  starter boundary.
+- Added the final AF15 collaboration readiness action-plan terms:
+  `readiness_status`, `summary`, `user_readiness_action_plan`, and
+  `recommended_next_actions`.
+- Added recommended action categories:
+  `informational_only`, `agent_handled_existing_workflow`,
+  `explicit_human_gate`, and `unsupported_deferred_repair_apply`.
+- Clarified that raw JSON remains evidence/debug output and that readiness
+  repair entries keep `mutation_performed: false` and
+  `apply_supported_now: false`.
+- Kept Project v2 as an optional visual mirror, not scheduler authority.
+- No live repair/apply, Project v2 mutation, generated Skill publish, runtime
+  install, Vault mutation, adapter publish, release artifact publishing, or
+  private/local evidence export is authorized by this catalog entry.
+
 ## 0.3.0
 
 - Added AF15 collaboration readiness guidance for new-project setup and

--- a/catalog/capability-packs/pack.multi-agent.optional/README.md
+++ b/catalog/capability-packs/pack.multi-agent.optional/README.md
@@ -35,11 +35,13 @@ dependency-gated queues、review handoffs，以及 write automation 前的 read-
 
 ## Collaboration Readiness / 协作就绪检查
 
-The current starter guidance includes the AF15 collaboration readiness model:
-new projects can check whether role labels, routing templates, Execution
-Contracts, Testing Contracts, and optional Project/Kanban mirrors are present
-before they start multi-agent work. Existing projects can audit drift and get a
-dry-run repair plan without changing GitHub or Project state.
+The current starter guidance includes the AF14 Testing Contract path and the
+AF15 collaboration readiness action-plan model. New projects can check whether
+role labels, routing templates, Execution Contracts, Testing Contracts, and
+optional Project/Kanban mirrors are present before they start multi-agent work.
+Existing projects can audit drift and get a readiness summary, recommended
+next actions, and a dry-run repair plan without changing GitHub or Project
+state.
 
 当前 starter guidance 包含 AF15 collaboration readiness model：新项目可以先检查
 role labels、routing templates、Execution Contracts、Testing Contracts 和可选的
@@ -47,13 +49,23 @@ Project/Kanban mirrors 是否齐备；已有项目可以 audit drift，并获得
 plan，而不会修改 GitHub 或 Project state。
 
 Readiness reports are expected to stay read-only. They should show
-`mutation_performed: false`, use REST-first GitHub access, query Project v2 only
-when configured and needed, avoid default full Project scans, and report
-degraded GitHub or Project access instead of hiding it.
+`readiness_status`, `summary`, `user_readiness_action_plan`, and
+`recommended_next_actions`; raw JSON remains evidence/debug output. Action
+categories are `informational_only`, `agent_handled_existing_workflow`,
+`explicit_human_gate`, and `unsupported_deferred_repair_apply`. Repair entries
+must show `mutation_performed: false` and `apply_supported_now: false`.
 
-Readiness reports 应保持 read-only。它们应显示 `mutation_performed: false`，
-优先使用 REST 访问 GitHub，仅在配置且必要时查询 Project v2，避免默认 full Project
-scan，并在 GitHub 或 Project 访问 degraded 时明确报告。
+Readiness reports 应保持 read-only。它们应显示 `readiness_status`、`summary`、
+`user_readiness_action_plan` 和 `recommended_next_actions`；raw JSON 仍是
+evidence/debug output。Action categories 是 `informational_only`、
+`agent_handled_existing_workflow`、`explicit_human_gate` 和
+`unsupported_deferred_repair_apply`。Repair entries 必须显示
+`mutation_performed: false` 和 `apply_supported_now: false`。
+
+The pack uses REST-first GitHub access, queries Project v2 only when configured
+and needed, avoids default full Project scans, and reports degraded GitHub or
+Project access instead of hiding it. Project v2 remains an optional visual
+mirror, not scheduler authority.
 
 ## What Remains Manual Or Review-Gated / 仍需手动或 Review-Gated 的内容
 
@@ -103,9 +115,9 @@ labels 和 issue comments 作为 workflow record，可以跳过它。
 
 The pack covers a base GitHub collaboration workflow: role labels, durable
 issue/PR comments, explicit Execution Contract fields, dependency-gated queues,
-Testing Contract evidence when needed, collaboration readiness audit, dry-run
-repair planning, degraded GitHub/Project access reporting, and read-only audit
-before write automation.
+Testing Contract evidence when needed, collaboration readiness action plans,
+dry-run repair planning, degraded GitHub/Project access reporting, and
+read-only audit before write automation.
 
 Project v2 status may be a configured visual mirror, but it is not the scheduler
 source of truth. Runtime helper install, generated Skill publish, and mutating
@@ -124,8 +136,10 @@ receipts remain downstream status surfaces, not catalog or pack authority.
 
 ## Versioning
 
-Pack version `0.3.0` identifies the reviewed GitHub collaboration readiness
-starter contract. Pack version `0.2.0` identified the earlier GitHub
+Pack version `0.4.0` identifies the reviewed GitHub collaboration readiness
+action-plan starter contract. Pack version `0.3.0` identified the earlier
+AF15 readiness and dry-run repair starter contract. Pack version `0.2.0`
+identified the earlier GitHub
 collaboration starter contract. Core git tags and releases identify repository
 snapshots. These are related but independent axes.
 
@@ -140,3 +154,9 @@ Review evidence:
 - https://github.com/farmerhunter/agent-foundry/issues/317
 - https://github.com/farmerhunter/agent-foundry/issues/318
 - https://github.com/farmerhunter/agent-foundry/issues/319
+- https://github.com/farmerhunter/agent-foundry/issues/328
+- https://github.com/farmerhunter/agent-foundry/issues/329
+- https://github.com/farmerhunter/agent-foundry/issues/330
+- https://github.com/farmerhunter/agent-foundry/issues/331
+- https://github.com/farmerhunter/agent-foundry/issues/336
+- https://github.com/farmerhunter/agent-foundry/issues/337

--- a/fixtures/capability-packs/bootstrap-minimal/manifest.yaml
+++ b/fixtures/capability-packs/bootstrap-minimal/manifest.yaml
@@ -3,7 +3,7 @@ pack_id: pack.bootstrap.minimal
 title: Minimal Agent Foundry Bootstrap Pack
 description: Minimal public bootstrap snapshot for first-run harvest, review, refresh, publish, root, and runtime-boundary workflows.
 lifecycle_status: reviewed
-version: 0.2.0
+version: 0.3.0
 exported_at: 2026-06-12
 distribution_type: mandatory_bootstrap
 source_provenance: "Agent Foundry public Core fixture for issue #77"
@@ -19,11 +19,11 @@ compatibility:
   requires_bootstrap_pack: false
 
 selection_review:
-  rationale: "Provide the smallest usable blank-Vault baseline: bootstrap orientation plus the public Practice Harvester asset and its canonical meta, governance, runtime, and source-of-truth boundary practices."
+  rationale: "Provide the smallest usable blank-Vault baseline: bootstrap orientation plus the public Practice Harvester asset and its canonical meta, governance, runtime, import-review, and source-of-truth boundary practices."
   included_groups:
     - bootstrap orientation and status records
     - Practice Harvester skill asset
-    - meta practices required for harvest, asset discovery, import review, dedupe, and adapter publishing
+    - meta practices required for harvest, asset discovery, external skill import/reference review, dedupe, and adapter publishing
     - governance practices required for source-of-truth, architecture boundary, and maintainability decisions
     - runtime practices required for root, adapter, sync, and privacy boundaries
     - Generated and Runtime downstream-status orientation plus Local Private evidence exclusion
@@ -112,8 +112,8 @@ included_records:
     kind: practice
     lifecycle_status: active
     path: records/practices/META-003-borrow-external-skills-through-review.md
-    source_version: 1
-    content_sha256: "ee3c7c051f185bc3b7d3747a5dac140effb8284933f30ecb151dd25f1db2f7b7"
+    source_version: 2
+    content_sha256: "b7b1ec65490050045ca61380ab31d964b91084d3d8b04bd9b0c71bfb73a97b41"
     destination_layer: canonical_vault_record
     membership_role: bootstrap_required
     activation_default: active

--- a/fixtures/capability-packs/bootstrap-minimal/records/practices/META-003-borrow-external-skills-through-review.md
+++ b/fixtures/capability-packs/bootstrap-minimal/records/practices/META-003-borrow-external-skills-through-review.md
@@ -4,9 +4,9 @@ title: Borrow external skills through review
 domain: meta
 type: playbook
 status: active
-version: 1
+version: 2
 created: 2026-05-26
-updated: 2026-05-26
+updated: 2026-07-06
 tags: [external-skills, imports, security, provenance]
 aliases:
   - META-003
@@ -31,11 +31,24 @@ Public skills may be useful, but they can also be generic, stale, overbroad, ins
 
 ## Guidance
 
-Use `workflows/import-external-skills.md`. Capture provenance, check license and scripts, extract candidate practices, deduplicate against `indexes/practice_index.yaml`, then ask for human approval before activation. After approval, publish relevant adapters automatically.
+Use `workflows/import-external-skills.md`. Capture provenance, user value, concrete function, duplicate target, license and security notes, sensitivity, script/network/file/credential/install/destructive flags, prompt-injection flags, exact post-approval changes, and re-review triggers.
+
+Classify the review outcome as exactly one of:
+
+- `discard`
+- `reference_only`
+- `defer`
+- `merge_into_existing`
+- `propose_practice`
+- `propose_asset`
+
+`publish_after_approval` is not a terminal import outcome. Adapter or generated Skill publishing is a post-approval action only after an accepted canonical practice or asset change. `reference_only` means sanitized selected Vault `imports/inbox/` review evidence for manual lookup and possible re-review. It cannot activate behavior, publish generated adapters or Skills, mutate runtime, bypass dedupe, or become practice, asset, or capability-pack authority.
+
+Deduplicate against existing practice and asset indexes before proposing canonical changes, then ask for human approval before activation. After approval, publish relevant adapters only through the reviewed adapter publishing path.
 
 ## Watch Out For
 
-Never execute external scripts, install dependencies, or copy large prompt packs into active adapters without explicit approval.
+Never execute external scripts, install dependencies, run `chmod`, fetch network dependencies, write runtime files, publish generated adapters, or copy large prompt packs into active adapters as part of import review. Script-bearing material remains inert unless a later explicit reviewed execution step approves otherwise.
 
 ## Example
 

--- a/fixtures/capability-packs/optional-multi-agent/manifest.yaml
+++ b/fixtures/capability-packs/optional-multi-agent/manifest.yaml
@@ -1,9 +1,9 @@
 manifest_schema_version: 1
 pack_id: pack.multi-agent.optional
 title: Optional Multi-Agent Collaboration Pack
-description: Reviewed optional first-party starter pack for role-generic GitHub issue and PR collaboration helpers, collaboration readiness, and dry-run repair planning.
+description: Reviewed optional first-party starter pack for role-generic GitHub issue and PR collaboration helpers, Testing Contract routing, collaboration readiness action plans, and dry-run repair planning.
 lifecycle_status: reviewed
-version: 0.3.0
+version: 0.4.0
 exported_at: 2026-07-06
 distribution_type: optional_capability
 source_provenance: "Agent Foundry public Core fixture reviewed through AF12-3 issue #253."
@@ -13,7 +13,7 @@ sensitivity: public
 review_state: reviewed
 
 pack_contract:
-  promised_use_case: "Help a project operate GitHub issues, PRs, labels, comments, collaboration readiness reports, dry-run repair plans, and optional visual status mirrors as a lightweight multi-agent scheduler."
+  promised_use_case: "Help a project operate GitHub issues, PRs, labels, comments, Testing Contract evidence routing, collaboration readiness action plans, dry-run repair plans, and optional visual status mirrors as a lightweight multi-agent scheduler."
   deployment_role: "optional user-selected capability after bootstrap"
   source_authority_after_deployment: "selected User Vault records"
   non_authority_boundaries: [generated adapters are downstream only, runtime installs are downstream only, pack staging is transfer evidence only, Core fixtures are schema and test evidence only]
@@ -23,6 +23,7 @@ evidence_sources:
   - "Agent Foundry issue 253 public starter-pack implementation review"
   - "Agent Foundry issue 315 collaboration readiness model decision"
   - "Agent Foundry issues 316-319 AF15 helper, docs, dry-run repair, and dogfood review"
+  - "Agent Foundry issues 328-331 AF15 action-plan UX completion and dogfood review"
   - "Agent Foundry public first-party starter-pack review"
 
 export_policy:
@@ -51,7 +52,9 @@ starter_contents:
     - "Testing Contract evidence routing when explicit testing is needed"
     - "dependency-gated ready queues"
     - "collaboration readiness before new project adoption"
-    - "existing project drift audit and dry-run repair planning"
+    - "existing project drift audit and readiness action plans"
+    - "recommended next action categories for informational, workflow-routed, human-gated, and deferred repair/apply cases"
+    - "raw JSON evidence/debug alongside user-facing summaries"
     - "degraded GitHub/Project access reporting"
     - "read-only audit before write automation"
   assets:
@@ -102,8 +105,8 @@ included_records:
     kind: practice
     lifecycle_status: candidate
     path: records/practices/COLLAB-PACK-001-review-handoff.md
-    source_version: 3
-    content_sha256: "463e006672c02dcc98a7e606ddb76fecd8a29539b7720e8d26c4cb2839942c18"
+    source_version: 4
+    content_sha256: "cc4c37f24d443c473586e3824176ff4eff7d5c3043ff444823d8cbf07d218093"
     destination_layer: canonical_vault_record
     membership_role: optional_member
     activation_default: manual_review
@@ -112,8 +115,8 @@ included_records:
     kind: asset
     lifecycle_status: candidate
     path: records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
-    source_version: 3
-    content_sha256: "fc2e79c4696d519af319a070fbbccd11d6f860ae932bd6b6956391066981e6ea"
+    source_version: 4
+    content_sha256: "00d901a71a4f0a9e6db3b88e10b9cbda01b75ed4284bec3e354a026e6c77d5c9"
     destination_layer: canonical_vault_record
     membership_role: optional_member
     activation_default: manual_review

--- a/fixtures/capability-packs/optional-multi-agent/records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
+++ b/fixtures/capability-packs/optional-multi-agent/records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
@@ -2,12 +2,12 @@ id: ASSET-COLLAB-PACK-001
 title: Role-Generic GitHub Scheduler Helper Set
 asset_type: skill
 status: candidate
-version: 3
+version: 4
 created: 2026-06-11
 updated: 2026-07-06
-purpose: Provide reviewed helper surfaces for role-generic GitHub issue/PR coordination and collaboration readiness reporting.
-responsibility: Support inbox, ready-queue, pickup, handoff, audit, collaboration readiness, dry-run repair planning, degraded GitHub/Project access reporting, label routing, issue context, PR context, and retry wrappers after managed install.
-non_responsibility: Does not decide product scope, override issue contracts, make Project v2 the scheduler authority, install helpers, execute from pack staging, apply dry-run repairs, publish generated Skills, or mutate Project v2 by default.
+purpose: Provide reviewed helper surfaces for role-generic GitHub issue/PR coordination, Testing Contract routing, and collaboration readiness action-plan reporting.
+responsibility: Support inbox, ready-queue, pickup, handoff, audit, Testing Contract evidence routing, collaboration readiness action plans, dry-run repair planning, degraded GitHub/Project access reporting, label routing, issue context, PR context, and retry wrappers after managed install.
+non_responsibility: Does not decide product scope, override issue contracts, make Project v2 the scheduler authority, install helpers, execute from pack staging, apply dry-run repairs, publish generated Skills, mutate Project v2 by default, or treat action plans as live repair/apply authorization.
 inputs:
   - issue number
   - PR number
@@ -20,6 +20,9 @@ process:
   - Resolve role labels and completion handoff from explicit configuration and contracts.
   - Report collaboration readiness for new or existing projects before multi-agent work relies on the setup.
   - Include Execution Contract validation and Testing Contract validation where the workflow asks for explicit test evidence.
+  - Include user-facing readiness_status, summary, user_readiness_action_plan, and recommended_next_actions.
+  - Use recommended action categories informational_only, agent_handled_existing_workflow, explicit_human_gate, and unsupported_deferred_repair_apply.
+  - Keep raw JSON as evidence/debug output for review, fixtures, and future migration.
   - Print dry-run plans before any mutating helper behavior is allowed.
   - Keep dry-run repair entries report-only with mutation_performed false and apply_supported_now false.
   - Prefer REST-first GitHub reads and targeted Project v2 GraphQL only when configured and needed.
@@ -32,6 +35,7 @@ outputs:
   - pickup or handoff dry-run
   - audit report
   - collaboration readiness report
+  - user-facing readiness action plan
   - dry-run repair plan
   - degraded-source summary
   - issue or PR context summary
@@ -51,4 +55,5 @@ success_criteria:
   - Project-specific defaults are represented as overlays rather than reusable pack defaults.
   - Mutating actions remain disabled until managed install, permissions, and receipts exist.
   - Readiness reports identify missing or drifted setup without mutating GitHub or Project state.
+  - Readiness action plans separate informational, existing-workflow, human-gated, and unsupported/deferred repair/apply next actions.
   - Degraded GitHub or Project access is visible in reports instead of hidden by inferred success.

--- a/fixtures/capability-packs/optional-multi-agent/records/practices/COLLAB-PACK-001-review-handoff.md
+++ b/fixtures/capability-packs/optional-multi-agent/records/practices/COLLAB-PACK-001-review-handoff.md
@@ -4,10 +4,10 @@ title: Role-Generic GitHub Handoff Routing
 domain: agent-collaboration
 type: checklist
 status: candidate
-version: 3
+version: 4
 created: 2026-06-11
 updated: 2026-07-06
-tags: [multi-agent, review, handoff, scheduler, readiness, dry-run-repair]
+tags: [multi-agent, review, handoff, scheduler, readiness, testing-contract, action-plan]
 aliases: [COLLAB-PACK-001]
 review_required: true
 ---
@@ -26,16 +26,20 @@ Multi-agent work loses continuity when completion evidence lives only in a chat 
 - Put pickup and handoff evidence on durable issue and PR surfaces when a PR exists.
 - Include scope, verification commands and outcomes, residual risks, and the expected next role.
 - Parse explicit Execution Contract fields for owner role, review role, acceptance role, dependency gates, branch strategy, and completion handoff.
-- Prefer read-only inbox, ready-queue, pickup, handoff, audit, and collaboration readiness dry-runs before write automation.
+- Prefer read-only inbox, ready-queue, pickup, handoff, audit, Testing Contract, and collaboration readiness dry-runs before write automation.
+- Route explicit testing evidence through Testing Contracts when the issue or risk profile asks for Tester support. Tester evidence supports Reviewer and Architect decisions; it is not final acceptance by itself.
 - For new projects, run collaboration readiness before relying on multi-agent routing. Check role labels, routing templates, Execution Contracts, Testing Contracts when needed, and optional Project/Kanban mirror fields.
-- For existing projects, use collaboration readiness to report drift and safe next actions. Dry-run repair plans may name missing labels, malformed contract values, Project item drift, or missing Project fields, but they must keep `mutation_performed: false` and `apply_supported_now: false`.
+- For existing projects, use collaboration readiness to report drift and safe next actions. User-facing reports should include `readiness_status`, `summary`, `user_readiness_action_plan`, and `recommended_next_actions`; raw JSON remains evidence/debug output.
+- Use action categories exactly: `informational_only`, `agent_handled_existing_workflow`, `explicit_human_gate`, and `unsupported_deferred_repair_apply`.
+- Dry-run repair plans may name missing labels, malformed contract values, Project item drift, or missing Project fields, but they must keep `mutation_performed: false` and `apply_supported_now: false`.
 - Treat TLS, EOF, timeout, rate-limit-like, and unavailable Project v2 responses as degraded sources. Return partial reports with `unknown` or `not_available` instead of inferring hidden state.
-- Keep Project status and roadmap status as mirrors or reports unless a project explicitly configures them as managed outputs.
+- Keep Project status and roadmap status as mirrors or reports unless a project explicitly configures them as managed outputs. Project v2 is not scheduler authority for this pack.
 - Treat project-specific repository names, Project ids, branch names, issue numbers, and status mappings as overlays, not reusable pack defaults.
 
 ## Boundaries
 
 - Do not run default full Project scans for ordinary collaboration reads.
 - Do not apply dry-run repairs from this pack.
+- Do not treat collaboration readiness action plans as live repair/apply authorization.
 - Do not publish generated Skills, install runtime helpers, or mutate Project v2 from pack deployment.
 - Keep selected User Vault records canonical after deployment; generated adapters, runtime receipts, and local helper outputs remain downstream evidence.

--- a/scripts/test_bootstrap_pack_deployment.py
+++ b/scripts/test_bootstrap_pack_deployment.py
@@ -65,6 +65,13 @@ def deploy_bootstrap(vault_root: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
+def manifest_version(pack_root: Path) -> str:
+    for line in (pack_root / "manifest.yaml").read_text(encoding="utf-8").splitlines():
+        if line.startswith("version:"):
+            return line.split(":", 1)[1].strip().strip('"')
+    raise AssertionError(f"{pack_root / 'manifest.yaml'} missing version")
+
+
 def tree_digest(root: Path) -> str:
     digest = hashlib.sha256()
     for path in sorted(p for p in root.rglob("*") if p.is_file()):
@@ -254,6 +261,7 @@ def main() -> int:
         deploy_result = deploy_bootstrap(vault)
         errors.extend(expect("deploy-bootstrap", deploy_result, True, "added: 25"))
         errors.extend(expect("deploy-bootstrap-validates", deploy_result, True, "selected Vault validated"))
+        bootstrap_version = manifest_version(BOOTSTRAP_PACK)
         for expected in [
             vault / "practices" / "meta" / "BOOT-001-bootstrap-orientation.md",
             vault / "practices" / "meta" / "META-001-canonical-practices-source-of-truth.md",
@@ -266,10 +274,10 @@ def main() -> int:
             else:
                 text = expected.read_text(encoding="utf-8")
                 for marker in [
-                    "provenance: \"Deployed from capability pack pack.bootstrap.minimal version 0.2.0",
+                    f"provenance: \"Deployed from capability pack pack.bootstrap.minimal version {bootstrap_version}",
                     "pack_membership",
                     "pack.bootstrap.minimal",
-                    "pack_source_version: \"0.2.0\"",
+                    f"pack_source_version: \"{bootstrap_version}\"",
                 ]:
                     if marker not in text:
                         errors.append(f"deploy-bootstrap: {expected} missing deployment metadata marker {marker}")

--- a/scripts/test_capability_pack_lifecycle.py
+++ b/scripts/test_capability_pack_lifecycle.py
@@ -219,7 +219,7 @@ def main() -> int:
         newer_version = copy_optional_variant(
             base,
             "newer-version-pack",
-            {"version: 0.3.0": "version: 0.4.0"},
+            {"version: 0.4.0": "version: 0.5.0"},
         )
         errors.extend(
             expect(

--- a/scripts/test_capability_pack_plan.py
+++ b/scripts/test_capability_pack_plan.py
@@ -579,7 +579,7 @@ def main() -> int:
         write_deployed_index(
             vault,
             "pack.multi-agent.optional",
-            "0.3.0",
+            "0.4.0",
             "0" * 64,
             "COLLAB-PACK-001",
             "",
@@ -592,7 +592,7 @@ def main() -> int:
         write_deployed_index(
             vault,
             "pack.bootstrap.minimal",
-            "0.2.0",
+            "0.3.0",
             sha256(BOOTSTRAP_PACK / "manifest.yaml"),
             "BOOT-001",
             current_hash,
@@ -605,7 +605,7 @@ def main() -> int:
         write_reordered_deployed_index(
             vault,
             "pack.bootstrap.minimal",
-            "0.2.0",
+            "0.3.0",
             sha256(BOOTSTRAP_PACK / "manifest.yaml"),
             "BOOT-001",
             sha256(target),


### PR DESCRIPTION
## Scope
- Updates pack.bootstrap.minimal for AF13 external skill import/reference semantics.
- Updates pack.multi-agent.optional for AF14 Testing Contract routing and AF15 collaboration readiness action-plan UX.
- Bumps bootstrap pack to 0.3.0 and optional multi-agent pack to 0.4.0.
- Updates manifest/catalog hashes and tests to match changed artifacts.
- Preserves the current two-pack starter set and does not reintroduce pack.architecture-boundary-review.starter.

## Changed files
- catalog/capability-packs/index.yaml
- catalog/capability-packs/pack.bootstrap.minimal/README.md
- catalog/capability-packs/pack.bootstrap.minimal/CHANGELOG.md
- catalog/capability-packs/pack.multi-agent.optional/README.md
- catalog/capability-packs/pack.multi-agent.optional/CHANGELOG.md
- fixtures/capability-packs/bootstrap-minimal/manifest.yaml
- fixtures/capability-packs/bootstrap-minimal/records/practices/META-003-borrow-external-skills-through-review.md
- fixtures/capability-packs/optional-multi-agent/manifest.yaml
- fixtures/capability-packs/optional-multi-agent/records/practices/COLLAB-PACK-001-review-handoff.md
- fixtures/capability-packs/optional-multi-agent/records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
- scripts/test_bootstrap_pack_deployment.py
- scripts/test_capability_pack_plan.py
- scripts/test_capability_pack_lifecycle.py

## Verification
- python3 scripts/check_capability_pack_fixtures.py
- python3 scripts/test_capability_pack_plan.py
- python3 scripts/test_capability_pack_apply.py
- python3 scripts/test_capability_pack_update.py
- python3 scripts/test_capability_pack_lifecycle.py
- python3 scripts/check_consistency.py
- git diff --check origin/main...HEAD
- targeted hash readback for both manifests and changed records
- targeted grep/read-through for AF13 import outcomes, reference_only boundaries, AF15 action-plan fields/categories, no Project v2 scheduler authority, and no standalone architecture-boundary pack reintroduction

## Hash readback
- bootstrap manifest: 79d7f579c0be89eac443dce005dde4750004099505d0d3a2b677b5c1bb2809c4
- optional multi-agent manifest: 95eeae82c6836905a28c4d48e4a2ce7598d2f0c300ca1401465ec1d45f6adaff
- META-003 record: b7b1ec65490050045ca61380ab31d964b91084d3d8b04bd9b0c71bfb73a97b41
- COLLAB-PACK-001 record: cc4c37f24d443c473586e3824176ff4eff7d5c3043ff444823d8cbf07d218093
- ASSET-COLLAB-PACK-001 record: 00d901a71a4f0a9e6db3b88e10b9cbda01b75ed4284bec3e354a026e6c77d5c9

## Safety
- No capability-pack deploy/apply.
- No live Vault/runtime/generated/private mutation.
- No generated Skill/adapter publish.
- No V2.0 or memory-system work.
- No release/tag work.
- #339 not started; #335/#339 not closed.

## Residual risks
- Reviewer should check whether version bumps and review_evidence updates are sufficient for v1.1 release-readiness.
- #339 remains the final v1.1 readiness/release gate.