### PR TITLE
Enable V2 local orchestration pack guidance

### DIFF
--- a/catalog/capability-packs/index.yaml
+++ b/catalog/capability-packs/index.yaml
@@ -27,9 +27,9 @@ entries:
     title: Optional GitHub Collaboration Starter Pack
     channel: official
     catalog_status: available
-    latest_version: 0.3.2
+    latest_version: 0.4.0
     manifest_path: fixtures/capability-packs/optional-multi-agent/manifest.yaml
-    manifest_sha256: a8261175a4c2cc64d2d0aa047fed3d9c33daaefadeaccee9eeb314c1748d9511
+    manifest_sha256: 293fba4cdfbf9a7a1933647361c1fbc89fa6d39b4695432242ecd321a335fa9d
     compatibility_summary: "Core schema 1; Vault layout [1]; bootstrap required; selected Vault review required."
     compatibility_metadata:
       core_schema_version_min: 1
@@ -38,7 +38,7 @@ entries:
       requires_bootstrap_pack: true
     changelog_path: catalog/capability-packs/pack.multi-agent.optional/CHANGELOG.md
     readme_path: catalog/capability-packs/pack.multi-agent.optional/README.md
-    review_evidence: https://github.com/farmerhunter/agent-foundry/issues/352
+    review_evidence: https://github.com/farmerhunter/agent-foundry/issues/375
     authority_after_deployment: selected_user_vault
     private_local_evidence: excluded
     core_release_axis: independent

--- a/catalog/capability-packs/pack.multi-agent.optional/CHANGELOG.md
+++ b/catalog/capability-packs/pack.multi-agent.optional/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.4.0
+
+- Added V2 Local Orchestration capability-layer activation guidance.
+- Preserved Base as the default behavior for ordinary collaboration, practice
+  harvest, generated Skill guidance, runtime actions, and capability-pack
+  behavior.
+- Clarified that Local Orchestration guidance requires durable signals such as
+  explicit user request, local capability config, accepted ledger state, issue
+  contract, runtime profile, or accepted operational UX contract.
+- Kept branch names, release lines, and PR targets as readiness or warning
+  evidence only, not canonical Local Orchestration triggers.
+- Kept runtime publish/apply, generated Skill publish, capability-pack
+  deploy/apply, live Project mutation, and final V2 closure outside pack
+  authority.
+
 ## 0.3.2
 
 - Added AF16 branch-aware collaboration guidance to the optional collaboration

--- a/catalog/capability-packs/pack.multi-agent.optional/README.md
+++ b/catalog/capability-packs/pack.multi-agent.optional/README.md
@@ -63,6 +63,32 @@ worktrees, retarget PRs, rebase, merge, reset, clean, or repair branches.
 **中文要点：** Branch readiness 只给 action plan，不执行 checkout/switch、worktree
 creation、PR retarget、rebase、merge、reset、clean 或 branch repair。
 
+## Local Orchestration Layer / Local Orchestration 层
+
+The current starter guidance includes the V2 Local Orchestration activation
+model. Base collaboration remains the default for ordinary GitHub issue/PR
+coordination, practice harvest, generated Skill guidance, runtime actions, and
+capability-pack behavior. Local Orchestration guidance appears only when durable
+evidence says it is in scope: an explicit user request, repo or local
+capability config, accepted local ledger state or manifest, issue/task contract
+field, capability pack or runtime profile, or accepted operational UX contract.
+
+**中文要点：** Base 是默认层。只有明确 user request、local capability config、
+accepted ledger state、issue contract、runtime profile 或 accepted operational UX
+contract 这类 durable signal 出现时，才启用 Local Orchestration 指导。
+
+Branch names, release lines, and PR targets are readiness and warning evidence.
+They can explain why a branch context looks suspicious, but they are not the
+canonical trigger that turns Base work into Local Orchestration work.
+
+**中文要点：** branch / release line / PR target 只能作为 readiness 或 warning
+evidence，不能单独决定启用 Local Orchestration。
+
+Mixed work should say which actions remain Base and which require Local
+Orchestration surfaces such as Local Collaboration Ledger, Foundry Board,
+migration apply, local action apply, Project sync plan/apply, mixed-state
+recovery, or operational cockpit.
+
 ## Collaboration Readiness / 协作就绪检查
 
 The current starter guidance includes the AF15 collaboration readiness model:
