### PR TITLE
Update optional collaboration pack for AF16 branch readiness

### DIFF
--- a/catalog/capability-packs/index.yaml
+++ b/catalog/capability-packs/index.yaml
@@ -27,9 +27,9 @@ entries:
     title: Optional GitHub Collaboration Starter Pack
     channel: official
     catalog_status: available
-    latest_version: 0.3.1
+    latest_version: 0.3.2
     manifest_path: fixtures/capability-packs/optional-multi-agent/manifest.yaml
-    manifest_sha256: ccb7ec67df17ed05e56fdcdd4f47486eee41549c67dde7200a337ad6ff957819
+    manifest_sha256: a8261175a4c2cc64d2d0aa047fed3d9c33daaefadeaccee9eeb314c1748d9511
     compatibility_summary: "Core schema 1; Vault layout [1]; bootstrap required; selected Vault review required."
     compatibility_metadata:
       core_schema_version_min: 1
@@ -38,7 +38,7 @@ entries:
       requires_bootstrap_pack: true
     changelog_path: catalog/capability-packs/pack.multi-agent.optional/CHANGELOG.md
     readme_path: catalog/capability-packs/pack.multi-agent.optional/README.md
-    review_evidence: https://github.com/farmerhunter/agent-foundry/issues/253
+    review_evidence: https://github.com/farmerhunter/agent-foundry/issues/352
     authority_after_deployment: selected_user_vault
     private_local_evidence: excluded
     core_release_axis: independent

--- a/catalog/capability-packs/pack.multi-agent.optional/CHANGELOG.md
+++ b/catalog/capability-packs/pack.multi-agent.optional/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.3.2
+
+- Added AF16 branch-aware collaboration guidance to the optional collaboration
+  starter contract.
+- Documented canonical `Target branch`, `Branch strategy`, generic strategy
+  families, Agent Foundry V1/V2 presets, and multi-branch action-plan concepts.
+- Kept branch repair/apply, checkout/switch, worktree creation, PR retarget,
+  rebase, merge, reset, clean, force-push, V2 merge-back, generated Skill
+  publish, runtime install, Vault mutation, and Project mutation outside pack
+  authority.
+
 ## 0.3.1
 
 - Added AF15 user-facing readiness action-plan semantics to the optional

--- a/catalog/capability-packs/pack.multi-agent.optional/README.md
+++ b/catalog/capability-packs/pack.multi-agent.optional/README.md
@@ -31,6 +31,38 @@ of truth.
 dependency-gated queues、review handoffs，以及 write automation 前的 read-only
 audit。
 
+## Branch-Aware Collaboration / Branch-Aware 协作
+
+The current starter guidance includes the AF16 branch-aware collaboration
+model. Execution Contracts should use `Target branch` as the canonical field
+and `Branch strategy` to describe the workflow family:
+`mainline-maintenance`, `integration-branch`, `release-branch`, `trunk-based`,
+`stacked-pr`, `multi-branch`, or `custom`. Older `Branch target` wording is
+legacy compatibility input, not the preferred field.
+
+**中文要点：** AF16 后，Execution Contract 使用 `Target branch` 和
+`Branch strategy`。`Branch target` 只作为旧字段兼容，不是新 contract 的推荐写法。
+
+Agent Foundry's V1/V2 behavior is a project preset on top of the generic
+strategy model: V1.x maintenance targets `main`; V2 integration targets
+`codex/v2-local-first-orchestration`; V2 merge-back remains a later readiness
+and Human-gated decision. Other projects may use custom, integration, release,
+trunk-based, stacked PR, or multi-branch strategies without being forced into
+the Agent Foundry preset.
+
+**中文要点：** Agent Foundry 的 V1/V2 只是项目 preset：V1.x 走 `main`，V2 走
+`codex/v2-local-first-orchestration`。其他项目可使用 generic strategy，不应被硬编码成
+Agent Foundry 分支模型。
+
+Branch readiness reports should be action plans only. They can say
+`current_branch_ok`, `switch_context_required`, `split_work_recommended`,
+`forward_merge_needed_later`, `verify_on_multiple_lines`, or
+`architect_decision_required`, but they must not switch branches, create
+worktrees, retarget PRs, rebase, merge, reset, clean, or repair branches.
+
+**中文要点：** Branch readiness 只给 action plan，不执行 checkout/switch、worktree
+creation、PR retarget、rebase、merge、reset、clean 或 branch repair。
+
 ## Collaboration Readiness / 协作就绪检查
 
 The current starter guidance includes the AF15 collaboration readiness model:
