### PR TITLE
V2 #362 dry-run Project sync plan

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -37,6 +37,7 @@ Use these short commands in day-to-day agent work. English command text is canon
 | `show Foundry Board` | `显示 Foundry Board` | Render a read-only local-first board/report from accepted ledger replay first, with GitHub/Project as mirror drift evidence. It does not write GitHub, Project, ledger, runtime, or Vault state. |
 | `show local collaboration ledger report` | `显示 local collaboration ledger report` | Replay local append-only ledger events from `usage/local/collaboration-ledger/` or a supplied test root into derived work-item state. Read-only; no GitHub dependency or write-back. |
 | `preview existing project ledger backfill` | `预览 existing project ledger backfill` | Convert bounded existing GitHub-first issue/PR/comment/label/milestone/Project evidence into candidate local ledger events for review only. No authoritative migration or writes. |
+| `preview GitHub Project sync plan` | `预览 GitHub Project sync plan` | Generate a dry-run Project mirror plan from ledger-backed board state with before/after values, conflicts, Human gates, and readback requirements. No Project/GitHub writes. |
 | `publish practices` | `发布 practices` | Publish adapters from current active practices; usually not needed manually. |
 | `check operation context` | `检查操作上下文` | Show current Agent Foundry Core/Vault/evidence/runtime context before writes. |
 | `check Agent Foundry status` | `检查 Agent Foundry 状态` | Run a read-only status pass for Core, selected Vault, generated output, runtime receipts, and manual targets. |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -153,6 +153,17 @@ The preview converts bounded issue/PR/comment/label/milestone/Project mirror evi
 
 **中文要点：** Backfill preview 只生成 candidate events 给 review；不会写 GitHub/Project，不会把 candidate 变成 accepted ledger state，也不会启动 #361 board 或 #362 sync。
 
+For GitHub Project mirroring, ask for a dry-run sync plan:
+
+```text
+preview GitHub Project sync plan
+预览 GitHub Project sync plan
+```
+
+The plan reads the ledger-backed Foundry Board and reports what Project fields would change, conflicts, Human gates, unsupported actions, and readback requirements. It is dry-run only: `mutation_performed: false`, `writes_supported_now: false`, and no Project/GitHub/branch/runtime/Vault/generated writes.
+
+**中文要点：** Project sync plan 只说明如果同步会改什么、哪里冲突、哪些需要 Human gate；它不会真正改 Project、GitHub issue、branch、runtime 或 Vault。
+
 ## First-Time Setup
 
 On a new machine, use `docs/deployment.md` for the full split Core/Vault install flow. Short version:

--- a/scripts/github_collaboration_helper.py
+++ b/scripts/github_collaboration_helper.py
@@ -42,6 +42,7 @@ READ_ONLY_ACTIONS = {
     "scheduler-audit",
     "collaboration-readiness",
     "foundry-board",
+    "project-sync-plan",
     "local-ledger-report",
     "local-ledger-backfill-preview",
     "activation-report",
@@ -739,6 +740,7 @@ def empty_derived_work_item(key: str, event: dict[str, Any]) -> dict[str, Any]:
         "blocked": False,
         "blocking_reason": None,
         "latest_event_id": None,
+        "latest_occurred_at": None,
         "latest_evidence": [],
         "provenance_links": [],
         "confidence": "unknown",
@@ -766,6 +768,7 @@ def apply_local_ledger_event(item: dict[str, Any], event: dict[str, Any]) -> Non
     event_type = event["event_type"]
     payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
     item["latest_event_id"] = event["event_id"]
+    item["latest_occurred_at"] = event.get("occurred_at", item.get("latest_occurred_at"))
     item["event_ids"].append(event["event_id"])
     item["confidence"] = event.get("confidence", item["confidence"])
     item["unknown_fields"] = merge_unique(item["unknown_fields"], event.get("unknown_fields", []))
@@ -1796,6 +1799,9 @@ def project_field_value(item: dict[str, Any], field: str) -> str | None:
         "Stage": ["Stage", "stage"],
         "Owner Role": ["Owner Role", "owner Role", "owner_role", "ownerRole"],
         "Risk": ["Risk", "risk"],
+        "Target Branch": ["Target Branch", "target Branch", "target_branch", "targetBranch"],
+        "Branch Readiness": ["Branch Readiness", "branch Readiness", "branch_readiness", "branchReadiness"],
+        "Evidence Links": ["Evidence Links", "evidence Links", "evidence_links", "evidenceLinks"],
     }
     for key in aliases[field]:
         if key not in item:
@@ -3301,6 +3307,7 @@ def board_item_from_ledger_item(
         "conflict_count": len(conflicts) + len(ledger_item.get("conflicts", [])),
         "mirror_status": mirror_status,
         "remote_mirror_state": remote_mirror_from_issue(repo, issue, project_item, project_status),
+        "local_updated_at": ledger_item.get("latest_occurred_at"),
         "confidence": ledger_item.get("confidence", "unknown"),
         "state_authority": state_authority,
         "unknown_fields": ledger_item.get("unknown_fields", []),
@@ -3488,6 +3495,309 @@ def build_foundry_board(
             "unknown_not_available_fields": ["exact_elapsed_time", "exact_api_call_count", "billing_grade_token_count"],
         },
     }