@@ -113,8 +139,8 @@ handoff mechanism.
 
 This pack does not merge PRs, close issues, create hidden access control, apply
 runtime helpers, publish generated Skills, mutate Project v2 by default, execute
-dry-run repair plans, export private Vault content, or treat local helper
-receipts as authority.
+dry-run repair plans, enable Local Orchestration by branch name alone, export
+private Vault content, or treat local helper receipts as authority.
 
 **中文要点：** 它不 merge/close、不执行 live repair/apply、不 mutate Project v2、
 不 publish generated Skills、不 export private Vault。
@@ -163,11 +189,13 @@ receipts remain downstream status surfaces, not catalog or pack authority.
 
 ## Versioning
 
-Pack version `0.3.2` identifies the reviewed branch-aware GitHub collaboration
-starter contract. Pack version `0.3.1` identified the AF15 collaboration
-readiness action-plan contract. Pack version `0.2.0` identified the earlier
-GitHub collaboration starter contract. Core git tags and releases identify
-repository snapshots. These are related but independent axes.
+Pack version `0.4.0` identifies the reviewed V2 Local Orchestration
+capability-layer activation contract. Pack version `0.3.2` identified the
+branch-aware GitHub collaboration starter contract. Pack version `0.3.1`
+identified the AF15 collaboration readiness action-plan contract. Pack version
+`0.2.0` identified the earlier GitHub collaboration starter contract. Core git
+tags and releases identify repository snapshots. These are related but
+independent axes.
 
 ## Review
 
@@ -178,6 +206,8 @@ Review evidence:
 - https://github.com/farmerhunter/agent-foundry/issues/315
 - https://github.com/farmerhunter/agent-foundry/issues/316
 - https://github.com/farmerhunter/agent-foundry/issues/317
+- https://github.com/farmerhunter/agent-foundry/issues/374
+- https://github.com/farmerhunter/agent-foundry/issues/375
 - https://github.com/farmerhunter/agent-foundry/issues/318
 - https://github.com/farmerhunter/agent-foundry/issues/319
 - https://github.com/farmerhunter/agent-foundry/issues/350

--- a/docs/roadmap/milestones-v2.md
+++ b/docs/roadmap/milestones-v2.md
@@ -109,13 +109,13 @@ complete the user-facing capability.
 | V2-6A GitHub Project Dry-Run Sync Plan | #362 | Implement read-only sync-plan generation that shows would-change/conflict/human-gate outcomes without writing Project. | Completed Phase 1 implementation |
 | V2-7 Phase 1 Readiness | #299 | Verify read-only ledger, backfill preview, board visibility, dry-run sync plan, docs, telemetry, and residual risks. | Accepted Phase 1 readiness |
 | V2-8 Capability Replan And Operational UX Contract | #369 | Redefine V2 completion around the full operation chain: capability layer, interfaces, data contracts, apply, sync, mixed-state recovery, dogfood, and enablement. | Next design gate |
