### PR TITLE
[AF16 #351] Document branch-aware collaboration strategy

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -33,6 +33,7 @@ Use these short commands in day-to-day agent work. English command text is canon
 | `check collaboration readiness for this repo` | `检查这个 repo 的 collaboration readiness` | Return readiness status, summary, and action plan from labels, routing config, contracts, issue/PR routing, and optional Project mirror state. |
 | `prepare this repo for multi-agent collaboration` | `为这个 repo 准备 multi-agent collaboration` | Start a new-repo setup action plan: role labels, routing template, optional Project mirror options, contracts, human gates, residual risks, and next safe action. |
 | `audit existing collaboration setup` | `审计现有 collaboration setup` | Review drift in an existing project and group next actions as informational, agent-handled, human-gated, or unsupported/deferred. Read-only. |
+| `check branch readiness for this issue or PR` | `检查这个 issue 或 PR 的 branch readiness` | Explain `Branch strategy`, `Target branch`, PR base, local branch state, and safe next action concepts such as split, switch context, forward-merge, or multi-line verification. Read-only. |
 | `publish practices` | `发布 practices` | Publish adapters from current active practices; usually not needed manually. |
 | `check operation context` | `检查操作上下文` | Show current Agent Foundry Core/Vault/evidence/runtime context before writes. |
 | `check Agent Foundry status` | `检查 Agent Foundry 状态` | Run a read-only status pass for Core, selected Vault, generated output, runtime receipts, and manual targets. |

--- a/docs/multi-agent-collaboration.md
+++ b/docs/multi-agent-collaboration.md
@@ -77,7 +77,7 @@ Implementer 做 scoped change，Tester 提供测试证据，Reviewer 做独立�
 | Step | Owner | What happens | Exit signal |
 | --- | --- | --- | --- |
 | 1. Intake | Coordinator | Rehydrate durable state, check dependencies, choose the next owner. | Issue has one clear next `needs:*` label or a recorded hold. |
-| 2. Design / Contract | Architect | Define scope, risk, allowed actions, forbidden actions, branch target, acceptance criteria, and whether Tester is needed. | Execution Contract is durable; next owner is released. |
+| 2. Design / Contract | Architect | Define scope, risk, allowed actions, forbidden actions, branch strategy, target branch, acceptance criteria, and whether Tester is needed. | Execution Contract is durable; next owner is released. |
 | 3. Implementation or Evidence | Implementer, Tester, or Harvester | Produce the scoped change or evidence packet. | Handoff names scope, verification, residual risks, and next owner. |
 | 4. Review | Reviewer | Review exact issue evidence or exact PR head. Findings lead; acceptance is not final closure. | Accepted, requested changes, or blocked with reasons. |
 | 5. Acceptance / Routing | Architect | Decide whether review evidence satisfies the contract and route merge, closure, human gate, or next issue. | Durable acceptance, hold, HDC, merge decision, or release decision. |
@@ -128,7 +128,7 @@ the diff focused, write or update required tests, avoid unrelated cleanup, and
 handoff with exact verification.
 
 Use Implementer only after the issue names allowed scope, dependencies, branch
-target, acceptance criteria, and required evidence. If scope changes while
+strategy, target branch, acceptance criteria, and required evidence. If scope changes while
 implementing, route back to Architect instead of expanding silently.
 
 **中文要点：** Implementer 在明确 contract 下写 production change 和 required tests。
@@ -202,7 +202,10 @@ Owner role: implementer
 Review role: reviewer
 Acceptance role: architect
 Completion handoff: to:reviewer
-Branch target: main | <integration-branch>
+Branch strategy: mainline-maintenance | integration-branch | release-branch | trunk-based | stacked-pr | multi-branch | custom
+Target branch: main | <integration-branch> | <release-branch>
+Affected branches: <optional comma-separated branch list>
+Verification branches: <optional comma-separated branch list>
 Merge rule: human-gated | delegated-child | delegated-main
 Forbidden actions:
   - live Vault/private/runtime/generated mutation
@@ -212,6 +215,64 @@ Forbidden actions:
 Natural-language details belong in separate fields such as `Reviewer target:`,
 `Human verification needed:`, or `Acceptance criteria:`. Do not hide prose
 inside role fields.
+
+`Target branch` is the canonical field. Older `Branch target` text may appear
+in legacy issues, but new contracts should not use it except to document
+compatibility mapping.
+
+**中文要点：** 新 contract 使用 `Branch strategy` 和 `Target branch`。`Branch target`
+只作为旧字段兼容说明，不再作为新示例。
+
+### Branch-Aware Collaboration
+
+Branch-aware collaboration helps a human decide where work should land before an
+agent starts editing or reviewing. It is an action-plan surface, not an
+automatic branch operator. The helper may report the current branch, expected PR
+base, local dirty/ahead/behind state, and degraded remote evidence, but it must
+not checkout, create worktrees, retarget PRs, rebase, merge, reset, clean, or
+apply repairs.
+
+Choose the branch strategy from the user's intent:
+
+| User intent | Branch strategy | Typical target |
+| --- | --- | --- |
+| Maintain the current stable product line. | `mainline-maintenance` | `main` |
+| Build on a shared feature/integration line. | `integration-branch` | named integration branch |
+| Prepare a release branch. | `release-branch` | release branch |
+| Land directly through a trunk-style flow. | `trunk-based` | trunk branch chosen by the repo |
+| Build a child PR on top of a parent PR. | `stacked-pr` | parent PR branch as `PR target` |
+| Change more than one maintained line. | `multi-branch` | primary target plus affected/verification branches |
+| Use a repo-specific policy. | `custom` | Architect-defined |
+
+Agent Foundry's current presets are:
+
+- V1.x maintenance: `Branch strategy: mainline-maintenance`,
+  `Target branch: main`.
+- V2 integration: `Branch strategy: integration-branch`,
+  `Target branch: codex/v2-local-first-orchestration`.
+- V2 merge-back to `main` remains a later readiness and Human-gated decision.
+
+When V2 work is active but a generic Core update belongs on `main`, split the
+work. Land the generic Core update on `main`, record a later forward-merge need,
+and verify on both lines before claiming cross-line readiness. Multi-branch work
+should name `Affected branches` and `Verification branches`; it should not hide
+ordered verification inside a single vague target.
+
+Action-plan concepts mean:
+
+| Concept | Human-facing meaning | Safe next step |
+| --- | --- | --- |
+| `current_branch_ok` | The sampled local branch matches at least one branch contract. | Continue normal scoped work. |
+| `switch_context_required` | The current local branch is not the target branch. | Stop editing in this checkout; route or prepare a separate reviewed context. |
+| `split_work_recommended` | The request mixes branch lines or stacked work. | Split the issue/PR or record ordered sub-work. |
+| `forward_merge_needed_later` | A later line needs the accepted change. | Record follow-up evidence; do not merge automatically. |
+| `verify_on_multiple_lines` | Readiness claim spans more than one branch line. | Run or request verification on every named line. |
+| `architect_decision_required` | Strategy is custom, unknown, or policy-sensitive. | Route to Architect before implementation or merge. |
+
+**中文要点：** Branch-aware collaboration 先帮人判断 work 应该落在哪条 branch line。
+它只给 action plan，不自动 checkout、retarget、merge 或 repair。V2 work 和通用 Core
+update 交错时，优先 split work：通用更新先落 `main`，记录后续 forward-merge，并在多条
+line 上验证。
 
 ### Testing Contract
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -56,6 +56,14 @@ check collaboration readiness for this repo
 
 The report should tell you whether role labels, routing templates, Execution Contracts, Testing Contracts, issue/PR routing, and optional Project/Kanban visibility are present or drifted. Normal users should read `readiness_status`, the short summary, and `recommended_next_actions` first. Raw JSON is evidence/debug output.
 
+Branch-aware readiness also tells you whether work appears to belong on `main`,
+an integration branch, a release branch, a stacked PR, or a multi-branch flow.
+Use `main` for V1.x maintenance in Agent Foundry, and
+`codex/v2-local-first-orchestration` for V2 integration. If a generic Core
+update belongs on `main` while V2 work is active, split the work, land the
+generic update on `main`, record the later forward-merge need, and verify every
+branch line named by the action plan.
+
 For a new project, ask for setup planning:
 
 ```text
@@ -79,7 +87,23 @@ Recommended actions use four categories:
 
 The action-plan report is read-only: `mutation_performed: false`, repair entries keep `apply_supported_now: false`, and the workflow does not perform live repair/apply, Project v2 mutation, generated Skill/adapter publish, or capability-pack deploy/apply.
 
+Branch action-plan concepts are also read-only:
+
+- `current_branch_ok`: continue normal scoped work.
+- `switch_context_required`: stop editing in this checkout and route or prepare
+  a separate reviewed context.
+- `split_work_recommended`: split mixed branch-line work instead of hiding it
+  in one PR.
+- `forward_merge_needed_later`: record the later merge need; do not merge
+  automatically.
+- `verify_on_multiple_lines`: verify every named branch line before claiming
+  cross-line readiness.
+- `architect_decision_required`: route custom or policy-sensitive branch
+  strategy to Architect.
+
 **中文要点：** 新 repo 先要 setup checklist；老 repo 先 audit drift。Action plan 只读，给出下一步，不自动 repair/apply。
+Branch action plan 也只读：它可以提示 split、switch context、forward-merge 或多线验证，
+但不会自动 checkout、retarget、merge、reset 或 clean。
 
 ## First-Time Setup
 

--- a/templates/github-dry-run-planning-examples.md
+++ b/templates/github-dry-run-planning-examples.md
@@ -39,6 +39,8 @@ Owner role: implementer
 Review role: reviewer
 Acceptance role: architect
 Completion handoff: to:reviewer
+Branch strategy: mainline-maintenance
+Target branch: main
 Reviewer target: separate Reviewer agent, focused on contract validation
 Human verification needed: no
 ```
@@ -53,6 +55,8 @@ Owner role: tester
 Review role: reviewer
 Acceptance role: architect
 Completion handoff: to:reviewer
+Branch strategy: integration-branch
+Target branch: codex/v2-local-first-orchestration
 
 ## Testing Contract
 
@@ -61,6 +65,36 @@ Tester Trigger:
   - stateful workflow evidence is required before review
 user_value_or_risk: user can see what was tested and what remains risky
 ```
+
+Branch-aware examples use `Target branch` as the canonical field. `Branch
+target` is legacy compatibility text only and should not appear in new dispatch
+examples.
+
+Use these branch strategy values:
+
+- `mainline-maintenance`: stable line maintenance, usually `main`.
+- `integration-branch`: shared integration line, such as
+  `codex/v2-local-first-orchestration`.
+- `release-branch`: release branch preparation.
+- `trunk-based`: repo-defined trunk flow.
+- `stacked-pr`: child PR built on a parent PR branch.
+- `multi-branch`: work affects more than one maintained line.
+- `custom`: repo-specific policy; route to Architect.
+
+Agent Foundry presets:
+
+- V1.x maintenance: `Branch strategy: mainline-maintenance`,
+  `Target branch: main`.
+- V2 integration: `Branch strategy: integration-branch`,
+  `Target branch: codex/v2-local-first-orchestration`.
+- V2 merge-back remains a later readiness and Human-gated decision.
+
+Action-plan concepts are report-only: `current_branch_ok`,
+`switch_context_required`, `split_work_recommended`,
+`forward_merge_needed_later`, `verify_on_multiple_lines`, and
+`architect_decision_required`. Do not use a dispatch preview to checkout,
+create a worktree, retarget a PR, rebase, merge, reset, clean, or apply branch
+repair.
 
 ```yaml
 dry_run_planning_example:
@@ -72,7 +106,9 @@ dry_run_planning_example:
     pull_request: 212
     parent_issue: 201
     stage: AF-11
+    branch_strategy: mainline-maintenance
     branch: codex/af11-unit-b-helper
+    target_branch: main
     head_sha: a0615b81b8457d004cc20a8153f487f249781498
     base_branch: main
   next_owner: Reviewer
@@ -81,8 +117,10 @@ dry_run_planning_example:
     - read PR body/diff/head SHA
     - run scoped verification
     - draft findings or acceptance recommendation
+    - report branch action-plan concepts without changing branches
   forbidden_actions:
     - write GitHub comments or labels from this preview
+    - checkout, create worktrees, retarget PRs, rebase, merge, reset, or clean
     - mutate Project v2 fields
     - merge or close
     - publish generated Skills or install runtime files
@@ -91,6 +129,7 @@ dry_run_planning_example:
   stop_condition:
     - blocking finding found
     - head SHA changed
+    - branch action plan reports architect_decision_required
     - authority sources disagree with this preview
   callback_required:
     - findings or no-findings statement
@@ -112,7 +151,11 @@ compact_rehydration_packet:
     pull_request: "<pr-number-or-null>"
     parent_issue: "<parent-issue-or-null>"
     stage: "<stage-label>"
+    branch_strategy: "<mainline-maintenance|integration-branch|release-branch|trunk-based|stacked-pr|multi-branch|custom>"
     branch: "<branch-name-or-null>"
+    target_branch: "<target-branch-or-null>"
+    affected_branches: []
+    verification_branches: []
     head_sha: "<head-sha-or-null>"
     base_branch: "<base-branch-or-null>"
   current_owner: Implementer

--- a/templates/github-role-routing.template.yaml
+++ b/templates/github-role-routing.template.yaml
@@ -83,6 +83,44 @@ github:
   project_v2_policy: "optional_visual_mirror_only_no_generalized_write_policy"
   runtime_approval_prompt_boundary: "workflow_authorization_does_not_override_app_level_approval_prompts"
 
+branch_readiness:
+  canonical_target_field: "Target branch"
+  legacy_target_field: "Branch target"
+  legacy_target_field_policy: "read_compatibility_only_do_not_use_in_new_examples"
+  strategy_field: "Branch strategy"
+  supported_strategies:
+    - "mainline-maintenance"
+    - "integration-branch"
+    - "release-branch"
+    - "trunk-based"
+    - "stacked-pr"
+    - "multi-branch"
+    - "custom"
+  agent_foundry_presets:
+    v1_x_maintenance:
+      branch_strategy: "mainline-maintenance"
+      target_branch: "main"
+    v2_integration:
+      branch_strategy: "integration-branch"
+      target_branch: "codex/v2-local-first-orchestration"
+      merge_back_policy: "later_readiness_and_human_gate"
+  action_plan_concepts:
+    - "current_branch_ok"
+    - "switch_context_required"
+    - "split_work_recommended"
+    - "forward_merge_needed_later"
+    - "verify_on_multiple_lines"
+    - "architect_decision_required"
+  helper_write_behavior: "read_only_action_plan_no_branch_repair_apply"
+  unsupported_actions:
+    - "checkout_switch"
+    - "branch_or_worktree_creation"
+    - "pr_retarget"
+    - "rebase"
+    - "merge"
+    - "reset"
+    - "clean"
+
 project_v2:
   mode: "optional_visual_mirror"
   source_of_truth: false

--- a/workflows/github-collaboration-helper.md
+++ b/workflows/github-collaboration-helper.md
@@ -110,6 +110,8 @@ Owner role: implementer
 Review role: reviewer
 Acceptance role: architect
 Completion handoff: to:reviewer
+Branch strategy: mainline-maintenance
+Target branch: main
 Reviewer target: separate Reviewer agent, contract-validation focused
 Human review prompt: only when a real human gate is needed
 ```
@@ -118,6 +120,33 @@ Keep natural-language reviewer descriptions, human prompts, and trial
 instructions in separate fields such as `Reviewer target:`, `Human verification
 needed:`, or `Human review prompt:`. Do not encode them in `Owner role:`,
 `Review role:`, `Acceptance role:`, or `Completion handoff:`.
+
+Branch-aware Execution Contract fields are also machine-readable:
+
+```markdown
+Branch strategy: mainline-maintenance | integration-branch | release-branch | trunk-based | stacked-pr | multi-branch | custom
+Target branch: main | <integration-branch> | <release-branch>
+Affected branches: <optional comma-separated branch list>
+Verification branches: <optional comma-separated branch list>
+PR target: <expected PR base branch>
+Forward-merge expectation: none | record later forward-merge | verify on multiple lines
+```
+
+`Target branch` is canonical. Treat `Branch target` only as a legacy
+compatibility input when reading old issues; do not use it in new examples.
+
+Agent Foundry presets:
+
+- V1.x maintenance uses `Branch strategy: mainline-maintenance` and
+  `Target branch: main`.
+- V2 integration uses `Branch strategy: integration-branch` and
+  `Target branch: codex/v2-local-first-orchestration`.
+- V2 merge-back to `main` remains a later readiness and Human-gated decision.
+
+For custom or unknown branch strategies, route to Architect rather than
+guessing. For stacked PRs or multi-branch work, emit review/action-plan
+guidance; do not checkout, create a worktree, retarget the PR, rebase, merge,
+reset, clean, or apply a repair.
 
 ## Tester Routing
 
@@ -349,6 +378,15 @@ issue/PR routing state, and optional Project/Kanban visibility. Raw JSON remains
 the evidence/debug layer; user-facing guidance comes from `readiness_status`,
 `summary`, and `user_readiness_action_plan.recommended_next_actions`.
 
+Branch-aware readiness also checks generic branch strategy fields before any
+Agent Foundry-specific preset. Supported strategies are
+`mainline-maintenance`, `integration-branch`, `release-branch`, `trunk-based`,
+`stacked-pr`, `multi-branch`, and `custom`. The generic checks cover required
+branch fields, expected PR base versus actual PR base, local dirty/staged/
+unstaged/untracked/ahead/behind state, degraded or unknown remote reads, and
+forbidden repair/apply actions. V1/V2 rules are an additional preset layer, not
+the only branch model.
+
 Valid `readiness_status` values are:
 
 - `ready`: sampled evidence is ready for normal collaboration workflow.
@@ -373,6 +411,27 @@ Recommended actions use these categories:
 | `agent_handled_existing_workflow` | A bounded issue/comment/label/PR/role-handoff action can proceed through existing Agent Foundry gates. | Route with durable issue or PR comments and `needs:*` labels. |
 | `explicit_human_gate` | The action changes product, governance, privacy/security, final integration, closure, or meaningful Project policy. | Post a Human Decision Contract before action. |
 | `unsupported_deferred_repair_apply` | The helper can describe the repair, but AF15 must not execute it. | Leave deferred or create a later gated issue. |
+
+Branch action-plan concepts:
+
+| Concept | Meaning | Current handling |
+| --- | --- | --- |
+| `current_branch_ok` | Current branch evidence matches a sampled contract. | Continue normal scoped work. |
+| `switch_context_required` | Current checkout is not the target branch. | Stop editing here; route or prepare a separately reviewed context. |
+| `split_work_recommended` | Request mixes branch lines, stacked work, or cross-line effects. | Split work or record ordered sub-work. |
+| `forward_merge_needed_later` | Another line needs the accepted change later. | Record follow-up; do not merge automatically. |
+| `verify_on_multiple_lines` | Cross-line readiness needs evidence on every named line. | Verify each branch line before acceptance. |
+| `architect_decision_required` | Strategy is custom, unknown, or policy-sensitive. | Route to Architect before implementation or merge. |
+
+Safe multi-branch UX for V2 work interleaved with generic Core updates:
+
+1. Split the generic Core update from V2-only work.
+2. Land the generic Core update on `main` first through the normal reviewed
+   path.
+3. Record `forward_merge_needed_later` for V2.
+4. Use `verify_on_multiple_lines` before claiming cross-line readiness.
+5. Keep checkout/switch, branch/worktree creation, PR retarget, rebase, merge,
+   reset, clean, and repair/apply unsupported in the helper.
 
 For new-project setup, use the action plan to confirm:
 


### PR DESCRIPTION
## Scope

Implements #351 docs/templates/role dispatch guidance after #350 branch-readiness helper landed.

- Documents canonical `Target branch` and generic `Branch strategy` values.
- Keeps `Branch target` only as legacy compatibility wording.
- Explains Agent Foundry V1/V2 presets: V1.x maintenance on `main`, V2 integration on `codex/v2-local-first-orchestration`, and V2 merge-back as later readiness + Human gate.
- Explains safe multi-branch UX for V2 work interleaved with generic Core updates.
- Adds user-facing meanings for `current_branch_ok`, `switch_context_required`, `split_work_recommended`, `forward_merge_needed_later`, `verify_on_multiple_lines`, and `architect_decision_required`.
- Updates role dispatch / Execution Contract examples and inert routing template fields.

## Changed Files

- `docs/multi-agent-collaboration.md`
- `docs/usage.md`
- `docs/commands.md`
- `workflows/github-collaboration-helper.md`
- `templates/github-role-routing.template.yaml`
- `templates/github-dry-run-planning-examples.md`

## Verification

- `python3 scripts/check_consistency.py`
- `git diff --check origin/main...HEAD`
- Targeted grep/read-through for `Target branch`, `Branch strategy`, supported strategy values, multi-branch action-plan concepts, unsupported branch repair/apply boundaries, and no stale `Branch target` examples except legacy mapping notes.

## Boundaries Preserved

Docs/templates only. No helper implementation change, live repair/apply, checkout/switch, branch/worktree creation, PR retarget, rebase, merge, reset, clean, force push, Project mutation, runtime/Vault/private/generated mutation, generated Skill publish, capability-pack deploy/apply, V2 implementation, release/tag work, or #352-#354 work.

## Residual Risks

- This updates Core docs/templates only. Generated/runtime Skill publish remains a later gated step if AF16 decides downstream runtime guidance must be refreshed.