+
+
+SYNC_PLAN_FIELDS = ["Status", "Roadmap Status", "Owner Role", "Stage", "Risk", "Target Branch", "Branch Readiness", "Evidence Links"]
+SYNC_PLAN_OWNER_OPTIONS = ["Architect", "Implementer", "Tester", "Reviewer", "Human", "Harvester"]
+
+
+def board_state_to_project_status(state: str) -> str:
+    if state == "done":
+        return "Done"
+    if state in {"in_progress", "tester_evidence", "review", "architect_acceptance", "human_gate"}:
+        return "In Progress"
+    if state in {"blocked", "stale_conflict"}:
+        return "Blocked"
+    return "Todo"
+
+
+def board_state_to_roadmap_status(state: str) -> str:
+    if state == "done":
+        return "Done"
+    if state in {"in_progress", "tester_evidence", "review", "architect_acceptance", "human_gate"}:
+        return "In Progress"
+    if state in {"ready"}:
+        return "Ready"
+    if state in {"blocked", "stale_conflict"}:
+        return "Blocked"
+    return "Planned"
+
+
+def project_item_identity(item: dict[str, Any] | None) -> str | None:
+    if not item:
+        return None
+    for key in ("id", "item_id", "project_item_id"):
+        if item.get(key):
+            return str(item[key])
+    number = project_item_issue_number(item)
+    return f"project-item-for-{number}" if number is not None else None
+
+
+def field_value_for_sync_item(item: dict[str, Any], field: str) -> str | None:
+    if field == "Status":
+        return board_state_to_project_status(str(item.get("state", "planned")))
+    if field == "Roadmap Status":
+        return board_state_to_roadmap_status(str(item.get("state", "planned")))
+    if field == "Owner Role":
+        owner = item.get("next_owner_role") or item.get("owner_role")
+        return str(owner).replace("_", " ").title().replace(" ", "") if owner else None
+    if field == "Stage":
+        stage = item.get("stage")
+        return str(stage) if stage else None
+    if field == "Risk":
+        risk = item.get("risk")
+        return str(risk) if risk else None
+    if field == "Target Branch":
+        return item.get("target_branch")
+    if field == "Branch Readiness":
+        return item.get("branch_readiness")
+    if field == "Evidence Links":
+        refs = item.get("evidence_refs") or []
+        links = [ref.get("url_or_path") for ref in refs if isinstance(ref, dict) and ref.get("url_or_path")]
+        return ", ".join(links) if links else None
+    return None
+
+
+def contains_sensitive_value(value: Any) -> bool:
+    text = json.dumps(value, sort_keys=True) if isinstance(value, (dict, list)) else str(value or "")
+    lowered = text.lower()
+    sensitive_markers = ("token", "secret", "credential", "private", "/users/", "~/.ssh", "ssh-rsa", "begin private key")
+    return any(marker in lowered for marker in sensitive_markers)
+
+
+def sync_conflict(code: str, item: dict[str, Any] | None, message: str, severity: str = "warning", details: dict[str, Any] | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "code": code,
+        "severity": severity,
+        "message": message,
+    }
+    if item is not None:
+        payload["work_item_id"] = item.get("work_item_id")
+        payload["board_item_id"] = item.get("board_item_id")
+    if details:
+        payload.update(details)
+    return payload
+
+
+def sync_human_gate(reason: str, item: dict[str, Any] | None, message: str, details: dict[str, Any] | None = None) -> dict[str, Any]:
+    gate: dict[str, Any] = {
+        "reason": reason,
+        "message": message,
+        "required_decision": "human_review_before_any_future_write_apply",
+    }
+    if item is not None:
+        gate["work_item_id"] = item.get("work_item_id")
+    if details:
+        gate.update(details)
+    return gate
+
+
+def compare_isoish(left: str | None, right: str | None) -> str | None:
+    if not left or not right or left == right:
+        return None
+    return "local_newer" if left > right else "remote_newer"
+
+
+def build_project_sync_plan(
+    repo: str,
+    board: dict[str, Any],
+    project_items: list[dict[str, Any]],
+    project_status: dict[str, Any],
+    project_attempts: dict[str, Any],
+    elapsed_time_ms: float,
+) -> dict[str, Any]:
+    fields_seen = set(project_status.get("fields_seen") or [])
+    options_seen = set(project_status.get("options_seen") or [])
+    project_by_issue: dict[int, list[dict[str, Any]]] = {}
+    for project_item in project_items:
+        number = project_item_issue_number(project_item)
+        if number is not None:
+            project_by_issue.setdefault(number, []).append(project_item)
+    conflicts: list[dict[str, Any]] = []
+    human_gates: list[dict[str, Any]] = [
+        sync_human_gate(
+            "future_write_apply_transition",
+            None,
+            "This helper only generates a dry-run plan; any future Project write/apply transition requires Human authorization.",
+        )
+    ]
+    operations: list[dict[str, Any]] = []
+    partial_results = []
+    if project_status.get("status") in {"config_missing", "skipped"}:
+        partial_results.append({"source": "github_graphql_project_v2", "status": project_status.get("status"), "impact": "Project mirror was not configured; plan reports local desired state only."})
+    elif project_status.get("status") != "ok":
+        conflicts.append(sync_conflict("degraded_project_readback", None, "Project readback is degraded; sync plan is partial.", details={"project_status": project_status.get("status"), "error": project_status.get("error")}))
+        partial_results.append({"source": "github_graphql_project_v2", "status": project_status.get("status"), "error": project_status.get("error")})
+    for field in SYNC_PLAN_FIELDS:
+        if field not in fields_seen and project_status.get("explicit_metadata"):
+            conflicts.append(sync_conflict("missing_project_field", None, f"Project field `{field}` is missing from configured metadata.", details={"field": field}))
+    if project_status.get("explicit_metadata"):
+        for option in SYNC_PLAN_OWNER_OPTIONS:
+            if option not in options_seen:
+                conflicts.append(sync_conflict("missing_project_option", None, f"Owner Role option `{option}` is missing.", details={"field": "Owner Role", "option": option}))
+    for item in board.get("items", []):
+        if item.get("state_authority") == "candidate_import":
+            conflicts.append(sync_conflict("candidate_state_not_authoritative", item, "Imported candidate state cannot be synced until a later migration acceptance gate."))
+            continue
+        number = None
+        match = re.search(r"#(?:issue|pr):(\d+)$", str(item.get("work_item_id", "")))
+        if match:
+            number = int(match.group(1))
+        project_matches = project_by_issue.get(number, []) if number is not None else []
+        if len(project_matches) > 1:
+            conflicts.append(sync_conflict("ambiguous_project_item", item, "Multiple Project items match the same work item.", details={"project_item_count": len(project_matches)}))
+            continue
+        project_item = project_matches[0] if project_matches else None
+        if project_status.get("status") == "ok" and project_item is None:
+            conflicts.append(sync_conflict("missing_project_item", item, "No Project mirror item exists for this local board item."))
+        remote_state = item.get("remote_mirror_state") if isinstance(item.get("remote_mirror_state"), dict) else {}
+        project_lane = project_field_value(project_item or {}, "Status")
+        project_roadmap = project_field_value(project_item or {}, "Roadmap Status")
+        github_state = str(remote_state.get("github_state") or "").upper()
+        if project_lane == "Done" and github_state == "OPEN":
+            conflicts.append(sync_conflict("project_done_while_issue_open", item, "Project is Done while GitHub issue is still open.", details={"project_status": project_lane, "github_state": github_state}))
+            human_gates.append(sync_human_gate("issue_closure_or_reopen_side_effect", item, "Do not infer issue closure/reopen from Project Done mismatch."))
+        if github_state == "CLOSED" and project_lane != "Done":
+            conflicts.append(sync_conflict("issue_closed_project_not_done", item, "GitHub issue is closed but Project mirror is not Done.", details={"project_status": project_lane, "github_state": github_state}))
+            human_gates.append(sync_human_gate("built_in_status_side_effect", item, "Changing built-in Project Status to Done can imply workflow movement and needs review."))
+        remote_owner = project_field_value(project_item or {}, "Owner Role")
+        desired_owner = field_value_for_sync_item(item, "Owner Role")
+        if remote_owner and desired_owner and remote_owner.lower() != desired_owner.lower():
+            conflicts.append(sync_conflict("owner_mismatch", item, "Project Owner Role differs from local board owner.", details={"remote_owner": remote_owner, "desired_owner": desired_owner}))
+        freshness = compare_isoish(item.get("local_updated_at"), (project_item or {}).get("updatedAt") or (project_item or {}).get("updated_at"))
+        if freshness:
+            conflicts.append(sync_conflict("local_remote_newer", item, "Local and remote mirror timestamps differ; review before any future apply.", details={"freshness": freshness, "local_updated_at": item.get("local_updated_at"), "remote_updated_at": (project_item or {}).get("updatedAt") or (project_item or {}).get("updated_at")}))
+        if contains_sensitive_value(item.get("evidence_refs")) or contains_sensitive_value(item.get("target_branch")):
+            conflicts.append(sync_conflict("privacy_sensitive_value", item, "Potentially private evidence or branch value would need redaction before sync.", severity="error"))
+            human_gates.append(sync_human_gate("privacy_security_sensitive_sync", item, "Privacy/security-sensitive values require Human review before any future write."))
+        target_branch = item.get("target_branch")
+        if target_branch:
+            release_line = "v2" if target_branch == V2_INTEGRATION_BRANCH else "v1" if target_branch == "main" else "custom"
+            stage = str(item.get("stage") or "").lower()
+            if (stage.startswith("v2") and release_line == "v1") or (stage in {"af-13", "af-14", "af-15", "v1.1"} and release_line == "v2"):
+                conflicts.append(sync_conflict("branch_line_mismatch", item, "Target branch does not match the item's stage/release line.", details={"target_branch": target_branch, "stage": item.get("stage")}))
+        for field in SYNC_PLAN_FIELDS:
+            desired = field_value_for_sync_item(item, field)
+            if desired is None:
+                continue
+            if contains_sensitive_value(desired):
+                conflicts.append(sync_conflict("privacy_sensitive_value", item, f"Desired `{field}` value may contain private data.", severity="error", details={"field": field}))
+                human_gates.append(sync_human_gate("privacy_security_sensitive_sync", item, f"Desired `{field}` value requires Human privacy review."))
+                continue
+            before = project_field_value(project_item or {}, field) if project_item else None
+            if before == desired:
+                continue
+            gate = "explicit_human_gate" if field == "Status" else "agent_handled_existing_workflow"
+            if field == "Status":
+                human_gates.append(sync_human_gate("built_in_status_side_effect", item, "Built-in Project Status changes are dry-run only and need Human review before any future write.", details={"before": before, "after": desired}))
+            operations.append(
+                {
+                    "operation": "set_project_field",
+                    "project_item_id": project_item_identity(project_item),
+                    "work_item_id": item.get("work_item_id"),
+                    "field": field,
+                    "before": before,
+                    "after": desired,
+                    "idempotency_key": f"{item.get('work_item_id')}::{field}::{desired}",
+                    "gate": gate,
+                    "evidence_refs": item.get("evidence_refs", []),
+                    "readback_required": {
+                        "source": "github_graphql_project_v2",
+                        "field": field,
+                        "expected": desired,
+                    },
+                    "mutation_performed": False,
+                }
+            )
+    broad_policy_fields = {"Status", "Roadmap Status", "Owner Role", "Stage", "Risk"} - fields_seen if project_status.get("explicit_metadata") else set()
+    if broad_policy_fields:
+        human_gates.append(sync_human_gate("broad_project_policy_change", None, "Creating or changing Project schema/options is out of scope for dry-run sync.", details={"fields": sorted(broad_policy_fields)}))
+    payload = {
+        "schema_version": 1,
+        "command": "project-sync-plan",
+        "repo": repo,
+        "mode": "dry_run",
+        "mutation_performed": False,
+        "writes_supported_now": False,
+        "apply_supported_now": False,
+        "source_of_truth": "local_collaboration_ledger_board",
+        "project_role": "optional_visual_mirror",
+        "field_mapping": {field: {"source": "foundry_board_item", "target": f"GitHub Project {field}"} for field in SYNC_PLAN_FIELDS},
+        "planned_operations": operations,
+        "conflicts": conflicts,
+        "human_gates": human_gates,
+        "unsupported_actions": [
+            "live Project mutation",
+            "GitHub write-back",
+            "issue closure automation",
+            "real sync/apply",
+            "branch repair/apply",
+            "checkout/switch",
+            "PR retarget",
+            "rebase",
+            "merge to main",
+            "reset/clean/force push/destructive action",
+            "runtime/Vault/private/generated mutation",
+            "generated publish or capability-pack deploy/apply",
+            "memory-system work",
+            "release/tag work",
+            "final V2 readiness closure",
+        ],
+        "readback": {
+            "project_status": project_status,
+            "project_attempts": project_attempts,
+            "partial_results": partial_results,
+            "full_project_scan_performed": False,
+        },
+        "user_facing_report": {
+            "summary": f"Dry-run Project sync plan prepared {len(operations)} would-change operations, {len(conflicts)} conflicts, and {len(human_gates)} Human gates.",
+            "next_actions": [
+                "review_conflicts_before_any_future_apply",
+                "collect_human_decision_for_human_gates",
+                "rerun_after_project_readback_if_degraded",
+            ],
+            "writes": "none",
+        },
+        "telemetry": {
+            "telemetry_issue": "#266",
+            "api_attempts": project_attempts.get("attempts", 0),
+            "elapsed_time_ms": elapsed_time_ms,
+            "item_count": len(board.get("items", [])),
+            "planned_operation_count": len(operations),
+            "conflict_count": len(conflicts),
+            "human_gate_count": len(human_gates),
+            "full_project_scan_performed": False,
+        },
+    }
+    return payload
+
+
+def cmd_project_sync_plan(args: argparse.Namespace) -> None:
+    start = time.perf_counter()
+    repo, repo_source = resolve_repo(args)
+    if args.issues_json or args.fixture_json:
+        issues = normalize_issue_collection(load_json(args.issues_json or args.fixture_json))
+        scope = {"mode": "fixture", "issue_numbers": [issue_number(issue) for issue in issues if issue_number(issue) is not None]}
+        project_items, project_status, project_attempts = read_project_items(args)
+    else:
+        issues, scope = read_live_issues(repo, args)
+        project_items, project_status, project_attempts = read_project_items(args)
+    local_git, _local_git_status, _local_git_attempts = read_local_git_state(args)
+    ledger_report = build_local_ledger_report(local_ledger_root(args))
+    candidate_events = normalize_candidate_events(load_json(args.candidate_events_json)) if args.candidate_events_json else []
+    board = build_foundry_board(
+        repo,
+        issues[: args.limit],
+        project_items,
+        project_status,
+        local_git,
+        args.name,
+        {"repo_source": repo_source, **scope, "ledger_root": ledger_report["ledger_root"], "sync_plan_source": True},
+        accepted_replay={"derived_work_items": ledger_report["derived_work_items"], "summary": ledger_report["summary"]},
+        candidate_events=candidate_events,
+    )
+    elapsed_time_ms = round((time.perf_counter() - start) * 1000, 3)
+    print_json_or_text(build_project_sync_plan(repo, board, project_items, project_status, project_attempts, elapsed_time_ms), args.json)
 
 
 def cmd_foundry_board(args: argparse.Namespace) -> None:
@@ -4155,6 +4465,25 @@ def build_parser() -> argparse.ArgumentParser:
     board.add_argument("--name", default="Foundry Board", help="Board name shown in the read-only report.")
     board.add_argument("--json", action="store_true", default=argparse.SUPPRESS, help="Emit JSON for foundry-board.")
     board.set_defaults(func=cmd_foundry_board)
+
+    sync_plan = sub.add_parser("project-sync-plan")
+    sync_plan.add_argument("--fixture-json", help="Legacy issue fixture; prefer --issues-json.")
+    sync_plan.add_argument("--issues-json", help="Fixture issue object, list, or object with issues/items.")
+    sync_plan.add_argument("--project-items-json", help="Fixture Project item list or gh project item-list JSON.")
+    sync_plan.add_argument("--local-git-json", help="Fixture local git state for branch/readiness display.")
+    sync_plan.add_argument("--ledger-root", help="Accepted local ledger root. Defaults to usage/local/collaboration-ledger.")
+    sync_plan.add_argument("--candidate-events-json", help="Read-only candidate event list or backfill preview output for conflict display.")
+    sync_plan.add_argument("--issues", help="Comma-separated explicit issue numbers for bounded live sync plan.")
+    sync_plan.add_argument("--stage", help="Stage value or label for bounded live issue report.")
+    sync_plan.add_argument("--limit", type=int, default=20, help="Maximum issues/items to inspect.")
+    sync_plan.add_argument("--project-owner", help="Project owner for targeted live Project item-list, such as @me or an org.")
+    sync_plan.add_argument("--project-number", type=int, help="Project number for targeted live Project item-list.")
+    sync_plan.add_argument("--project-limit", type=int, default=50, help="Maximum Project items to read when explicitly configured.")
+    sync_plan.add_argument("--project-retries", type=int, default=2, help="Bounded retries for transient Project reads.")
+    sync_plan.add_argument("--project-retry-backoff", type=float, default=0.5, help="Seconds between transient Project read retries.")
+    sync_plan.add_argument("--name", default="Foundry Board", help="Board name for the internal read-only board source.")
+    sync_plan.add_argument("--json", action="store_true", default=argparse.SUPPRESS, help="Emit JSON for project-sync-plan.")
+    sync_plan.set_defaults(func=cmd_project_sync_plan)
 
     ledger_append = sub.add_parser("local-ledger-append")
     ledger_append.add_argument("--ledger-root", help="Local ledger root. Defaults to usage/local/collaboration-ledger.")