@@ -111,8 +143,8 @@ comments as the workflow record.
 The pack covers a base GitHub collaboration workflow: role labels, durable
 issue/PR comments, explicit Execution Contract fields, dependency-gated queues,
 Testing Contract evidence when needed, collaboration readiness audit, dry-run
-repair planning, degraded GitHub/Project access reporting, and read-only audit
-before write automation.
+repair planning, branch-aware action plans, degraded GitHub/Project access
+reporting, and read-only audit before write automation.
 
 Project v2 status may be a configured visual mirror, but it is not the scheduler
 source of truth. Runtime helper install, generated Skill publish, and mutating
@@ -131,10 +163,11 @@ receipts remain downstream status surfaces, not catalog or pack authority.
 
 ## Versioning
 
-Pack version `0.3.1` identifies the reviewed GitHub collaboration readiness
-starter contract. Pack version `0.2.0` identified the earlier GitHub
-collaboration starter contract. Core git tags and releases identify repository
-snapshots. These are related but independent axes.
+Pack version `0.3.2` identifies the reviewed branch-aware GitHub collaboration
+starter contract. Pack version `0.3.1` identified the AF15 collaboration
+readiness action-plan contract. Pack version `0.2.0` identified the earlier
+GitHub collaboration starter contract. Core git tags and releases identify
+repository snapshots. These are related but independent axes.
 
 ## Review
 
@@ -147,3 +180,6 @@ Review evidence:
 - https://github.com/farmerhunter/agent-foundry/issues/317
 - https://github.com/farmerhunter/agent-foundry/issues/318
 - https://github.com/farmerhunter/agent-foundry/issues/319
+- https://github.com/farmerhunter/agent-foundry/issues/350
+- https://github.com/farmerhunter/agent-foundry/issues/351
+- https://github.com/farmerhunter/agent-foundry/issues/352

--- a/fixtures/capability-packs/optional-multi-agent/manifest.yaml
+++ b/fixtures/capability-packs/optional-multi-agent/manifest.yaml
@@ -1,10 +1,10 @@
 manifest_schema_version: 1
 pack_id: pack.multi-agent.optional
 title: Optional Multi-Agent Collaboration Pack
-description: Reviewed optional first-party starter pack for role-generic GitHub issue and PR collaboration helpers, collaboration readiness, and dry-run repair planning.
+description: Reviewed optional first-party starter pack for role-generic GitHub issue and PR collaboration helpers, collaboration readiness, branch-aware action plans, and dry-run repair planning.
 lifecycle_status: reviewed
-version: 0.3.1
-exported_at: 2026-07-06
+version: 0.3.2
+exported_at: 2026-07-07
 distribution_type: optional_capability
 source_provenance: "Agent Foundry public Core fixture reviewed through AF12-3 issue #253."
 maintainer_contact: "https://github.com/farmerhunter/agent-foundry"
@@ -13,7 +13,7 @@ sensitivity: public
 review_state: reviewed
 
 pack_contract:
-  promised_use_case: "Help a project operate GitHub issues, PRs, labels, comments, collaboration readiness reports, dry-run repair plans, and optional visual status mirrors as a lightweight multi-agent scheduler."
+  promised_use_case: "Help a project operate GitHub issues, PRs, labels, comments, collaboration readiness reports, branch-aware action plans, dry-run repair plans, and optional visual status mirrors as a lightweight multi-agent scheduler."
   deployment_role: "optional user-selected capability after bootstrap"
   source_authority_after_deployment: "selected User Vault records"
   non_authority_boundaries: [generated adapters are downstream only, runtime installs are downstream only, pack staging is transfer evidence only, Core fixtures are schema and test evidence only]
@@ -24,6 +24,7 @@ evidence_sources:
   - "Agent Foundry issue 315 collaboration readiness model decision"
   - "Agent Foundry issues 316-319 AF15 helper, docs, dry-run repair, and dogfood review"
   - "Agent Foundry issues 328-331 AF15 action-plan UX correction and dogfood review"
+  - "Agent Foundry issues 348-352 AF16 branch-aware collaboration readiness and docs/template enablement"
   - "Agent Foundry public first-party starter-pack review"
 
 export_policy:
@@ -54,6 +55,9 @@ starter_contents:
     - "collaboration readiness before new project adoption"
     - "existing project drift audit and dry-run repair planning"
     - "user-facing readiness action-plan output"