-| V2-9 Accepted Migration Apply | #370 | Turn reviewed backfill candidates into accepted local ledger state through explicit apply gates, with rollback/readback evidence and no GitHub writes. | Planned |
-| V2-10 Local Orchestration Action Apply | #371 | Let users apply approved local board actions as ledger events: assignment, blocked, review, acceptance, closure, recovery, and supersession. | Planned |
-| V2-11 GitHub Project Sync Apply | #372 | Apply approved Project mirror changes after dry-run review, with idempotency, readback, partial failure handling, and Human gates for risky writes. | Planned |
-| V2-12 Mixed-State Conflict And Recovery | #373 | Handle interleaved local-first and GitHub-first edits, stale comments, branch-line drift, partial sync, superseded work, and rollback/recovery paths. | Planned |
-| V2-13 Operational UX Contract And Management Surface | #378 | Implement stable operational ViewModels and a management surface for board, item detail, migration review, apply review, sync plan, conflicts, health, and cross-environment/version coordination. | Planned |
-| V2-14 Real-Project Dogfood And UX Conclusion | #374 | Run the complete workflow on a real project, document practical friction, and decide whether the experience is good enough for adoption. | Planned |
-| V2-15 Runtime / Skill / Capability Pack Enablement | #375 | Harvest and publish layer-aware V2 practices, Skills, and packs without making Local Orchestration behavior the default for Base workflows. | Planned |
+| V2-9 Accepted Migration Apply | #370 | Turn reviewed backfill candidates into accepted local ledger state through explicit apply gates, with rollback/readback evidence and no GitHub writes. | Completed implementation |
+| V2-10 Local Orchestration Action Apply | #371 | Let users apply approved local board actions as ledger events: assignment, blocked, review, acceptance, closure, recovery, and supersession. | Completed implementation |
+| V2-11 GitHub Project Sync Apply | #372 | Apply approved Project mirror changes after dry-run review, with idempotency, readback, partial failure handling, and Human gates for risky writes. | Completed implementation |
+| V2-12 Mixed-State Conflict And Recovery | #373 | Handle interleaved local-first and GitHub-first edits, stale comments, branch-line drift, partial sync, superseded work, and rollback/recovery paths. | Completed implementation |
+| V2-13 Operational UX Contract And Management Surface | #378 | Implement stable operational ViewModels and a management surface for board, item detail, migration review, apply review, sync plan, conflicts, health, and cross-environment/version coordination. | Completed implementation |
+| V2-14 Real-Project Dogfood And UX Conclusion | #374 | Run the complete workflow on a real project, document practical friction, and decide whether the experience is good enough for adoption. | Completed dogfood |
+| V2-15 Runtime / Skill / Capability Pack Enablement | #375 | Harvest and publish layer-aware V2 practices, Skills, and packs without making Local Orchestration behavior the default for Base workflows. | Active |
 | V2-16 Final V2 Integration And Release Gate | #376 | Verify full V2 usability, dogfood conclusions, docs, enablement, and decide on merge-back to `main` plus `v2.0.0` release. | Planned |
 
 ## V2 Capability Phases

--- a/fixtures/capability-packs/optional-multi-agent/manifest.yaml
+++ b/fixtures/capability-packs/optional-multi-agent/manifest.yaml
@@ -1,10 +1,10 @@
 manifest_schema_version: 1
 pack_id: pack.multi-agent.optional
 title: Optional Multi-Agent Collaboration Pack
-description: Reviewed optional first-party starter pack for role-generic GitHub issue and PR collaboration helpers, collaboration readiness, branch-aware action plans, and dry-run repair planning.
+description: Reviewed optional first-party starter pack for role-generic GitHub issue and PR collaboration helpers, collaboration readiness, branch-aware action plans, Local Orchestration activation guidance, and dry-run repair planning.
 lifecycle_status: reviewed
-version: 0.3.2
-exported_at: 2026-07-07
+version: 0.4.0
+exported_at: 2026-07-10
 distribution_type: optional_capability
 source_provenance: "Agent Foundry public Core fixture reviewed through AF12-3 issue #253."
 maintainer_contact: "https://github.com/farmerhunter/agent-foundry"
@@ -25,6 +25,8 @@ evidence_sources:
   - "Agent Foundry issues 316-319 AF15 helper, docs, dry-run repair, and dogfood review"
   - "Agent Foundry issues 328-331 AF15 action-plan UX correction and dogfood review"
   - "Agent Foundry issues 348-352 AF16 branch-aware collaboration readiness and docs/template enablement"
