### PR TITLE
[V2] Implement local orchestration action apply

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -38,6 +38,7 @@ Use these short commands in day-to-day agent work. English command text is canon
 | `show local collaboration ledger report` | `显示 local collaboration ledger report` | Replay local append-only ledger events from `usage/local/collaboration-ledger/` or a supplied test root into derived work-item state. Read-only; no GitHub dependency or write-back. |
 | `preview existing project ledger backfill` | `预览 existing project ledger backfill` | Convert bounded existing GitHub-first issue/PR/comment/label/milestone/Project evidence into candidate local ledger events for review only. No authoritative migration or writes. |
 | `apply reviewed migration candidates` | `应用 reviewed migration candidates` | Apply reviewed accept/reject/skip decisions for backfill candidates into the accepted local ledger. Writes only local ledger JSONL; no GitHub or Project mutation. |
+| `apply approved local board action` | `应用 approved local board action` | Apply an approved Foundry Board/local next action into the local ledger. Writes only local ledger JSONL; no GitHub/Project/runtime/Vault mutation. |
 | `preview GitHub Project sync plan` | `预览 GitHub Project sync plan` | Generate a dry-run Project mirror plan from ledger-backed board state with before/after values, conflicts, Human gates, and readback requirements. No Project/GitHub writes. |
 | `publish practices` | `发布 practices` | Publish adapters from current active practices; usually not needed manually. |
 | `check operation context` | `检查操作上下文` | Show current Agent Foundry Core/Vault/evidence/runtime context before writes. |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -172,6 +172,24 @@ The decision file records explicit `accept`, `reject`, or `skip` choices for can
 
 **中文要点：** Migration apply 只把 review 后的 accept/reject/skip 决策写入本地 ledger JSONL，不改 GitHub/Project。重复运行会跳过已写入的 deterministic events；#371/#372/#373 仍是后续 gate。
 