--- a/scripts/test_github_collaboration_helper.py
+++ b/scripts/test_github_collaboration_helper.py
@@ -92,6 +92,8 @@ def main() -> int:
                 "usage/local/collaboration-ledger/events.jsonl",
                 "local-ledger-report",
                 "local-ledger-backfill-preview",
+                "project-sync-plan",
+                "writes_supported_now: false",
             ],
         )
     )
@@ -131,6 +133,10 @@ def main() -> int:
         foundry_board_project = base / "foundry-board-project.json"
         foundry_board_ledger_root = base / "foundry-board-ledger"
         foundry_board_candidate_events = base / "foundry-board-candidate-events.json"
+        sync_plan_issues = base / "sync-plan-issues.json"
+        sync_plan_project = base / "sync-plan-project.json"
+        sync_plan_ledger_root = base / "sync-plan-ledger"
+        sync_plan_candidate_events = base / "sync-plan-candidate-events.json"
         new_repo_labels = base / "new-repo-labels.json"
         new_repo_issues = base / "new-repo-issues.json"
         new_repo_prs = base / "new-repo-prs.json"
@@ -1053,6 +1059,273 @@ def main() -> int:
             ("foundry-board-project-degraded-fallback", "accepted_local_ledger_replay"),
         ):
             errors.extend(expect_ok(name, degraded_foundry_board, expected))