+  - "Agent Foundry issues 359-374 V2 Local Collaboration Ledger, Foundry Board, apply, sync, mixed-state recovery, operational cockpit, and dogfood evidence"
+  - "Agent Foundry issue 375 V2 runtime Skill and capability-pack enablement"
   - "Agent Foundry public first-party starter-pack review"
 
 export_policy:
@@ -58,6 +60,9 @@ starter_contents:
     - "branch-aware Execution Contract fields: Branch strategy, Target branch, affected branches, and verification branches"
     - "generic branch strategy families with Agent Foundry V1/V2 presets as project overlays"
     - "multi-branch, stacked PR, split-work, forward-merge, and multi-line verification action-plan concepts"
+    - "capability-layer classification: base, local_orchestration, and mixed"
+    - "Local Orchestration activation only from durable signals such as explicit user request, local capability config, accepted ledger state, issue contract, runtime profile, or accepted operational UX contract"
+    - "Base remains the default for ordinary collaboration, harvest, Skill, runtime, and capability-pack behavior"
     - "degraded GitHub/Project access reporting"
     - "read-only audit before write automation"
   assets:
@@ -110,8 +115,8 @@ included_records:
     kind: practice
     lifecycle_status: candidate
     path: records/practices/COLLAB-PACK-001-review-handoff.md
-    source_version: 5
-    content_sha256: "316cbd91d14dee915b09561e8e9d2576582772f2ca25a1212ecde6a4872208bd"
+    source_version: 6
+    content_sha256: "d90c256ed1b2a0e7445cf4e006011fc7073fdd427cf978076589da2e05a00702"
     destination_layer: canonical_vault_record
     membership_role: optional_member
     activation_default: manual_review
@@ -120,8 +125,8 @@ included_records:
     kind: asset
     lifecycle_status: candidate
     path: records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
-    source_version: 5
-    content_sha256: "8c8eb717577fac50cf0ee80cd16d1e6443f9a84340ff6c3dbe5798cf42a2069d"
+    source_version: 6
+    content_sha256: "0b9dd2a59594a219c9a317015df601904668d1d72023f0d8ba19371dbc03e989"
     destination_layer: canonical_vault_record
     membership_role: optional_member
     activation_default: manual_review

--- a/fixtures/capability-packs/optional-multi-agent/records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
+++ b/fixtures/capability-packs/optional-multi-agent/records/assets/ASSET-COLLAB-PACK-001-review-handoff-helper.asset.yaml
@@ -2,12 +2,12 @@ id: ASSET-COLLAB-PACK-001
 title: Role-Generic GitHub Scheduler Helper Set
 asset_type: skill
 status: candidate
-version: 5
+version: 6
 created: 2026-06-11
-updated: 2026-07-07
-purpose: Provide reviewed helper surfaces for role-generic GitHub issue/PR coordination, collaboration readiness reporting, and branch-aware action-plan guidance.
-responsibility: Support inbox, ready-queue, pickup, handoff, audit, collaboration readiness, branch/worktree/PR-target readiness reporting, user-facing readiness action plans, dry-run repair planning, degraded GitHub/Project access reporting, label routing, issue context, PR context, and retry wrappers after managed install.
-non_responsibility: Does not decide product scope, override issue contracts, make Project v2 the scheduler authority, install helpers, execute from pack staging, apply dry-run repairs, publish generated Skills, mutate Project v2 by default, repair branches, switch checkout context, create worktrees, retarget PRs, rebase, merge, reset, clean, or force-push.
+updated: 2026-07-10
+purpose: Provide reviewed helper surfaces for role-generic GitHub issue/PR coordination, collaboration readiness reporting, branch-aware action-plan guidance, and explicit Local Orchestration capability-layer activation.
+responsibility: Support inbox, ready-queue, pickup, handoff, audit, collaboration readiness, branch/worktree/PR-target readiness reporting, user-facing readiness action plans, dry-run repair planning, degraded GitHub/Project access reporting, label routing, issue context, PR context, retry wrappers, and Local Orchestration guidance only when durable capability-layer evidence selects it after managed install.
+non_responsibility: Does not decide product scope, override issue contracts, make Project v2 the scheduler authority, install helpers, execute from pack staging, apply dry-run repairs, publish generated Skills, mutate Project v2 by default, infer Local Orchestration from branch names alone, repair branches, switch checkout context, create worktrees, retarget PRs, rebase, merge, reset, clean, or force-push.
 inputs:
   - issue number
   - PR number