+After a Foundry Board next action has the required local review gate, apply that local action into the ledger:
+
+```text
+apply approved local board action
+应用 approved local board action
+```
+
+```bash
+python3 scripts/github_collaboration_helper.py --repo <owner>/<repo> local-ledger-action-apply \
+  --ledger-root usage/local/collaboration-ledger \
+  --action-json /tmp/local-actions.json \
+  --json
+```
+
+The action file records approved local actions such as assignment, handoff, blocked/unblocked, review result, Architect acceptance, Human approval evidence, local closure evidence, supersession, or recovery evidence. Reviewer-, Architect-, and Human-owned actions must name the matching `required_gate` and `approved_by_role`; otherwise the helper fails closed before writing. Successful apply appends only deterministic local ledger events, reports before/after replay state, and leaves GitHub/Project sync for later gates.
+
+**中文要点：** Local action apply 只写 accepted local ledger。Reviewer/Architect/Human gate 不匹配时会 fail closed；它不会改 GitHub issue/PR、Project、runtime、Vault 或 generated artifacts。Project sync 仍属于 #372。
+
 For GitHub Project mirroring, ask for a dry-run sync plan:
 
 ```text

--- a/scripts/github_collaboration_helper.py
+++ b/scripts/github_collaboration_helper.py
@@ -54,7 +54,7 @@ DRY_RUN_ACTIONS = {
     "permission-smoke",
     "comparison-draft",
 }
-LOCAL_WRITE_ACTIONS = {"local-ledger-append", "local-ledger-migration-apply"}
+LOCAL_WRITE_ACTIONS = {"local-ledger-append", "local-ledger-migration-apply", "local-ledger-action-apply"}
 REMOTE_RE = re.compile(r"(?:github\.com[:/])([^/]+)/([^/.]+)(?:\.git)?$")
 CONTRACT_HEADINGS = ("Final Execution Contract", "Execution Contract", "Draft Execution Contract")
 ROLE_FIELDS = ("Owner role", "Review role", "Acceptance role")
@@ -120,6 +120,9 @@ LOCAL_LEDGER_EVENT_TYPES = {
     "merge",
     "closure",
     "blocked",
+    "unblocked",
+    "supersession",
+    "recovery",
     "sync_readback",
 }
 CAPABILITY_LAYER_VALUES = {"base", "local_orchestration", "mixed"}
@@ -727,6 +730,24 @@ def append_local_ledger_event(root: Path, event: dict[str, Any]) -> dict[str, An
     }
 
 
+def append_events_if_absent(
+    root: Path,
+    events: list[dict[str, Any]],
+    existing_ids: set[str],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    appended: list[dict[str, Any]] = []
+    duplicate_skips: list[dict[str, Any]] = []
+    for event in events:
+        event_id = event["event_id"]
+        if event_id in existing_ids:
+            duplicate_skips.append({"event_id": event_id, "reason": "idempotent_duplicate_event_id"})
+            continue
+        result = append_local_ledger_event(root, event)
+        appended.append(result)
+        existing_ids.add(event_id)
+    return appended, duplicate_skips
+
+
 def empty_derived_work_item(key: str, event: dict[str, Any]) -> dict[str, Any]:
     work_item = event.get("work_item", {})
     return {
@@ -839,6 +860,22 @@ def apply_local_ledger_event(item: dict[str, Any], event: dict[str, Any]) -> Non
         item["state"] = "blocked"
         item["blocking_reason"] = payload.get("reason", "unknown")
         item["next_review_or_action_needed"] = "resolve_blocker"
+    elif event_type == "unblocked":
+        item["blocked"] = False
+        item["state"] = payload.get("next_state", "assigned")
+        item["blocking_reason"] = None
+        item["latest_evidence"].append({"event_id": event["event_id"], "summary": payload.get("summary", "unblocked")})
+        item["next_review_or_action_needed"] = payload.get("next_review_or_action_needed", "review_unblocked_state")
+    elif event_type == "supersession":
+        item["state"] = "superseded"
+        item["superseded_by"] = payload.get("superseded_by", "unknown")
+        item["latest_evidence"].append({"event_id": event["event_id"], "summary": payload.get("summary", "supersession")})
+        item["next_review_or_action_needed"] = payload.get("next_review_or_action_needed", "follow_superseding_work")
+    elif event_type == "recovery":
+        item["state"] = payload.get("recovered_state", "recovery_review")
+        item["recovery_reason"] = payload.get("reason", "unknown")
+        item["latest_evidence"].append({"event_id": event["event_id"], "summary": payload.get("summary", "recovery")})
+        item["next_review_or_action_needed"] = payload.get("next_review_or_action_needed", "verify_recovered_state")
     elif event_type == "sync_readback":
         observed_state = payload.get("observed_state")
         local_state = payload.get("local_state")
@@ -1672,6 +1709,291 @@ def cmd_local_ledger_migration_apply(args: argparse.Namespace) -> None:
     preview_doc = load_json(args.candidate_events_json)
     decision_doc = load_json(args.decision_json)
     result = build_local_ledger_migration_apply_from_decision_json(local_ledger_root(args), preview_doc, decision_doc)
+    print_json_or_text(result, args.json)
+    if result["status"] == "invalid":
+        raise SystemExit(6)
+
+
+LOCAL_ACTION_EVENT_TYPES = {
+    "assignment": "assignment",
+    "handoff": "dispatch",
+    "blocked": "blocked",
+    "unblocked": "unblocked",
+    "review_result": "review",
+    "architect_acceptance": "acceptance",
+    "human_approval": "human_approval",
+    "local_done": "closure",
+    "closure": "closure",
+    "supersession": "supersession",
+    "recovery": "evidence",
+}
+LOCAL_ACTION_REQUIRED_GATES = {
+    "review_result": "reviewer",
+    "architect_acceptance": "architect",
+    "human_approval": "human",
+    "local_done": "reviewer",
+    "closure": "reviewer",
+}
+
+
+def normalize_local_action_collection(data: Any) -> tuple[list[dict[str, Any]], list[str]]:
+    if isinstance(data, dict) and "actions" in data:
+        data = data["actions"]
+    elif isinstance(data, dict):
+        data = [data]
+    if not isinstance(data, list):
+        return [], ["action JSON must be an object, list, or object with actions"]
+    actions: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for index, action in enumerate(data, start=1):
+        if not isinstance(action, dict):
+            errors.append(f"action #{index} must be an object")
+            continue
+        action_type = str(action.get("action_type") or action.get("type") or "").strip()
+        if action_type not in LOCAL_ACTION_EVENT_TYPES:
+            errors.append(f"action #{index} has unsupported action_type {action_type!r}")
+            continue
+        work_item = action.get("work_item")
+        if not isinstance(work_item, dict) or not (work_item.get("id") or (work_item.get("repo") and work_item.get("type") and work_item.get("number") is not None)):
+            errors.append(f"action #{index} must include work_item with id or repo/type/number")
+            continue
+        action_id = str(action.get("action_id") or action.get("id") or f"{work_item_key(work_item)}-{action_type}").strip()
+        required_gate = str(action.get("required_gate") or LOCAL_ACTION_REQUIRED_GATES.get(action_type, "none")).lower()
+        approved_by_role = str(action.get("approved_by_role") or action.get("actor_role") or "agent").lower()
+        if required_gate not in {"none", "reviewer", "architect", "human"}:
+            errors.append(f"action #{index} has unsupported required_gate {required_gate!r}")
+            continue
+        if required_gate != "none" and approved_by_role != required_gate:
+            errors.append(f"action #{index} requires {required_gate} gate but approved_by_role is {approved_by_role}")
+            continue
+        normalized = dict(action)
+        normalized["action_id"] = action_id
+        normalized["action_type"] = action_type
+        normalized["work_item"] = work_item
+        normalized["required_gate"] = required_gate
+        normalized["approved_by_role"] = approved_by_role
+        actions.append(normalized)
+    return actions, errors
+
+
+def sanitized_event_id(value: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9_.:-]+", "-", value.strip())
+    return cleaned.strip("-") or "unknown"
+
+
+def local_action_capability_layer(action: dict[str, Any]) -> dict[str, str]:
+    raw = action.get("capability_layer")
+    if isinstance(raw, dict):
+        layer = str(raw.get("layer") or raw.get("value") or "").strip()
+        source = str(raw.get("source") or "local_action_apply").strip()
+        confidence = str(raw.get("confidence") or "observed").strip()
+    else:
+        layer = str(raw or "local_orchestration").strip()
+        source = str(action.get("capability_layer_source") or "local_action_apply").strip()
+        confidence = str(action.get("capability_layer_confidence") or "observed").strip()
+    if layer not in CAPABILITY_LAYER_VALUES:
+        layer = "mixed" if str(raw).lower() == "mixed" else "local_orchestration"
+        source = "local_action_apply_default"
+        confidence = "inferred"
+    if confidence not in LOCAL_LEDGER_CONFIDENCE_VALUES:
+        confidence = "inferred"
+    return {"layer": layer, "source": source, "confidence": confidence}
+
+
+def local_action_event(action: dict[str, Any]) -> dict[str, Any]:
+    action_type = action["action_type"]
+    event_type = LOCAL_ACTION_EVENT_TYPES[action_type]
+    capability_layer = local_action_capability_layer(action)
+    evidence_refs = action.get("evidence_refs") or action.get("provenance_links") or []
+    if not isinstance(evidence_refs, list):
+        evidence_refs = [str(evidence_refs)]
+    payload = dict(action.get("payload") if isinstance(action.get("payload"), dict) else {})
+    if action_type == "assignment":
+        payload.setdefault("owner_role", action.get("owner_role") or action.get("target_role") or "unknown")
+    elif action_type == "handoff":
+        payload.setdefault("target_role", action.get("target_role") or action.get("owner_role") or "unknown")
+        if action.get("thread_id"):
+            payload.setdefault("thread_id", action["thread_id"])
+    elif action_type == "blocked":
+        payload.setdefault("reason", action.get("reason") or "local action marked blocked")
+    elif action_type == "unblocked":
+        payload.setdefault("summary", action.get("summary") or "local action unblocked item")
+        payload.setdefault("next_state", action.get("next_state") or "assigned")
+    elif action_type == "review_result":
+        payload.setdefault("decision", action.get("decision") or "reviewed")
+    elif action_type == "architect_acceptance":
+        payload.setdefault("decision", action.get("decision") or "accepted")
+    elif action_type == "human_approval":
+        payload.setdefault("approval", action.get("approval") or "approved")
+    elif action_type in {"local_done", "closure"}:
+        payload.setdefault("state", "closed")
+    elif action_type == "supersession":
+        payload.setdefault("superseded_by", action.get("superseded_by") or "unknown")
+    elif action_type == "recovery":
+        payload.setdefault("summary", action.get("summary") or "local recovery evidence")
+    payload["local_action_type"] = action_type
+    payload["required_gate"] = action["required_gate"]
+    payload["approved_by_role"] = action["approved_by_role"]
+    event = {
+        "schema_version": LOCAL_LEDGER_SCHEMA_VERSION,
+        "event_id": f"local-action-{sanitized_event_id(action['action_id'])}",
+        "event_type": event_type,
+        "occurred_at": str(action.get("occurred_at") or time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())),
+        "work_item": action["work_item"],
+        "actor_role": action["approved_by_role"],
+        "confidence": action.get("confidence", "observed"),
+        "unknown_fields": action.get("unknown_fields", []),
+        "not_available_fields": action.get("not_available_fields", []),
+        "degraded_evidence": action.get("degraded_evidence", []),
+        "supersedes_event_ids": action.get("supersedes_event_ids", []),
+        "provenance": {
+            "links": evidence_refs,
+            "local_action_id": action["action_id"],
+            "required_gate": action["required_gate"],
+            "capability_layer_source": capability_layer["source"],
+            "capability_layer_confidence": capability_layer["confidence"],
+        },
+        "capability_layer": capability_layer["layer"],
+        "capability_layer_source": capability_layer["source"],
+        "capability_layer_confidence": capability_layer["confidence"],
+        "base_behavior_preserved": True,
+        "payload": payload,
+    }
+    return event
+
+
+def build_local_ledger_action_apply(root: Path, action_doc: Any) -> dict[str, Any]:
+    start = time.perf_counter()
+    actions, action_errors = normalize_local_action_collection(action_doc)
+    if action_errors or not actions:
+        return {
+            "schema_version": 1,
+            "command": "local-ledger-action-apply",
+            "status": "invalid",
+            "errors": action_errors + ([] if actions else ["at least one approved local action is required"]),
+            "mutation_performed": False,
+            "github_write_back_performed": False,
+            "project_mutation_performed": False,
+        }
+    before_events, before_invalid, before_storage = read_local_ledger_events(root)
+    before_replay = replay_local_ledger(before_events)
+    existing_ids = {event["event_id"] for event in before_events}
+    planned_events = [local_action_event(action) for action in actions]
+    validation_errors: list[str] = []
+    for event in planned_events:
+        normalized, errors, _status = validate_local_ledger_event(event)
+        if normalized is None:
+            validation_errors.append(f"{event.get('event_id', 'unknown')}: {'; '.join(errors)}")
+    if validation_errors:
+        return {
+            "schema_version": 1,
+            "command": "local-ledger-action-apply",
+            "status": "invalid",
+            "errors": validation_errors,
+            "mutation_performed": False,
+            "github_write_back_performed": False,
+            "project_mutation_performed": False,
+        }
+    appended_events, duplicate_skips = append_events_if_absent(root, planned_events, existing_ids)
+    after_events, after_invalid, after_storage = read_local_ledger_events(root)
+    after_replay = replay_local_ledger(after_events)
+    action_counts: dict[str, int] = {}
+    gate_counts: dict[str, int] = {}
+    for action in actions:
+        action_counts[action["action_type"]] = action_counts.get(action["action_type"], 0) + 1
+        gate_counts[action["required_gate"]] = gate_counts.get(action["required_gate"], 0) + 1
+    residual_risks = [
+        "local action apply updates only accepted ledger state; remote mirrors may now drift until #372",
+    ]
+    if before_invalid or after_invalid:
+        residual_risks.append("invalid local ledger records remain visible for later recovery")
+    if after_replay["summary"]["conflict_count"]:
+        residual_risks.append("contradictory local replay remains visible for later mixed-state recovery")
+    if any(event.get("degraded_evidence") for event in planned_events):
+        residual_risks.append("degraded action evidence was preserved rather than guessed clean")
+    return {
+        "schema_version": 1,
+        "command": "local-ledger-action-apply",
+        "mode": "apply",
+        "status": "ok",
+        "ledger_root": str(root),
+        "events_path": str(local_ledger_events_path(root)),
+        "mutation_performed": bool(appended_events),
+        "write_scope": "local_ledger_events_jsonl_only",
+        "github_write_back_performed": False,
+        "project_mutation_performed": False,
+        "runtime_vault_private_generated_write_performed": False,
+        "action_count": len(actions),
+        "appended_event_count": len(appended_events),
+        "duplicate_skip_count": len(duplicate_skips),
+        "action_counts": action_counts,
+        "gate_counts": gate_counts,
+        "appended_events": appended_events,
+        "duplicate_skips": duplicate_skips,
+        "before": {
+            "storage": before_storage,
+            "invalid_event_count": len(before_invalid),
+            "summary": before_replay["summary"],
+            "derived_work_items": before_replay["derived_work_items"],
+        },
+        "after": {
+            "storage": after_storage,
+            "invalid_event_count": len(after_invalid),
+            "summary": after_replay["summary"],
+            "derived_work_items": after_replay["derived_work_items"],
+        },
+        "action_records": [
+            {
+                "action_id": action["action_id"],
+                "action_type": action["action_type"],
+                "result_event_id": f"local-action-{sanitized_event_id(action['action_id'])}",
+                "owner_role": action.get("owner_role") or action.get("target_role") or "unknown",
+                "required_gate": action["required_gate"],
+                "approved_by_role": action["approved_by_role"],
+                "capability_layer": local_action_capability_layer(action),
+                "evidence_refs": action.get("evidence_refs") or action.get("provenance_links") or [],
+            }
+            for action in actions
+        ],
+        "user_facing_report": {
+            "summary": f"Applied {len(appended_events)} local orchestration action event(s); {len(duplicate_skips)} duplicates were skipped.",
+            "next_actions": [
+                "run_local-ledger-report_to_review_accepted_state",
+                "run_foundry-board_to_review_next_actions",
+                "defer_project_sync_until_#372",
+            ],
+            "writes": "local_ledger_events_jsonl_only",
+            "residual_risks": residual_risks,
+        },
+        "forbidden_actions": [
+            "GitHub issue/PR mutation",
+            "GitHub Project mutation",
+            "branch repair/apply or PR retarget",
+            "#372 Project sync apply",
+            "#373 mixed-state recovery implementation",
+            "#378 management surface implementation",
+            "runtime/Vault/private/generated mutation",
+            "generated Skill publish or capability-pack deploy/apply",
+            "main merge or release/tag work",
+            "destructive ledger history rewrite",
+        ],
+        "telemetry": {
+            "telemetry_issue": "#266",
+            "action_count": len(actions),
+            "appended_event_count": len(appended_events),
+            "duplicate_skip_count": len(duplicate_skips),
+            "before_event_count": before_replay["summary"]["event_count"],
+            "after_event_count": after_replay["summary"]["event_count"],
+            "before_conflict_count": before_replay["summary"]["conflict_count"],
+            "after_conflict_count": after_replay["summary"]["conflict_count"],
+            "degraded_evidence_count": after_replay["summary"]["degraded_evidence_count"],
+            "elapsed_time_ms": round((time.perf_counter() - start) * 1000, 3),
+        },
+    }
+
+
+def cmd_local_ledger_action_apply(args: argparse.Namespace) -> None:
+    result = build_local_ledger_action_apply(local_ledger_root(args), load_json(args.action_json))
     print_json_or_text(result, args.json)
     if result["status"] == "invalid":
         raise SystemExit(6)
@@ -4777,6 +5099,12 @@ def build_parser() -> argparse.ArgumentParser:
     migration_apply.add_argument("--decision-json", required=True, help="Migration decision JSON with accept/reject/skip event ids.")
     migration_apply.add_argument("--json", action="store_true", default=argparse.SUPPRESS, help="Emit JSON for local-ledger-migration-apply.")
     migration_apply.set_defaults(func=cmd_local_ledger_migration_apply)
+
+    action_apply = sub.add_parser("local-ledger-action-apply")
+    action_apply.add_argument("--ledger-root", help="Local ledger root. Defaults to usage/local/collaboration-ledger.")
+    action_apply.add_argument("--action-json", required=True, help="Approved local orchestration action object, list, or object with actions.")
+    action_apply.add_argument("--json", action="store_true", default=argparse.SUPPRESS, help="Emit JSON for local-ledger-action-apply.")
+    action_apply.set_defaults(func=cmd_local_ledger_action_apply)
 
     ledger_report = sub.add_parser("local-ledger-report")
     ledger_report.add_argument("--ledger-root", help="Local ledger root. Defaults to usage/local/collaboration-ledger.")

--- a/scripts/test_github_collaboration_helper.py
+++ b/scripts/test_github_collaboration_helper.py
@@ -1931,6 +1931,7 @@ def main() -> int:
             second = json.loads(ledger_report_again.stdout)
             for payload in (first, second):
                 payload["telemetry"]["replay_time_ms"] = 0
+                payload["telemetry"]["user_facing_output_bytes"] = 0
                 payload["summary"]["replay_time_ms"] = 0
             if first == second:
                 print("local-ledger-replay-deterministic: ok")
@@ -2191,6 +2192,183 @@ def main() -> int:
             ("local-ledger-migration-idempotent-reason", "idempotent_duplicate_event_id"),
         ):
             errors.extend(expect_ok(name, migration_apply_again, expected))
+        local_action_root = base / "local-action-ledger"
+        local_actions = base / "local-actions.json"
+        write(
+            local_actions,
+            json.dumps(
+                {
+                    "actions": [
+                        {
+                            "action_id": "assign-510",
+                            "action_type": "assignment",
+                            "work_item": {"id": "farmerhunter/agent-foundry#issue:510", "repo": "farmerhunter/agent-foundry", "type": "issue", "number": 510},
+                            "owner_role": "implementer",
+                            "approved_by_role": "agent",
+                            "evidence_refs": ["https://github.com/farmerhunter/agent-foundry/issues/510#assignment"],
+                            "capability_layer": {"layer": "local_orchestration", "source": "issue_contract", "confidence": "observed"},
+                        },
+                        {
+                            "action_id": "handoff-510",
+                            "action_type": "handoff",
+                            "work_item": {"id": "farmerhunter/agent-foundry#issue:510", "repo": "farmerhunter/agent-foundry", "type": "issue", "number": 510},
+                            "target_role": "reviewer",
+                            "approved_by_role": "agent",
+                            "evidence_refs": ["https://github.com/farmerhunter/agent-foundry/issues/510#handoff"],
+                        },
+                        {
+                            "action_id": "blocked-511",
+                            "action_type": "blocked",
+                            "work_item": {"id": "farmerhunter/agent-foundry#issue:511", "repo": "farmerhunter/agent-foundry", "type": "issue", "number": 511},
+                            "reason": "missing external evidence",
+                            "approved_by_role": "agent",
+                            "degraded_evidence": [{"source": "github", "status": "degraded"}],
+                        },
+                        {
+                            "action_id": "unblocked-511",
+                            "action_type": "unblocked",
+                            "work_item": {"id": "farmerhunter/agent-foundry#issue:511", "repo": "farmerhunter/agent-foundry", "type": "issue", "number": 511},
+                            "approved_by_role": "agent",
+                            "payload": {"next_review_or_action_needed": "resume_work"},
+                        },
+                        {
+                            "action_id": "review-512",
+                            "action_type": "review_result",
+                            "work_item": {"id": "farmerhunter/agent-foundry#issue:512", "repo": "farmerhunter/agent-foundry", "type": "issue", "number": 512},
+                            "required_gate": "reviewer",
+                            "approved_by_role": "reviewer",
+                            "decision": "request_changes",
+                        },
+                        {
+                            "action_id": "accept-513",
+                            "action_type": "architect_acceptance",
+                            "work_item": {"id": "farmerhunter/agent-foundry#issue:513", "repo": "farmerhunter/agent-foundry", "type": "issue", "number": 513},
+                            "required_gate": "architect",
+                            "approved_by_role": "architect",
+                        },
+                        {
+                            "action_id": "human-514",
+                            "action_type": "human_approval",
+                            "work_item": {"id": "farmerhunter/agent-foundry#issue:514", "repo": "farmerhunter/agent-foundry", "type": "issue", "number": 514},
+                            "required_gate": "human",
+                            "approved_by_role": "human",
+                            "approval": "approved local ledger action",
+                            "capability_layer": "mixed",
+                        },
+                        {
+                            "action_id": "done-515",
+                            "action_type": "local_done",
+                            "work_item": {"id": "farmerhunter/agent-foundry#issue:515", "repo": "farmerhunter/agent-foundry", "type": "issue", "number": 515},
+                            "required_gate": "reviewer",
+                            "approved_by_role": "reviewer",
+                        },
+                        {
+                            "action_id": "supersede-516",
+                            "action_type": "supersession",
+                            "work_item": {"id": "farmerhunter/agent-foundry#issue:516", "repo": "farmerhunter/agent-foundry", "type": "issue", "number": 516},
+                            "approved_by_role": "agent",
+                            "superseded_by": "farmerhunter/agent-foundry#issue:517",
+                        },
+                        {
+                            "action_id": "recover-517",
+                            "action_type": "recovery",
+                            "work_item": {"id": "farmerhunter/agent-foundry#issue:517", "repo": "farmerhunter/agent-foundry", "type": "issue", "number": 517},
+                            "approved_by_role": "agent",
+                            "summary": "recorded interrupted apply recovery evidence",
+                            "unknown_fields": ["remote_project_readback"],
+                        },
+                    ]
+                }
+            ),
+        )
+        local_action_apply = run(
+            [
+                "local-ledger-action-apply",
+                "--ledger-root",
+                str(local_action_root),
+                "--action-json",
+                str(local_actions),
+                "--json",
+            ],
+            base,
+        )
+        for name, expected in (
+            ("local-ledger-action-apply-command", '"command": "local-ledger-action-apply"'),
+            ("local-ledger-action-apply-mode", '"mode": "apply"'),
+            ("local-ledger-action-apply-mutates-local", '"mutation_performed": true'),
+            ("local-ledger-action-apply-local-scope", '"write_scope": "local_ledger_events_jsonl_only"'),
+            ("local-ledger-action-apply-no-github", '"github_write_back_performed": false'),
+            ("local-ledger-action-apply-no-project", '"project_mutation_performed": false'),
+            ("local-ledger-action-apply-no-runtime", '"runtime_vault_private_generated_write_performed": false'),
+            ("local-ledger-action-apply-assignment", '"assignment": 1'),
+            ("local-ledger-action-apply-handoff", '"handoff": 1'),
+            ("local-ledger-action-apply-blocked", '"blocked": 1'),
+            ("local-ledger-action-apply-unblocked", '"unblocked": 1'),
+            ("local-ledger-action-apply-review", '"review_result": 1'),
+            ("local-ledger-action-apply-acceptance", '"architect_acceptance": 1'),
+            ("local-ledger-action-apply-human", '"human_approval": 1'),
+            ("local-ledger-action-apply-closure", '"local_done": 1'),
+            ("local-ledger-action-apply-supersession", '"supersession": 1'),
+            ("local-ledger-action-apply-recovery", '"recovery": 1'),
+            ("local-ledger-action-apply-reviewer-gate", '"reviewer": 2'),
+            ("local-ledger-action-apply-architect-gate", '"architect": 1'),
+            ("local-ledger-action-apply-human-gate", '"human": 1'),
+            ("local-ledger-action-apply-layer", '"layer": "local_orchestration"'),
+            ("local-ledger-action-apply-mixed", '"layer": "mixed"'),
+            ("local-ledger-action-apply-user-report", "run_foundry-board_to_review_next_actions"),
+            ("local-ledger-action-apply-forbidden-project", "GitHub Project mutation"),
+            ("local-ledger-action-apply-forbidden-372", "#372 Project sync apply"),
+            ("local-ledger-action-apply-telemetry", '"telemetry_issue": "#266"'),
+        ):
+            errors.extend(expect_ok(name, local_action_apply, expected))
+        local_action_report = run(["local-ledger-report", "--ledger-root", str(local_action_root), "--json"], base)
+        for name, expected in (
+            ("local-ledger-action-replay-assigned", '"state": "dispatched"'),
+            ("local-ledger-action-replay-unblocked", "resume_work"),
+            ("local-ledger-action-replay-review", '"state": "review_changes_requested"'),
+            ("local-ledger-action-replay-accepted", '"state": "accepted"'),
+            ("local-ledger-action-replay-human", '"state": "human_approved"'),
+            ("local-ledger-action-replay-closed", '"state": "closed"'),
+            ("local-ledger-action-replay-superseded", '"state": "superseded"'),
+            ("local-ledger-action-replay-recovery", "recorded interrupted apply recovery evidence"),
+        ):
+            errors.extend(expect_ok(name, local_action_report, expected))
+        local_action_apply_again = run(
+            [
+                "local-ledger-action-apply",
+                "--ledger-root",
+                str(local_action_root),
+                "--action-json",
+                str(local_actions),
+                "--json",
+            ],
+            base,
+        )
+        for name, expected in (
+            ("local-ledger-action-idempotent-no-new-write", '"mutation_performed": false'),
+            ("local-ledger-action-idempotent-duplicates", '"duplicate_skip_count": 10'),
+            ("local-ledger-action-idempotent-reason", "idempotent_duplicate_event_id"),
+        ):
+            errors.extend(expect_ok(name, local_action_apply_again, expected))
+        bad_local_action = base / "bad-local-action.json"
+        write(
+            bad_local_action,
+            json.dumps(
+                {
+                    "action_type": "human_approval",
+                    "work_item": {"id": "farmerhunter/agent-foundry#issue:518", "repo": "farmerhunter/agent-foundry", "type": "issue", "number": 518},
+                    "required_gate": "human",
+                    "approved_by_role": "reviewer",
+                }
+            ),
+        )
+        errors.extend(
+            expect_fail(
+                "local-ledger-action-gate-fails-closed",
+                run(["local-ledger-action-apply", "--ledger-root", str(local_action_root), "--action-json", str(bad_local_action), "--json"], base),
+                "requires human gate",
+            )
+        )
         degraded_backfill = run(
             [
                 "--repo",

--- a/workflows/github-collaboration-helper.md
+++ b/workflows/github-collaboration-helper.md
@@ -674,6 +674,61 @@ Forbidden in this apply step:
 - generated Skill publish or capability-pack deploy/apply;
 - main merge, release, or tag work.
 
+## Local Orchestration Action Apply
+
+Use `local-ledger-action-apply` when an approved Foundry Board next action or
+local orchestration action should become an accepted append-only Local
+Collaboration Ledger event.
+
+Skill-facing request:
+
+```text
+apply approved local board action
+```
+
+Debug/helper surface:
+
+```text
+agent-foundry-github-collab --repo <owner>/<repo> local-ledger-action-apply \
+  --ledger-root usage/local/collaboration-ledger \
+  --action-json /tmp/local-actions.json \
+  --json
+```
+
+Supported action families are `assignment`, `handoff`, `blocked`,
+`unblocked`, `review_result`, `architect_acceptance`, `human_approval`,
+`local_done`, `closure`, `supersession`, and `recovery`. The action input must
+name the work item, evidence refs when available, owner or target role when
+relevant, required gate, approving role, and capability layer when the action is
+not clearly local orchestration. `base`, `local_orchestration`, and `mixed`
+must remain explicit report values rather than branch-derived assumptions.
+
+Gate enforcement:
+
+- `review_result`, `local_done`, and `closure` require reviewer approval.
+- `architect_acceptance` requires architect approval.
+- `human_approval` requires human approval.
+- If the named `approved_by_role` does not match the required gate, the helper
+  must fail closed before appending any ledger event.
+
+The report must include before/after local replay state, appended and
+idempotently skipped events, evidence refs, owner role, required gate, residual
+risks, #266 telemetry, and forbidden remote side effects. Re-running the same
+approved actions must not duplicate local state.
+
+Forbidden in this apply step:
+
+- #372 Project sync apply;
+- #373 mixed-state recovery implementation beyond visible residual risks;
+- #378 management surface implementation;
+- GitHub issue/PR mutation;
+- GitHub Project mutation;
+- branch repair/apply or PR retarget;
+- runtime/Vault/private/generated mutation;
+- generated Skill publish or capability-pack deploy/apply;
+- main merge, release, or tag work;
+- destructive ledger history rewrite.
+
 ## Project Sync Plan Dry Run
 
 Use `project-sync-plan` when V2 local-first orchestration needs to preview how


### PR DESCRIPTION
## Summary
- Adds `local-ledger-action-apply` for approved Foundry Board/local next actions.
- Converts supported local action families into append-only Local Collaboration Ledger events.
- Adds gate validation, idempotency, before/after replay output, forbidden remote side-effect reporting, and #266 telemetry.
- Updates docs/workflow guidance for the local action apply path.

## Verification
- `python3 -m py_compile scripts/github_collaboration_helper.py scripts/test_github_collaboration_helper.py`
- `python3 scripts/test_github_collaboration_helper.py`
- `python3 scripts/check_consistency.py`
- `git diff --check origin/codex/v2-local-first-orchestration...HEAD`
- `git diff --check`

## Boundaries
- No #372 Project sync apply.
- No #373 mixed-state recovery implementation beyond #371-visible residual risks/reporting.
- No #378 management surface implementation.
- No live GitHub issue/PR mutation or GitHub Project mutation as product behavior.
- No branch repair/apply or PR retarget.
- No runtime/Vault/private/generated mutation.
- No generated Skill publish or capability-pack deploy/apply.
- No main merge, release/tag, V2 final closure, destructive git operation, reset/clean/force push.

Closes no issue directly; #371 remains open for review/acceptance.