+    - "branch-aware Execution Contract fields: Branch strategy, Target branch, affected branches, and verification branches"
+    - "generic branch strategy families with Agent Foundry V1/V2 presets as project overlays"
+    - "multi-branch, stacked PR, split-work, forward-merge, and multi-line verification action-plan concepts"
     - "degraded GitHub/Project access reporting"
     - "read-only audit before write automation"
   assets:
@@ -64,6 +68,7 @@ starter_contents:
     - "Testing Contract template"
     - "pickup and handoff comment templates"
     - "collaboration readiness adoption guidance"
+    - "branch-aware Execution Contract and role dispatch examples"
   executable_payload_candidates:
     - "agent-inbox"
     - "agent-ready-queue"
@@ -92,6 +97,7 @@ rejected_as_pack:
   - "execution from product project paths, pack staging, or canonical Vault payload paths"
   - "active Agent Foundry practices without separate harvest review"
   - "live Project repair/apply behavior without later reviewed gate"
+  - "branch repair/apply, checkout/switch, worktree creation, PR retarget, rebase, merge, reset, clean, or force-push behavior"
 
 compatibility:
   core_schema_version_min: 1
@@ -104,8 +110,8 @@ included_records:
     kind: practice
     lifecycle_status: candidate
     path: records/practices/COLLAB-PACK-001-review-handoff.md
-    source_version: 4
-    content_sha256: "9c35b4a380ce398119175a4378625767c057cbcb222ddee9323fe21953027f13"
+    source_version: 5
+    content_sha256: "316cbd91d14dee915b09561e8e9d2576582772f2ca25a1212ecde6a4872208bd"
     destination_layer: canonical_vault_record
     membership_role: optional_member
     activation_default: manual_review
@@ -114,8 +120,8 @@ included_records:
     kind: asset
     lifecycle_status: candidate
     path: records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
-    source_version: 4
-    content_sha256: "ca4191e0d9d843a6606481edcb811e93ed01e1975a85d4811453779a23c73ef8"
+    source_version: 5
+    content_sha256: "8c8eb717577fac50cf0ee80cd16d1e6443f9a84340ff6c3dbe5798cf42a2069d"
     destination_layer: canonical_vault_record
     membership_role: optional_member
     activation_default: manual_review

--- a/fixtures/capability-packs/optional-multi-agent/records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
+++ b/fixtures/capability-packs/optional-multi-agent/records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
@@ -2,17 +2,20 @@ id: ASSET-COLLAB-PACK-001
 title: Role-Generic GitHub Scheduler Helper Set
 asset_type: skill
 status: candidate
-version: 4
+version: 5
 created: 2026-06-11
-updated: 2026-07-06
-purpose: Provide reviewed helper surfaces for role-generic GitHub issue/PR coordination and collaboration readiness reporting.
-responsibility: Support inbox, ready-queue, pickup, handoff, audit, collaboration readiness, user-facing readiness action plans, dry-run repair planning, degraded GitHub/Project access reporting, label routing, issue context, PR context, and retry wrappers after managed install.
-non_responsibility: Does not decide product scope, override issue contracts, make Project v2 the scheduler authority, install helpers, execute from pack staging, apply dry-run repairs, publish generated Skills, or mutate Project v2 by default.
+updated: 2026-07-07
+purpose: Provide reviewed helper surfaces for role-generic GitHub issue/PR coordination, collaboration readiness reporting, and branch-aware action-plan guidance.
+responsibility: Support inbox, ready-queue, pickup, handoff, audit, collaboration readiness, branch/worktree/PR-target readiness reporting, user-facing readiness action plans, dry-run repair planning, degraded GitHub/Project access reporting, label routing, issue context, PR context, and retry wrappers after managed install.
+non_responsibility: Does not decide product scope, override issue contracts, make Project v2 the scheduler authority, install helpers, execute from pack staging, apply dry-run repairs, publish generated Skills, mutate Project v2 by default, repair branches, switch checkout context, create worktrees, retarget PRs, rebase, merge, reset, clean, or force-push.
 inputs:
   - issue number
   - PR number
   - role name
   - Execution Contract text
+  - Target branch
+  - Branch strategy
+  - optional affected or verification branch list
   - GitHub label and comment state
   - optional project-local routing config
 process:
@@ -21,6 +24,9 @@ process:
   - Report collaboration readiness for new or existing projects before multi-agent work relies on the setup.
   - Present readiness status, summary, blocking gaps, unknown/degraded sources, recommended next actions, forbidden actions, and telemetry before raw debug evidence.
   - Include Execution Contract validation and Testing Contract validation where the workflow asks for explicit test evidence.