@@ -16,6 +16,8 @@ inputs:
   - Target branch
   - Branch strategy
   - optional affected or verification branch list
+  - optional Capability layer contract field
+  - optional local orchestration capability config
   - GitHub label and comment state
   - optional project-local routing config
 process:
@@ -27,6 +29,10 @@ process:
   - Validate branch-aware contract fields as report data: canonical Target branch, Branch strategy, expected PR base, local dirty/ahead/behind state, and degraded or unknown remote state.
   - Report branch action-plan concepts such as current_branch_ok, switch_context_required, split_work_recommended, forward_merge_needed_later, verify_on_multiple_lines, and architect_decision_required without performing branch repair.
   - Preserve generic branch strategies, including mainline-maintenance, integration-branch, release-branch, trunk-based, stacked-pr, multi-branch, and custom, with Agent Foundry V1/V2 as project presets rather than the only model.
+  - Preserve Base behavior as the default unless durable capability-layer evidence selects Local Orchestration.
+  - Treat explicit user requests, repo/local capability config, accepted local ledger state, issue contract fields, capability pack or runtime profiles, or accepted operational UX contracts as valid Local Orchestration triggers.
+  - Treat branch names, release lines, and PR targets as readiness or warning evidence only, not canonical Local Orchestration triggers.
+  - For mixed work, separate Base operations from Local Orchestration operations before recommending ledger, board, migration, sync, recovery, or cockpit surfaces.
   - Print dry-run plans before any mutating helper behavior is allowed.
   - Keep dry-run repair entries report-only with mutation_performed false and apply_supported_now false.
   - Prefer REST-first GitHub reads and targeted Project v2 GraphQL only when configured and needed.
@@ -42,6 +48,8 @@ outputs:
   - branch readiness report
   - readiness action plan
   - branch action plan
+  - capability-layer activation guidance
+  - mixed Base and Local Orchestration action guidance
   - dry-run repair plan
   - degraded-source summary
   - issue or PR context summary
@@ -63,4 +71,7 @@ success_criteria:
   - Mutating actions remain disabled until managed install, permissions, and receipts exist.
   - Readiness reports identify missing or drifted setup without mutating GitHub or Project state.
   - Branch readiness reports identify contract, local-state, PR-base, split-work, forward-merge, and multi-line verification needs without changing branches or PR targets.
+  - Local Orchestration guidance appears only when durable capability-layer evidence selects it.
+  - Base/V1.x maintenance reports do not silently switch to V2 behavior because of branch or release-line evidence alone.
+  - Mixed reports separate Base-safe next actions from Local Orchestration-only next actions.
   - Degraded GitHub or Project access is visible in reports instead of hidden by inferred success.

--- a/fixtures/capability-packs/optional-multi-agent/records/practices/COLLAB-PACK-001-review-handoff.md
+++ b/fixtures/capability-packs/optional-multi-agent/records/practices/COLLAB-PACK-001-review-handoff.md
@@ -4,10 +4,10 @@ title: Role-Generic GitHub Handoff Routing
 domain: agent-collaboration
 type: checklist
 status: candidate
-version: 5
+version: 6
 created: 2026-06-11
-updated: 2026-07-07
-tags: [multi-agent, review, handoff, scheduler, readiness, dry-run-repair, branch-aware]
+updated: 2026-07-10
+tags: [multi-agent, review, handoff, scheduler, readiness, dry-run-repair, branch-aware, local-orchestration]
 aliases: [COLLAB-PACK-001]
 review_required: true
 ---
