### PR TITLE
AF17: add semantic practice reachability gates

### DIFF
--- a/scripts/check_adapter_quality.py
+++ b/scripts/check_adapter_quality.py
@@ -8,6 +8,7 @@ adapter validation from selected-Vault generated output validation.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import re
 from pathlib import Path
 
@@ -157,11 +158,13 @@ def active_skill_assets(vault_root: Path) -> list[dict[str, object]]:
         record.update(
             {
                 "slug": slug_from_asset(entry),
+                "source_path": entry.get("path", ""),
                 "title": yaml_scalar(text, "title") or entry.get("title", entry["id"]),
                 "purpose": yaml_scalar(text, "purpose"),
                 "responsibility": yaml_scalar(text, "responsibility"),
                 "usage_triggers": yaml_list(text, "usage_triggers"),
                 "process": yaml_list(text, "process"),
+                "canonical_practices": yaml_list(text, "canonical_practices"),
                 "published_to": yaml_list(text, "published_to") or inline_list(entry.get("published_to", "")),
             }
         )
@@ -350,6 +353,171 @@ def check_generated_skill_artifacts(generated_root: Path, vault_root: Path, mani
     return errors
 
 
+def active_practice_records(vault_root: Path) -> dict[str, dict[str, str]]:
+    return {
+        entry["id"]: entry
+        for entry in parse_index_entries(vault_root / "indexes" / "practice_index.yaml")
+        if entry.get("status") in ACTIVE_STATUSES and entry.get("id") and entry.get("path")
+    }
+
+
+def semantic_route_paths(adapter_id: str, slug: str, practice_id: str) -> tuple[str, str, str]:
+    if adapter_id in SKILL_FOLDER_ADAPTERS:
+        root = f"{adapter_id}/skills/{slug}"
+        return f"{root}/SKILL.md", f"{root}/references/{practice_id}.md", "skill_reference"
+    if adapter_id == "claude-code":
+        return "claude-code/CLAUDE.md", f"claude-code/references/{slug}/{practice_id}.md", "claude_reference"
+    if adapter_id == "chatgpt":
+        return "chatgpt/custom-instructions.md", f"chatgpt/knowledge/{slug}/{practice_id}.md", "knowledge_file"
+    raise ValueError(f"unsupported semantic adapter target: {adapter_id}")
+
+
+def semantic_manifest_routes(path: Path) -> list[dict[str, str]]:
+    routes: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    in_routes = False
+    for raw in read(path).splitlines():
+        line = raw.rstrip()
+        if line.startswith("routes:"):
+            in_routes = line.split(":", 1)[1].strip() != "[]"
+            continue
+        if in_routes and line and not line.startswith(" "):
+            break
+        if not in_routes:
+            continue
+        stripped = line.strip()
+        if stripped.startswith("- target:"):
+            if current:
+                routes.append(current)
+            current = {"target": stripped.split(":", 1)[1].strip().strip('"').strip("'")}
+        elif current is not None and ":" in stripped:
+            key, value = stripped.split(":", 1)
+            current[key] = value.strip().strip('"').strip("'")
+    if current:
+        routes.append(current)
+    return routes
+
+
+def contained_generated_path(generated_root: Path, relative: str) -> Path | None:
+    path = Path(relative)
+    if not relative or path.is_absolute() or ".." in path.parts:
+        return None
+    candidate = (generated_root / path).resolve()
+    try:
+        candidate.relative_to(generated_root.resolve())
+    except ValueError:
+        return None
+    return candidate
+
+
+def expected_semantic_routes(vault_root: Path) -> dict[tuple[str, str, str], dict[str, str]]:
+    practices = active_practice_records(vault_root)
+    expected: dict[tuple[str, str, str], dict[str, str]] = {}
+    for asset in active_skill_assets(vault_root):
+        practices_for_asset = asset.get("canonical_practices", [])
+        published_to = asset.get("published_to", [])
+        if not isinstance(practices_for_asset, list) or not isinstance(published_to, list):
+            continue
+        for practice_id in practices_for_asset:
+            practice = practices.get(str(practice_id))
+            if practice is None:
+                continue
+            source = vault_root / practice["path"]
+            if not source.is_file():
+                continue
+            source_sha256 = hashlib.sha256(source.read_bytes()).hexdigest()
+            for target in sorted(SKILL_FOLDER_ADAPTERS | {"claude-code", "chatgpt"}):
+                if target not in published_to and not (
+                    target == "trae" and TRAE_COMPATIBLE_SKILL_ADAPTERS.intersection(published_to)
+                ):
+                    continue
+                router_path, target_path, packaging = semantic_route_paths(target, str(asset["slug"]), str(practice_id))
+                expected[(target, str(asset["id"]), str(practice_id))] = {
+                    "source_path": practice["path"],
+                    "source_sha256": source_sha256,
+                    "router_path": router_path,
+                    "target_path": target_path,
+                    "packaging": packaging,
+                }
+    return expected
+
+
+def check_semantic_reachability(generated_root: Path, vault_root: Path, manifest: Path) -> list[str]:
+    errors: list[str] = []
+    pointer = yaml_scalar(read(manifest), "semantic_reachability_manifest")
+    if pointer != "semantic-reachability-manifest.yaml":
+        return [
+            "Selected output semantic reachability: publish manifest missing the authoritative "
+            "semantic_reachability_manifest pointer. Re-run publish_adapters.py for this generated root."
+        ]
+    semantic_path = contained_generated_path(generated_root, pointer)
+    if semantic_path is None or not semantic_path.is_file():
+        return [
+            "Selected output semantic reachability: missing semantic_reachability_manifest under the exact "
+            "--generated-root. Core adapter templates are not a substitute."
+        ]
+
+    semantic_text = read(semantic_path)
+    if yaml_scalar(semantic_text, "surface") != "selected_output" or yaml_scalar(
+        semantic_text, "authoritative_generated_root"
+    ) != "true":
+        return [
+            "Selected output semantic reachability: manifest is not marked as the authoritative "
+            "selected-output root. Re-run publish_adapters.py for the exact --generated-root."
+        ]
+
+    expected = expected_semantic_routes(vault_root)
+    routes = semantic_manifest_routes(semantic_path)
+    seen: set[tuple[str, str, str]] = set()
+    for route in routes:
+        key = (route.get("target", ""), route.get("asset_id", ""), route.get("practice_id", ""))
+        if key in seen:
+            errors.append(f"Selected output semantic reachability: duplicate mapping: {key}")
+            continue
+        seen.add(key)
+        contract = expected.get(key)
+        if contract is None:
+            errors.append(
+                "Selected output semantic reachability: dangling mapping for "
+                f"target={key[0]} asset={key[1]} practice={key[2]}"
+            )
+            continue
+        if route.get("declared_required") != "true":
+            errors.append(f"Selected output semantic reachability: required mapping not declared required: {key}")
+        if not route.get("condition") or route.get("condition") == "not_applicable":
+            errors.append(f"Selected output semantic reachability: missing conditional route: {key}")
+        if route.get("route_kind") != "reference_file":
+            errors.append(f"Selected output semantic reachability: unsupported or ID-only route kind: {key}")
+        for field in ["source_path", "source_sha256", "router_path", "target_path", "packaging"]:
+            if route.get(field) != contract[field]:
+                reason = "stale or missing provenance" if field.startswith("source_") else "target-specific packaging omission"
+                errors.append(
+                    f"Selected output semantic reachability: {reason} for {key}: "
+                    f"expected {field}={contract[field]!r}, got {route.get(field, '')!r}"
+                )
+
+        router = contained_generated_path(generated_root, route.get("router_path", ""))
+        target = contained_generated_path(generated_root, route.get("target_path", ""))
+        if router is None or not router.is_file():
+            errors.append(f"Selected output semantic reachability: missing or out-of-root router for {key}")
+        elif key[2] not in read(router) or route.get("target_path", "") not in read(router):
+            errors.append(
+                f"Selected output semantic reachability: ID-only router has no readable reference route for {key}"
+            )
+        if target is None or not target.is_file():
+            errors.append(f"Selected output semantic reachability: missing or out-of-root readable target for {key}")
+        elif key[2] not in read(target) or route.get("source_sha256", "") not in read(target):
+            errors.append(f"Selected output semantic reachability: readable target lacks provenance for {key}")
+
+    for key in expected:
+        if key not in seen:
+            errors.append(
+                "Selected output semantic reachability: missing declared practice route "
+                f"for target={key[0]} asset={key[1]} practice={key[2]}"
+            )
+    return errors
+
+
 def manifest_ids(manifest: Path, key: str) -> list[str]:
     ids: list[str] = []
     in_list = False
@@ -460,6 +628,7 @@ def check_selected_output_surface(core_root: Path, vault_root: Path, generated_r
             if phrase and phrase not in text:
                 errors.append(f"Selected output coverage: {name} generated output missing command phrase: {phrase}")
     errors.extend(check_generated_skill_artifacts(generated_root, vault_root, manifest))
+    errors.extend(check_semantic_reachability(generated_root, vault_root, manifest))
     return errors
 
 

--- a/scripts/publish_adapters.py
+++ b/scripts/publish_adapters.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import re
 from datetime import date
 from pathlib import Path
@@ -52,6 +53,14 @@ def simple_yaml_entries(index_text: str, list_key: str) -> list[dict[str, str]]:
 def active_entries(vault_root: Path, index_rel: str, list_key: str) -> list[dict[str, str]]:
     entries = simple_yaml_entries(read(vault_root / index_rel), list_key)
     return [entry for entry in entries if entry.get("status") in ACTIVE_STATUSES]
+
+
+def active_practice_records(vault_root: Path) -> dict[str, dict[str, str]]:
+    return {
+        entry["id"]: entry
+        for entry in active_entries(vault_root, "indexes/practice_index.yaml", "practices")
+        if entry.get("id") and entry.get("path")
+    }
 
 
 def inline_list(value: str) -> list[str]:
@@ -204,6 +213,77 @@ def skill_artifact_records(output_root: Path, skill_assets: list[dict[str, objec
     return records
 
 
+def semantic_route_condition(practice_id: str) -> str:
+    if practice_id == "ARCH-001":
+        return "always_preflight"
+    if practice_id == "ARCH-006":
+        return "when_scoping_mvp_or_phase"
+    return "always_for_declared_asset"
+
+
+def semantic_route_paths(adapter_id: str, slug: str, practice_id: str) -> tuple[str, str, str]:
+    if adapter_id in SKILL_FOLDER_ADAPTERS:
+        root = f"{adapter_id}/skills/{slug}"
+        return f"{root}/SKILL.md", f"{root}/references/{practice_id}.md", "skill_reference"
+    if adapter_id == "claude-code":
+        return "claude-code/CLAUDE.md", f"claude-code/references/{slug}/{practice_id}.md", "claude_reference"
+    if adapter_id == "chatgpt":
+        return "chatgpt/custom-instructions.md", f"chatgpt/knowledge/{slug}/{practice_id}.md", "knowledge_file"
+    raise ValueError(f"unsupported semantic adapter target: {adapter_id}")
+
+
+def semantic_reachability_routes(
+    vault_root: Path,
+    skill_assets: list[dict[str, object]],
+    practice_records: dict[str, dict[str, str]],
+) -> list[dict[str, str]]:
+    routes: list[dict[str, str]] = []
+    for asset in skill_assets:
+        practice_ids = asset.get("canonical_practices", [])
+        published_to = asset.get("published_to", [])
+        if not isinstance(practice_ids, list) or not isinstance(published_to, list):
+            continue
+        targets = {
+            adapter_id
+            for adapter_id in SKILL_FOLDER_ADAPTERS | {"claude-code", "chatgpt"}
+            if adapter_id in published_to
+            or (adapter_id == "trae" and TRAE_COMPATIBLE_SKILL_ADAPTERS.intersection(published_to))
+        }
+        for practice_id in practice_ids:
+            practice = practice_records.get(str(practice_id))
+            if practice is None:
+                raise ValueError(
+                    f"active skill asset {asset['id']} declares missing or non-active canonical practice {practice_id}"
+                )
+            source_path = practice["path"]
+            source = vault_root / source_path
+            if not source.is_file():
+                raise ValueError(
+                    f"active skill asset {asset['id']} canonical practice source missing: {source_path}"
+                )
+            source_sha256 = hashlib.sha256(source.read_bytes()).hexdigest()
+            for adapter_id in sorted(targets):
+                router_path, target_path, packaging = semantic_route_paths(
+                    adapter_id, str(asset["slug"]), str(practice_id)
+                )
+                routes.append(
+                    {
+                        "target": adapter_id,
+                        "asset_id": str(asset["id"]),
+                        "practice_id": str(practice_id),
+                        "source_path": source_path,
+                        "source_sha256": source_sha256,
+                        "route_kind": "reference_file",
+                        "router_path": router_path,
+                        "target_path": target_path,
+                        "declared_required": "true",
+                        "condition": semantic_route_condition(str(practice_id)),
+                        "packaging": packaging,
+                    }
+                )
+    return routes
+
+
 def manifest_text(
     active_practices: list[dict[str, str]],
     active_assets: list[dict[str, str]],
@@ -214,6 +294,7 @@ def manifest_text(
         f"updated: {date.today().isoformat()}",
         "source: selected_vault",
         "private_paths_recorded: false",
+        "semantic_reachability_manifest: semantic-reachability-manifest.yaml",
         "",
     ]
     if active_practices:
@@ -244,6 +325,34 @@ def manifest_text(
     return "\n".join(lines)
 
 
+def semantic_manifest_text(routes: list[dict[str, str]]) -> str:
+    lines = [
+        "schema_version: 1",
+        "surface: selected_output",
+        "authoritative_generated_root: true",
+        "routes:",
+    ]
+    if not routes:
+        lines[-1] = "routes: []"
+    for route in routes:
+        lines.append(f"  - target: {route['target']}")
+        for key in [
+            "asset_id",
+            "practice_id",
+            "source_path",
+            "source_sha256",
+            "route_kind",
+            "router_path",
+            "target_path",
+            "declared_required",
+            "condition",
+            "packaging",
+        ]:
+            lines.append(f"    {key}: {route[key]}")
+    lines.append("")
+    return "\n".join(lines)
+
+
 def write_manifest(output_root: Path, text: str, apply: bool) -> None:
     path = output_root / "adapter-publish-manifest.yaml"
     print(f"{'write' if apply else 'would write'}: {path}")
@@ -252,11 +361,20 @@ def write_manifest(output_root: Path, text: str, apply: bool) -> None:
         path.write_text(text, encoding="utf-8")
 
 
+def write_semantic_manifest(output_root: Path, routes: list[dict[str, str]], apply: bool) -> None:
+    path = output_root / "semantic-reachability-manifest.yaml"
+    print(f"{'write' if apply else 'would write'}: {path}")
+    if apply:
+        output_root.mkdir(parents=True, exist_ok=True)
+        path.write_text(semantic_manifest_text(routes), encoding="utf-8")
+
+
 def adapter_body(
     adapter_id: str,
     profile: dict[str, object],
     active_practices: list[dict[str, str]],
     active_assets: list[dict[str, str]],
+    semantic_routes: list[dict[str, str]],
 ) -> str:
     practice_ids = [entry["id"] for entry in active_practices]
     asset_ids = [entry["id"] for entry in active_assets]
@@ -279,7 +397,15 @@ def adapter_body(
     lines.extend(["", "## Command Vocabulary"])
     lines.extend(f"- {phrase}" for phrase in phrases if phrase)
     lines.extend(["", "## Boundary"])
-    lines.append("Full semantic regeneration from canonical sections is future generator work.")
+    lines.append("Canonical practice references are generated under the selected output root and remain downstream from the selected Vault.")
+    adapter_routes = [route for route in semantic_routes if route["target"] == adapter_id]
+    if adapter_routes:
+        lines.extend(["", "## Semantic Practice References"])
+        for route in adapter_routes:
+            lines.append(
+                f"- {route['asset_id']} -> {route['practice_id']}: `{route['target_path']}` "
+                f"({route['condition']})"
+            )
     lines.append("")
     return "\n".join(lines)
 
@@ -298,6 +424,7 @@ def write_adapter_outputs(
     output_root: Path,
     active_practices: list[dict[str, str]],
     active_assets: list[dict[str, str]],
+    semantic_routes: list[dict[str, str]],
     apply: bool,
 ) -> list[Path]:
     profiles = parse_profiles(core_root)
@@ -308,7 +435,7 @@ def write_adapter_outputs(
         outputs = list(profile.get("outputs", []))
         if not outputs:
             continue
-        text = adapter_body(adapter_id, profile, active_practices, active_assets)
+        text = adapter_body(adapter_id, profile, active_practices, active_assets, semantic_routes)
         for output in outputs:
             target = output_file(output_root, str(output))
             written.append(target)
@@ -324,7 +451,7 @@ def bullet_lines(values: object) -> list[str]:
     return [f"- {item}" for item in items] or ["- Not specified in canonical asset record."]
 
 
-def generated_skill_body(record: dict[str, object]) -> str:
+def generated_skill_body(record: dict[str, object], adapter_id: str, semantic_routes: list[dict[str, str]]) -> str:
     slug = str(record["slug"])
     title = str(record.get("title") or record["id"])
     purpose = str(record.get("purpose") or "Generated Agent Foundry runtime skill.")
@@ -375,18 +502,37 @@ def generated_skill_body(record: dict[str, object]) -> str:
         "## Canonical Practices",
         *bullet_lines(record.get("canonical_practices", [])),
         "",
+        "## Semantic Practice Routes",
+    ]
+    routes = [
+        route
+        for route in semantic_routes
+        if route["target"] == adapter_id and route["asset_id"] == str(record["id"])
+    ]
+    if routes:
+        lines.extend(
+            f"- {route['practice_id']}: read `{route['target_path']}` "
+            f"when {route['condition']}."
+            for route in routes
+        )
+    else:
+        lines.append("- No canonical practice routes are declared for this generated asset.")
+    lines.extend(
+        [
         "## Safety Boundaries",
         "- Treat the Vault YAML asset record as the source of truth.",
         "- Do not perform high-risk actions without explicit approval.",
         "- Do not mutate runtime, config, private remote, or canonical practice state unless the user explicitly approves that action.",
         "",
-    ]
+        ]
+    )
     return "\n".join(lines)
 
 
 def write_generated_skill_outputs(
     output_root: Path,
     skill_assets: list[dict[str, object]],
+    semantic_routes: list[dict[str, str]],
     apply: bool,
 ) -> list[Path]:
     written: list[Path] = []
@@ -404,7 +550,41 @@ def write_generated_skill_outputs(
             print(f"{'write' if apply else 'would write'}: {target}")
             if apply:
                 target.parent.mkdir(parents=True, exist_ok=True)
-                target.write_text(generated_skill_body(record), encoding="utf-8")
+                target.write_text(generated_skill_body(record, adapter_id, semantic_routes), encoding="utf-8")
+    return written
+
+
+def generated_practice_reference(vault_root: Path, route: dict[str, str]) -> str:
+    source = vault_root / route["source_path"]
+    return "\n".join(
+        [
+            f"# Canonical Practice {route['practice_id']}",
+            "",
+            "Generated full reference from the selected Agent Foundry Vault.",
+            f"Asset ID: `{route['asset_id']}`.",
+            f"Canonical practice ID: `{route['practice_id']}`.",
+            f"Source path: `{route['source_path']}`.",
+            f"Source SHA-256: `{route['source_sha256']}`.",
+            "",
+            "## Canonical Practice",
+            "",
+            read(source).rstrip(),
+            "",
+        ]
+    )
+
+
+def write_semantic_reference_outputs(
+    vault_root: Path, output_root: Path, routes: list[dict[str, str]], apply: bool
+) -> list[Path]:
+    written: list[Path] = []
+    for route in routes:
+        target = output_root / route["target_path"]
+        written.append(target)
+        print(f"{'write' if apply else 'would write'}: {target}")
+        if apply:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(generated_practice_reference(vault_root, route), encoding="utf-8")
     return written
 
 
@@ -433,6 +613,7 @@ def publish(core_root: Path, vault_root: Path, output_root: Path, apply: bool) -
     active_assets = active_entries(vault_root, "indexes/asset_index.yaml", "assets")
     if not active_practices and not active_assets:
         print("Selected Vault has no active or revised practices/assets. Nothing to publish.")
+        write_semantic_manifest(output_root, [], apply)
         write_manifest(output_root, manifest_text(active_practices, active_assets, []), apply)
         print_follow_up_commands(core_root, vault_root, output_root)
         return 0
@@ -446,9 +627,18 @@ def publish(core_root: Path, vault_root: Path, output_root: Path, apply: bool) -
         return 1
 
     skill_assets = skill_asset_records(vault_root, active_assets)
+    try:
+        semantic_routes = semantic_reachability_routes(
+            vault_root, skill_assets, active_practice_records(vault_root)
+        )
+    except ValueError as error:
+        print(f"Semantic reachability publish failed: {error}")
+        return 1
     skill_artifacts = skill_artifact_records(output_root, skill_assets)
-    written = write_adapter_outputs(core_root, output_root, active_practices, active_assets, apply)
-    written.extend(write_generated_skill_outputs(output_root, skill_assets, apply))
+    written = write_adapter_outputs(core_root, output_root, active_practices, active_assets, semantic_routes, apply)
+    written.extend(write_generated_skill_outputs(output_root, skill_assets, semantic_routes, apply))
+    written.extend(write_semantic_reference_outputs(vault_root, output_root, semantic_routes, apply))
+    write_semantic_manifest(output_root, semantic_routes, apply)
     write_manifest(output_root, manifest_text(active_practices, active_assets, skill_artifacts), apply)
     print(f"Adapter publish {'wrote' if apply else 'planned'} {len(written)} files.")
     print(f"Active practices selected: {len(active_practices)}")

--- a/scripts/test_adapter_quality_split.py
+++ b/scripts/test_adapter_quality_split.py
@@ -114,11 +114,13 @@ def main() -> int:
     errors: list[str] = []
     real_vault = configured_vault_root()
     adapters_before = digest_tree(ROOT / "adapters")
+    vault_before = digest_tree(real_vault)
 
     with tempfile.TemporaryDirectory(prefix="agent-foundry-adapter-quality-") as tmp:
         base = Path(tmp)
         temp_vault = base / "vault"
         generated = base / "generated-adapters"
+        id_only_generated = base / "id-only-generated-adapters"
         missing_generated = base / "missing-generated"
         shutil.copytree(real_vault, temp_vault)
         promote_asset_collab_002(temp_vault)
@@ -194,6 +196,204 @@ def main() -> int:
             ]
         )
         errors.extend(expect("selected-output-promoted-asset", selected_quality, True, "selected-output surface"))
+
+        semantic_manifest = generated / "semantic-reachability-manifest.yaml"
+        semantic_text = semantic_manifest.read_text(encoding="utf-8")
+        for expected in [
+            "authoritative_generated_root: true",
+            "asset_id: ASSET-ARCH-001",
+            "practice_id: ARCH-001",
+            "route_kind: reference_file",
+            "router_path: codex/skills/architecture-design/SKILL.md",
+            "target_path: codex/skills/architecture-design/references/ARCH-001.md",
+            "packaging: skill_reference",
+        ]:
+            if expected not in semantic_text:
+                errors.append(f"selected-output-semantic-reachability: manifest missing {expected}")
+
+        shutil.copytree(generated, id_only_generated)
+        id_only_skill = id_only_generated / "codex" / "skills" / "architecture-design" / "SKILL.md"
+        id_only_reference = id_only_generated / "codex" / "skills" / "architecture-design" / "references" / "ARCH-001.md"
+        id_only_skill.write_text(
+            id_only_skill.read_text(encoding="utf-8").replace(
+                "`codex/skills/architecture-design/references/ARCH-001.md`", "`ARCH-001`", 1
+            ),
+            encoding="utf-8",
+        )
+        id_only_reference.unlink()
+        id_only_quality = run(
+            [
+                str(QUALITY),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(temp_vault),
+                "--surface",
+                "selected-output",
+                "--generated-root",
+                str(id_only_generated),
+            ]
+        )
+        errors.extend(
+            expect(
+                "selected-output-id-only-architecture-design",
+                id_only_quality,
+                False,
+                "ID-only router has no readable reference route",
+            )
+        )
+        repaired_publish = run(
+            [
+                str(PUBLISH),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(temp_vault),
+                "--output-root",
+                str(id_only_generated),
+                "--apply",
+            ]
+        )
+        errors.extend(expect("selected-output-readable-route-regeneration", repaired_publish, True, "Adapter publish wrote"))
+        repaired_quality = run(
+            [
+                str(QUALITY),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(temp_vault),
+                "--surface",
+                "selected-output",
+                "--generated-root",
+                str(id_only_generated),
+            ]
+        )
+        errors.extend(expect("selected-output-readable-route-regenerated", repaired_quality, True, "selected-output surface"))
+
+        stale_semantic_text = semantic_text.replace("source_sha256: ", "source_sha256: stale-", 1)
+        semantic_manifest.write_text(stale_semantic_text, encoding="utf-8")
+        stale_provenance_quality = run(
+            [
+                str(QUALITY),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(temp_vault),
+                "--surface",
+                "selected-output",
+                "--generated-root",
+                str(generated),
+            ]
+        )
+        errors.extend(
+            expect(
+                "selected-output-stale-semantic-provenance",
+                stale_provenance_quality,
+                False,
+                "stale or missing provenance",
+            )
+        )
+        semantic_manifest.write_text(semantic_text, encoding="utf-8")
+
+        missing_condition_text = semantic_text.replace("condition: always_for_declared_asset", "condition: ", 1)
+        semantic_manifest.write_text(missing_condition_text, encoding="utf-8")
+        missing_condition_quality = run(
+            [
+                str(QUALITY),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(temp_vault),
+                "--surface",
+                "selected-output",
+                "--generated-root",
+                str(generated),
+            ]
+        )
+        errors.extend(
+            expect(
+                "selected-output-missing-semantic-condition",
+                missing_condition_quality,
+                False,
+                "missing conditional route",
+            )
+        )
+        semantic_manifest.write_text(semantic_text, encoding="utf-8")
+
+        out_of_root_text = semantic_text.replace("target_path: codex/skills/", "target_path: ../outside/", 1)
+        semantic_manifest.write_text(out_of_root_text, encoding="utf-8")
+        out_of_root_quality = run(
+            [
+                str(QUALITY),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(temp_vault),
+                "--surface",
+                "selected-output",
+                "--generated-root",
+                str(generated),
+            ]
+        )
+        errors.extend(
+            expect(
+                "selected-output-semantic-out-of-root-target",
+                out_of_root_quality,
+                False,
+                "missing or out-of-root readable target",
+            )
+        )
+        semantic_manifest.write_text(semantic_text, encoding="utf-8")
+
+        missing_packaging_text = semantic_text.replace("packaging: skill_reference", "packaging: omitted", 1)
+        semantic_manifest.write_text(missing_packaging_text, encoding="utf-8")
+        missing_packaging_quality = run(
+            [
+                str(QUALITY),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(temp_vault),
+                "--surface",
+                "selected-output",
+                "--generated-root",
+                str(generated),
+            ]
+        )
+        errors.extend(
+            expect(
+                "selected-output-semantic-packaging-omission",
+                missing_packaging_quality,
+                False,
+                "target-specific packaging omission",
+            )
+        )
+        semantic_manifest.write_text(semantic_text, encoding="utf-8")
+
+        dangling_mapping_text = semantic_text.replace("asset_id: ASSET-META-001", "asset_id: ASSET-NOT-REAL", 1)
+        semantic_manifest.write_text(dangling_mapping_text, encoding="utf-8")
+        dangling_mapping_quality = run(
+            [
+                str(QUALITY),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(temp_vault),
+                "--surface",
+                "selected-output",
+                "--generated-root",
+                str(generated),
+            ]
+        )
+        errors.extend(
+            expect(
+                "selected-output-semantic-dangling-mapping",
+                dangling_mapping_quality,
+                False,
+                "dangling mapping",
+            )
+        )
+        semantic_manifest.write_text(semantic_text, encoding="utf-8")
         collaboration_paths = [
             ("codex", generated / "codex" / "skills" / "agent-collaboration" / "SKILL.md"),
             ("hermes", generated / "hermes" / "skills" / "agent-collaboration" / "SKILL.md"),
@@ -330,6 +530,8 @@ def main() -> int:
 
     if digest_tree(ROOT / "adapters") != adapters_before:
         errors.append("core-adapters-mutated: regression fixture changed tracked Core adapters")
+    if digest_tree(real_vault) != vault_before:
+        errors.append("selected-vault-mutated: regression fixture changed the real selected Vault")
 
     if errors:
         print("Adapter quality split fixture failed:")


### PR DESCRIPTION
## Summary
- Generate root-local semantic reachability manifests and target-specific canonical practice references for selected adapter output.
- Fail selected-output quality checks on ID-only routes, missing or out-of-root targets, stale provenance, missing conditions, dangling mappings, and packaging omissions.
- Add isolated regression coverage with no Core adapter or real Vault mutation.

## Execution Contract
- Owner role: implementer
- Review role: reviewer
- Acceptance role: architect
- Completion handoff: to:reviewer
- Branch strategy: integration-branch
- Target branch: codex/semantic-practice-loading-integration

## Verification
- python3 -m py_compile scripts/publish_adapters.py scripts/check_adapter_quality.py scripts/test_adapter_quality_split.py
- python3 scripts/test_adapter_quality_split.py
- python3 scripts/test_first_run_ux.py
- python3 scripts/test_foundry_roots.py
- python3 scripts/test_capability_pack_apply.py
- python3 scripts/check_consistency.py
- git diff --check origin/codex/semantic-practice-loading-integration...HEAD

## Boundaries
No selected Vault mutation, generated adapter publish, runtime install, V2.1 cache/sync, or main merge.