+  - Validate branch-aware contract fields as report data: canonical Target branch, Branch strategy, expected PR base, local dirty/ahead/behind state, and degraded or unknown remote state.
+  - Report branch action-plan concepts such as current_branch_ok, switch_context_required, split_work_recommended, forward_merge_needed_later, verify_on_multiple_lines, and architect_decision_required without performing branch repair.
+  - Preserve generic branch strategies, including mainline-maintenance, integration-branch, release-branch, trunk-based, stacked-pr, multi-branch, and custom, with Agent Foundry V1/V2 as project presets rather than the only model.
   - Print dry-run plans before any mutating helper behavior is allowed.
   - Keep dry-run repair entries report-only with mutation_performed false and apply_supported_now false.
   - Prefer REST-first GitHub reads and targeted Project v2 GraphQL only when configured and needed.
@@ -33,7 +39,9 @@ outputs:
   - pickup or handoff dry-run
   - audit report
   - collaboration readiness report
+  - branch readiness report
   - readiness action plan
+  - branch action plan
   - dry-run repair plan
   - degraded-source summary
   - issue or PR context summary
@@ -46,6 +54,7 @@ usage_triggers:
   - GitHub issue scheduler
   - multi-agent ready queue
   - collaboration readiness
+  - branch readiness
   - dry-run repair plan
   - degraded GitHub access
 success_criteria:
@@ -53,4 +62,5 @@ success_criteria:
   - Project-specific defaults are represented as overlays rather than reusable pack defaults.
   - Mutating actions remain disabled until managed install, permissions, and receipts exist.
   - Readiness reports identify missing or drifted setup without mutating GitHub or Project state.
+  - Branch readiness reports identify contract, local-state, PR-base, split-work, forward-merge, and multi-line verification needs without changing branches or PR targets.
   - Degraded GitHub or Project access is visible in reports instead of hidden by inferred success.

--- a/fixtures/capability-packs/optional-multi-agent/records/practices/COLLAB-PACK-001-review-handoff.md
+++ b/fixtures/capability-packs/optional-multi-agent/records/practices/COLLAB-PACK-001-review-handoff.md
@@ -4,10 +4,10 @@ title: Role-Generic GitHub Handoff Routing
 domain: agent-collaboration
 type: checklist
 status: candidate
-version: 4
+version: 5
 created: 2026-06-11
-updated: 2026-07-06
-tags: [multi-agent, review, handoff, scheduler, readiness, dry-run-repair]
+updated: 2026-07-07
+tags: [multi-agent, review, handoff, scheduler, readiness, dry-run-repair, branch-aware]
 aliases: [COLLAB-PACK-001]
 review_required: true
 ---
@@ -26,6 +26,11 @@ Multi-agent work loses continuity when completion evidence lives only in a chat 
 - Put pickup and handoff evidence on durable issue and PR surfaces when a PR exists.
 - Include scope, verification commands and outcomes, residual risks, and the expected next role.
 - Parse explicit Execution Contract fields for owner role, review role, acceptance role, dependency gates, branch strategy, and completion handoff.
+- Use `Target branch` as the canonical branch contract field. Treat `Branch target` as legacy compatibility input only when mapping older contracts.
+- Record `Branch strategy` with one of: `mainline-maintenance`, `integration-branch`, `release-branch`, `trunk-based`, `stacked-pr`, `multi-branch`, or `custom`.
+- Apply project presets only as overlays. In Agent Foundry, V1.x maintenance targets `main`; V2 integration targets `codex/v2-local-first-orchestration`; V2 merge-back remains a later readiness and Human-gated decision.
+- For interleaved V2 work and generic Core updates, prefer split work and explicit evidence: land generic Core updates on `main`, record later forward-merge need, and verify on multiple lines before claiming cross-line readiness.
+- Surface branch action-plan concepts as report output: `current_branch_ok`, `switch_context_required`, `split_work_recommended`, `forward_merge_needed_later`, `verify_on_multiple_lines`, and `architect_decision_required`.
 - Prefer read-only inbox, ready-queue, pickup, handoff, audit, and collaboration readiness dry-runs before write automation.
 - For new projects, run collaboration readiness before relying on multi-agent routing. Check role labels, routing templates, Execution Contracts, Testing Contracts when needed, and optional Project/Kanban mirror fields.
 - For existing projects, use collaboration readiness to report drift and safe next actions. Read the user-facing action-plan layer first: readiness status, summary, blocking gaps, unknown/degraded sources, recommended next actions, forbidden actions, and telemetry.