+        v2_contract = "\n".join(
+            [
+                "Owner role: implementer",
+                "Review role: reviewer",
+                "Acceptance role: architect",
+                "Completion handoff: to:reviewer",
+                "Branch strategy: integration-branch",
+                "Release line: v2.0",
+                "Target branch: codex/v2-local-first-orchestration",
+                "Base branch: codex/v2-local-first-orchestration",
+                "PR target: codex/v2-local-first-orchestration",
+            ]
+        )
+        main_contract = v2_contract.replace("Target branch: codex/v2-local-first-orchestration", "Target branch: main").replace(
+            "PR target: codex/v2-local-first-orchestration",
+            "PR target: main",
+        )
+        write(
+            sync_plan_issues,
+            json.dumps(
+                {
+                    "issues": [
+                        {
+                            "number": 420,
+                            "title": "Open local work item",
+                            "state": "OPEN",
+                            "url": "https://github.com/farmerhunter/agent-foundry/issues/420",
+                            "labels": [{"name": "stage:v2.0"}, {"name": "risk:high"}, {"name": "needs:implementer"}],
+                            "body": "## Execution Contract\n\n" + v2_contract + "\n",
+                        },
+                        {
+                            "number": 421,
+                            "title": "Closed local work item",
+                            "state": "CLOSED",
+                            "url": "https://github.com/farmerhunter/agent-foundry/issues/421",
+                            "labels": [{"name": "stage:v2.0"}, {"name": "risk:high"}],
+                            "body": "## Execution Contract\n\n" + v2_contract + "\n",
+                        },
+                        {
+                            "number": 422,
+                            "title": "Wrong branch line",
+                            "state": "OPEN",
+                            "url": "https://github.com/farmerhunter/agent-foundry/issues/422",
+                            "labels": [{"name": "stage:v2.0"}, {"name": "risk:high"}, {"name": "needs:implementer"}],
+                            "body": "## Execution Contract\n\n" + main_contract + "\n",
+                        },
+                        {
+                            "number": 424,
+                            "title": "Ambiguous Project item",
+                            "state": "OPEN",
+                            "url": "https://github.com/farmerhunter/agent-foundry/issues/424",
+                            "labels": [{"name": "stage:v2.0"}, {"name": "risk:medium"}, {"name": "needs:reviewer"}],
+                            "body": "## Execution Contract\n\n" + v2_contract + "\n",
+                        },
+                    ]
+                }
+            ),
+        )
+        write(
+            sync_plan_project,
+            json.dumps(
+                {
+                    "fields": [
+                        {"name": "Status"},
+                        {"name": "Roadmap Status"},
+                        {"name": "Owner Role", "options": [{"name": "Architect"}, {"name": "Implementer"}]},
+                    ],
+                    "items": [
+                        {
+                            "id": "P420A",
+                            "content": {"number": 420},
+                            "status": {"name": "Done"},
+                            "roadmap Status": {"name": "Done"},
+                            "owner Role": {"name": "Reviewer"},
+                            "updatedAt": "2026-07-08T11:00:00Z",
+                        },
+                        {
+                            "id": "P421A",
+                            "content": {"number": 421},
+                            "status": {"name": "Todo"},
+                            "roadmap Status": {"name": "Ready"},
+                            "owner Role": {"name": "Reviewer"},
+                            "updatedAt": "2026-07-08T13:00:00Z",
+                        },
+                        {
+                            "id": "P422A",
+                            "content": {"number": 422},
+                            "status": {"name": "Todo"},
+                            "roadmap Status": {"name": "Ready"},
+                            "owner Role": {"name": "Implementer"},
+                            "updatedAt": "2026-07-08T11:00:00Z",
+                        },
+                        {
+                            "id": "P424A",
+                            "content": {"number": 424},
+                            "status": {"name": "Todo"},
+                            "roadmap Status": {"name": "Ready"},
+                            "owner Role": {"name": "Reviewer"},
+                            "updatedAt": "2026-07-08T11:00:00Z",
+                        },
+                        {
+                            "id": "P424B",
+                            "content": {"number": 424},
+                            "status": {"name": "Todo"},
+                            "roadmap Status": {"name": "Ready"},
+                            "owner Role": {"name": "Reviewer"},
+                            "updatedAt": "2026-07-08T11:01:00Z",
+                        },
+                    ],
+                }
+            ),
+        )
+        sync_plan_events = [
+            {
+                "schema_version": 1,
+                "event_id": "sync-accepted-420",
+                "event_type": "assignment",
+                "occurred_at": "2026-07-08T12:00:00Z",
+                "work_item": {"id": "farmerhunter/agent-foundry#issue:420", "repo": "farmerhunter/agent-foundry", "type": "issue", "number": 420},
+                "actor_role": "coordinator",
+                "confidence": "observed",
+                "provenance": {"links": ["https://github.com/farmerhunter/agent-foundry/issues/420#ledger"]},
+                "payload": {"owner_role": "implementer"},
+            },
+            {
+                "schema_version": 1,
+                "event_id": "sync-accepted-421",
+                "event_type": "closure",
+                "occurred_at": "2026-07-08T12:01:00Z",
+                "work_item": {"id": "farmerhunter/agent-foundry#issue:421", "repo": "farmerhunter/agent-foundry", "type": "issue", "number": 421},
+                "actor_role": "architect",
+                "confidence": "observed",
+                "provenance": {"links": ["https://github.com/farmerhunter/agent-foundry/issues/421#closed"]},
+                "payload": {"state": "closed"},
+            },
+            {
+                "schema_version": 1,
+                "event_id": "sync-accepted-422",
+                "event_type": "assignment",
+                "occurred_at": "2026-07-08T12:02:00Z",
+                "work_item": {"id": "farmerhunter/agent-foundry#issue:422", "repo": "farmerhunter/agent-foundry", "type": "issue", "number": 422},
+                "actor_role": "coordinator",
+                "confidence": "observed",
+                "provenance": {"links": ["/Users/private/token.txt"]},
+                "payload": {"owner_role": "implementer"},
+            },
+            {
+                "schema_version": 1,
+                "event_id": "sync-accepted-424",
+                "event_type": "review",
+                "occurred_at": "2026-07-08T12:03:00Z",
+                "work_item": {"id": "farmerhunter/agent-foundry#issue:424", "repo": "farmerhunter/agent-foundry", "type": "issue", "number": 424},
+                "actor_role": "reviewer",
+                "confidence": "observed",
+                "provenance": {"links": ["https://github.com/farmerhunter/agent-foundry/issues/424#review"]},
+                "payload": {"decision": "approved"},
+            },
+        ]
+        for event in sync_plan_events:
+            event_path = base / f"{event['event_id']}.json"
+            write(event_path, json.dumps(event))
+            errors.extend(
+                expect_ok(
+                    f"project-sync-plan-ledger-append-{event['event_id']}",
+                    run(["local-ledger-append", "--ledger-root", str(sync_plan_ledger_root), "--event-json", str(event_path), "--json"], base),
+                    '"mutation_performed": true',
+                )
+            )
+        write(
+            sync_plan_candidate_events,
+            json.dumps(
+                {
+                    "candidate_imported_events": [
+                        {
+                            "schema_version": 1,
+                            "event_id": "sync-candidate-423",
+                            "event_type": "assignment",
+                            "occurred_at": "2026-07-08T12:04:00Z",
+                            "work_item": {"id": "farmerhunter/agent-foundry#issue:423", "repo": "farmerhunter/agent-foundry", "type": "issue", "number": 423},
+                            "actor_role": "coordinator",
+                            "confidence": "inferred",
+                            "provenance": {"links": ["https://github.com/farmerhunter/agent-foundry/issues/423#candidate"]},
+                            "payload": {"owner_role": "architect"},
+                        }
+                    ]
+                }
+            ),
+        )
+        sync_plan = run(
+            [
+                "project-sync-plan",
+                "--issues-json",
+                str(sync_plan_issues),
+                "--project-items-json",
+                str(sync_plan_project),
+                "--ledger-root",
+                str(sync_plan_ledger_root),
+                "--candidate-events-json",
+                str(sync_plan_candidate_events),
+                "--json",
+            ],
+            base,
+            {"AGENT_REPO": "farmerhunter/agent-foundry"},
+        )
+        for name, expected in (
+            ("project-sync-plan-command", '"command": "project-sync-plan"'),
+            ("project-sync-plan-dry-run", '"mode": "dry_run"'),
+            ("project-sync-plan-no-mutation", '"mutation_performed": false'),
+            ("project-sync-plan-no-writes", '"writes_supported_now": false'),
+            ("project-sync-plan-source", '"source_of_truth": "local_collaboration_ledger_board"'),
+            ("project-sync-plan-operation", '"operation": "set_project_field"'),
+            ("project-sync-plan-before", '"before": "Done"'),
+            ("project-sync-plan-after", '"after": "Blocked"'),
+            ("project-sync-plan-idempotency", '"idempotency_key"'),
+            ("project-sync-plan-evidence", '"evidence_refs"'),
+            ("project-sync-plan-readback", '"readback_required"'),
+            ("project-sync-plan-human-gate", '"gate": "explicit_human_gate"'),
+            ("project-sync-plan-missing-field", "missing_project_field"),
+            ("project-sync-plan-missing-option", "missing_project_option"),
+            ("project-sync-plan-ambiguous-item", "ambiguous_project_item"),
+            ("project-sync-plan-project-done-open", "project_done_while_issue_open"),
+            ("project-sync-plan-closed-not-done", "issue_closed_project_not_done"),
+            ("project-sync-plan-owner-mismatch", "owner_mismatch"),
+            ("project-sync-plan-newer", "local_remote_newer"),
+            ("project-sync-plan-privacy", "privacy_sensitive_value"),
+            ("project-sync-plan-branch-line", "branch_line_mismatch"),
+            ("project-sync-plan-candidate", "candidate_state_not_authoritative"),
+            ("project-sync-plan-built-in-gate", "built_in_status_side_effect"),
+            ("project-sync-plan-issue-gate", "issue_closure_or_reopen_side_effect"),
+            ("project-sync-plan-privacy-gate", "privacy_security_sensitive_sync"),
+            ("project-sync-plan-policy-gate", "broad_project_policy_change"),
+            ("project-sync-plan-future-write-gate", "future_write_apply_transition"),
+            ("project-sync-plan-user-report", '"user_facing_report"'),
+            ("project-sync-plan-telemetry", '"telemetry_issue": "#266"'),
+            ("project-sync-plan-api-attempts", '"api_attempts"'),
+            ("project-sync-plan-elapsed", '"elapsed_time_ms"'),
+            ("project-sync-plan-item-count", '"item_count"'),
+            ("project-sync-plan-operation-count", '"planned_operation_count"'),
+            ("project-sync-plan-conflict-count", '"conflict_count"'),
+            ("project-sync-plan-human-count", '"human_gate_count"'),
+            ("project-sync-plan-no-full-scan", '"full_project_scan_performed": false'),
+            ("project-sync-plan-unsupported-project-write", "live Project mutation"),
+            ("project-sync-plan-unsupported-branch", "checkout/switch"),
+        ):
+            errors.extend(expect_ok(name, sync_plan, expected))
+        degraded_sync_plan = run(
+            [
+                "project-sync-plan",
+                "--issues-json",
+                str(sync_plan_issues),
+                "--ledger-root",
+                str(sync_plan_ledger_root),
+                "--project-owner",
+                "@me",
+                "--project-number",
+                "3",
+                "--json",
+            ],
+            base,
+            {"AGENT_REPO": "farmerhunter/agent-foundry", "PATH": str(fake_bin) + os.pathsep + os.environ.get("PATH", "")},
+        )
+        for name, expected in (
+            ("project-sync-plan-degraded", "degraded_project_readback"),
+            ("project-sync-plan-partial", '"partial_results"'),
+            ("project-sync-plan-degraded-source", "github_graphql_project_v2"),
+        ):
+            errors.extend(expect_ok(name, degraded_sync_plan, expected))
         branch_readiness_json = run(
             [
                 "collaboration-readiness",

--- a/workflows/github-collaboration-helper.md
+++ b/workflows/github-collaboration-helper.md
@@ -619,6 +619,61 @@ Forbidden in this preview:
 - generated publish or capability-pack deploy/apply;
 - memory-system work.
 
+## Project Sync Plan Dry Run
+
+Use `project-sync-plan` when V2 local-first orchestration needs to preview how
+accepted local board/ledger state would mirror into GitHub Project fields.
+
+Skill-facing request:
+
+```text
+preview GitHub Project sync plan
+```
+
+Debug/helper surface:
+
+```text
+agent-foundry-github-collab --repo <owner>/<repo> project-sync-plan \
+  --ledger-root usage/local/collaboration-ledger \
+  --issues <bounded-issue-list> \
+  --project-owner @me \
+  --project-number <number> \
+  --json
+```
+
+The report must be dry-run only:
+
+```text
+mode: dry_run
+mutation_performed: false
+writes_supported_now: false
+```
+
+The sync plan reads the ledger-backed Foundry Board as local source of truth and
+uses GitHub Project as an optional mirror. It should describe proposed
+operations with before/after values, idempotency keys, evidence refs, gate
+classification, and readback requirements. It should classify conflicts for
+missing fields/options, ambiguous items, Project Done while issue open, issue
+closed while Project is not Done, owner mismatch, local/remote freshness,
+degraded Project readback, privacy-sensitive values, and branch-line mismatch.
+
+Human gates include built-in Project Status side effects, issue closure/reopen
+implications, privacy/security-sensitive sync, broad Project policy/schema
+changes, and any future transition from dry-run to write/apply.
+
+Forbidden in this dry-run:
+
+- live Project mutation or GitHub write-back;
+- issue closure automation;
+- real sync/apply;
+- branch repair/apply, checkout/switch, PR retarget, rebase, merge, reset,
+  clean, force push, or destructive action;
+- runtime/Vault/private/generated mutation;
+- generated publish or capability-pack deploy/apply;
+- memory-system work;
+- release/tag work;
+- final V2 readiness closure.
+
 ## Dispatch Evidence Modes
 
 Dispatch evidence must name the mechanism actually used:


### PR DESCRIPTION
## Summary
- Add read-only `project-sync-plan` helper command that generates a dry-run GitHub Project mirror plan from ledger-backed Foundry Board state.
- Include field mapping, proposed would-change operations, before/after values, idempotency keys, evidence refs, gate classification, and readback requirements.
- Classify conflict and gate cases for missing fields/options, ambiguous Project items, Done/open mismatches, owner mismatch, local/remote freshness, degraded Project readback, privacy-sensitive values, branch-line mismatch, built-in Status side effects, issue closure/reopen implications, broad Project policy/schema change, and future write/apply transition.
- Add #266 telemetry for API attempts, elapsed time, item count, planned operation count, conflict count, Human gate count, and `full_project_scan_performed`.
- Update command/docs/workflow guidance for the user-facing dry-run path.

## Verification
- `python3 -m py_compile scripts/github_collaboration_helper.py scripts/test_github_collaboration_helper.py`
- `python3 scripts/test_github_collaboration_helper.py`
- `python3 scripts/check_consistency.py`
- `git diff --check origin/codex/v2-local-first-orchestration...HEAD`
- Targeted grep/read-through for dry-run/no-write flags, conflict taxonomy, Human gates, #266 telemetry, no full Project scan, and unsupported mutation/branch actions.

## Safety
- Dry-run only: `mutation_performed=false`, `writes_supported_now=false`, `apply_supported_now=false`.
- No live Project mutation, GitHub write-back, issue closure automation, real sync/apply, branch repair/apply, checkout/switch, PR retarget, rebase, main merge, reset/clean/force push/destructive action, runtime/Vault/private/generated mutation, generated publish/capability-pack deploy/apply, memory-system work, release/tag work, or final V2 readiness closure.

Refs #362