@@ -38,11 +38,16 @@ Multi-agent work loses continuity when completion evidence lives only in a chat 
 - Treat TLS, EOF, timeout, rate-limit-like, and unavailable Project v2 responses as degraded sources. Return partial reports with `unknown` or `not_available` instead of inferring hidden state.
 - Keep Project status and roadmap status as mirrors or reports unless a project explicitly configures them as managed outputs.
 - Treat project-specific repository names, Project ids, branch names, issue numbers, and status mappings as overlays, not reusable pack defaults.
+- Preserve Base behavior as the default capability layer for ordinary GitHub collaboration, practice harvest, asset review, generated Skill guidance, runtime actions, and capability-pack behavior.
+- Enable Local Orchestration guidance only when durable capability-layer evidence says it is in scope: an explicit user request, repo or local capability config, accepted local ledger state or manifest, issue/task contract field, capability pack or runtime profile, or accepted operational UX contract.
+- Treat branch names, release lines, and PR targets as readiness and warning evidence, not as canonical Local Orchestration triggers.
+- For `mixed` work, say which operations remain Base and which require Local Orchestration surfaces such as Local Collaboration Ledger, Foundry Board, migration apply, local action apply, Project sync plan/apply, mixed-state recovery, or operational cockpit.
 
 ## Boundaries
 
 - Do not run default full Project scans for ordinary collaboration reads.
 - Do not apply dry-run repairs from this pack.
 - Do not perform branch repair/apply, checkout or switch branches, create worktrees, retarget PRs, rebase, merge, reset, clean, or force-push from this pack.
+- Do not silently switch Base/V1.x maintenance workflows into Local Orchestration behavior based only on branch or release-line evidence.
 - Do not publish generated Skills, install runtime helpers, or mutate Project v2 from pack deployment.
 - Keep selected User Vault records canonical after deployment; generated adapters, runtime receipts, and local helper outputs remain downstream evidence.

--- a/scripts/test_capability_pack_lifecycle.py
+++ b/scripts/test_capability_pack_lifecycle.py
@@ -219,7 +219,7 @@ def main() -> int:
         newer_version = copy_optional_variant(
             base,
             "newer-version-pack",
-            {"version: 0.3.2": "version: 0.4.0"},
+            {"version: 0.4.0": "version: 0.4.1"},
         )
         errors.extend(
             expect(

--- a/scripts/test_capability_pack_plan.py
+++ b/scripts/test_capability_pack_plan.py
@@ -579,7 +579,7 @@ def main() -> int:
         write_deployed_index(
             vault,
             "pack.multi-agent.optional",
-            "0.3.2",
+            "0.4.0",
             "0" * 64,
             "COLLAB-PACK-001",
             "",


### PR DESCRIPTION
## Summary

Implements the Core artifact slice for V2-15 runtime Skill and capability-pack enablement:

- updates `pack.multi-agent.optional` from 0.3.2 to 0.4.0;
- adds Local Orchestration capability-layer activation guidance;
- preserves Base as the default behavior for ordinary collaboration, harvest, generated Skill guidance, runtime actions, and capability-pack behavior;
- keeps branch names, release lines, and PR targets as readiness/warning evidence only, not canonical Local Orchestration triggers;
- updates roadmap V2 status rows for #370-#375 after #374 dogfood.

## Verification

- `python3 -m py_compile scripts/test_capability_pack_plan.py scripts/test_capability_pack_lifecycle.py`
- `python3 scripts/check_capability_pack_fixtures.py`
- `python3 scripts/test_capability_pack_plan.py`
- `python3 scripts/test_capability_pack_lifecycle.py`
- `python3 scripts/test_capability_pack_apply.py`
- `python3 scripts/test_capability_pack_update.py`
- `python3 scripts/test_advanced_capability_workflow_surface.py`
- `python3 scripts/check_consistency.py`
- `git diff --check`

## Boundaries

No selected Vault mutation, runtime/generated/private mutation, generated Skill publish, capability-pack deploy/apply, live Project mutation, main merge, release/tag, V2 final closure, or destructive action was performed.

Runtime generated Skill refresh and any actual runtime apply remain separately gated unless explicitly approved.