@@ -38,5 +43,6 @@ Multi-agent work loses continuity when completion evidence lives only in a chat 
 
 - Do not run default full Project scans for ordinary collaboration reads.
 - Do not apply dry-run repairs from this pack.
+- Do not perform branch repair/apply, checkout or switch branches, create worktrees, retarget PRs, rebase, merge, reset, clean, or force-push from this pack.
 - Do not publish generated Skills, install runtime helpers, or mutate Project v2 from pack deployment.
 - Keep selected User Vault records canonical after deployment; generated adapters, runtime receipts, and local helper outputs remain downstream evidence.

--- a/scripts/test_capability_pack_lifecycle.py
+++ b/scripts/test_capability_pack_lifecycle.py
@@ -219,7 +219,7 @@ def main() -> int:
         newer_version = copy_optional_variant(
             base,
             "newer-version-pack",
-            {"version: 0.3.1": "version: 0.4.0"},
+            {"version: 0.3.2": "version: 0.4.0"},
         )
         errors.extend(
             expect(

--- a/scripts/test_capability_pack_plan.py
+++ b/scripts/test_capability_pack_plan.py
@@ -579,7 +579,7 @@ def main() -> int:
         write_deployed_index(
             vault,
             "pack.multi-agent.optional",
-            "0.3.1",
+            "0.3.2",
             "0" * 64,
             "COLLAB-PACK-001",
             "",


### PR DESCRIPTION
## Scope

Implements AF16 #352 capability-pack impact update for branch-aware collaboration.

- Updates `pack.multi-agent.optional` to version `0.3.2` for AF16 branch-aware collaboration readiness/action-plan guidance.
- Adds canonical `Target branch`, `Branch strategy`, generic strategy families, Agent Foundry V1/V2 presets, and multi-branch action-plan concepts to the optional pack docs and member records.
- Preserves read-only/report-only boundaries: no branch repair/apply, checkout/switch, worktree creation, PR retarget, rebase, merge, reset, clean, force-push, Project mutation, runtime publish, generated Skill publish, or Vault mutation.
- Updates manifest member record versions/hashes and official catalog version/hash metadata.
- Keeps `pack.bootstrap.minimal` unchanged: AF16 branch-aware collaboration belongs to the optional multi-agent pack, not bootstrap-level governance/setup orientation.

## Hash Evidence

- `COLLAB-PACK-001` record sha256: `316cbd91d14dee915b09561e8e9d2576582772f2ca25a1212ecde6a4872208bd`
- `ASSET-COLLAB-PACK-001` record sha256: `8c8eb717577fac50cf0ee80cd16d1e6443f9a84340ff6c3dbe5798cf42a2069d`
- optional pack manifest sha256: `a8261175a4c2cc64d2d0aa047fed3d9c33daaefadeaccee9eeb314c1748d9511`
- catalog readback confirmed latest version `0.3.2` and manifest hash match.

## Verification

- `python3 -m py_compile scripts/test_capability_pack_plan.py scripts/test_capability_pack_lifecycle.py`
- `python3 scripts/check_capability_pack_fixtures.py`
- `python3 scripts/test_advanced_capability_workflow_surface.py`
- `python3 scripts/test_capability_pack_plan.py`
- `python3 scripts/test_capability_pack_apply.py`
- `python3 scripts/test_capability_pack_update.py`
- `python3 scripts/test_capability_pack_lifecycle.py`
- `python3 scripts/check_consistency.py`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- Targeted grep/read-through for `Target branch`, `Branch strategy`, branch action-plan concepts, selected User Vault authority, no standalone architecture-boundary pack, and no branch repair/apply authority.

## Generated Skill / Harvest Gate

Generated `agent-collaboration` Skill guidance remains a downstream runtime surface. This PR does not harvest canonical selected-Vault practices/assets, publish generated Skills/adapters, or apply runtime changes. If runtime Skill enablement is required, it should go through the existing harvest/publish/apply gate.

## #353 Tester Handoff

Tester should treat generated/runtime enablement as deferred unless a later harvest/publish/apply gate refreshes generated Skills. When that happens, test that runtime `agent-collaboration` guidance exposes AF16 branch-aware action-plan concepts and still refuses checkout/switch, worktree creation, PR retarget, rebase, merge, reset, clean, Project mutation, and branch repair/apply.

## Residual Risks

- Pack artifacts now carry AF16 guidance, but runtime generated Skills may remain stale until a separate harvest/publish/apply workflow updates them.
- This PR updates public Core pack artifacts only; it does not prove adopter runtime behavior.

Closes no issues directly; routes #352 to Reviewer.
