### PR TITLE
fix: package Claude semantic references

### DIFF
--- a/scripts/check_adapter_quality.py
+++ b/scripts/check_adapter_quality.py
@@ -372,6 +372,12 @@ def semantic_route_paths(adapter_id: str, slug: str, practice_id: str) -> tuple[
     raise ValueError(f"unsupported semantic adapter target: {adapter_id}")
 
 
+def semantic_installed_path(adapter_id: str, slug: str, practice_id: str) -> str:
+    if adapter_id == "claude-code":
+        return f"references/{slug}/{practice_id}.md"
+    return ""
+
+
 def semantic_manifest_routes(path: Path) -> list[dict[str, str]]:
     routes: list[dict[str, str]] = []
     current: dict[str, str] | None = None
@@ -437,6 +443,7 @@ def expected_semantic_routes(vault_root: Path) -> dict[tuple[str, str, str], dic
                     "source_sha256": source_sha256,
                     "router_path": router_path,
                     "target_path": target_path,
+                    "installed_path": semantic_installed_path(target, str(asset["slug"]), str(practice_id)),
                     "packaging": packaging,
                 }
     return expected
@@ -488,7 +495,7 @@ def check_semantic_reachability(generated_root: Path, vault_root: Path, manifest
             errors.append(f"Selected output semantic reachability: missing conditional route: {key}")
         if route.get("route_kind") != "reference_file":
             errors.append(f"Selected output semantic reachability: unsupported or ID-only route kind: {key}")
-        for field in ["source_path", "source_sha256", "router_path", "target_path", "packaging"]:
+        for field in ["source_path", "source_sha256", "router_path", "target_path", "installed_path", "packaging"]:
             if route.get(field) != contract[field]:
                 reason = "stale or missing provenance" if field.startswith("source_") else "target-specific packaging omission"
                 errors.append(
@@ -500,7 +507,9 @@ def check_semantic_reachability(generated_root: Path, vault_root: Path, manifest
         target = contained_generated_path(generated_root, route.get("target_path", ""))
         if router is None or not router.is_file():
             errors.append(f"Selected output semantic reachability: missing or out-of-root router for {key}")
-        elif key[2] not in read(router) or route.get("target_path", "") not in read(router):
+        elif key[2] not in read(router) or (
+            route.get("installed_path") or route.get("target_path", "")
+        ) not in read(router):
             errors.append(
                 f"Selected output semantic reachability: ID-only router has no readable reference route for {key}"
             )

--- a/scripts/publish_adapters.py
+++ b/scripts/publish_adapters.py
@@ -232,6 +232,12 @@ def semantic_route_paths(adapter_id: str, slug: str, practice_id: str) -> tuple[
     raise ValueError(f"unsupported semantic adapter target: {adapter_id}")
 
 
+def semantic_installed_path(adapter_id: str, slug: str, practice_id: str) -> str:
+    if adapter_id == "claude-code":
+        return f"references/{slug}/{practice_id}.md"
+    return ""
+
+
 def semantic_reachability_routes(
     vault_root: Path,
     skill_assets: list[dict[str, object]],
@@ -276,6 +282,9 @@ def semantic_reachability_routes(
                         "route_kind": "reference_file",
                         "router_path": router_path,
                         "target_path": target_path,
+                        "installed_path": semantic_installed_path(
+                            adapter_id, str(asset["slug"]), str(practice_id)
+                        ),
                         "declared_required": "true",
                         "condition": semantic_route_condition(str(practice_id)),
                         "packaging": packaging,
@@ -344,6 +353,7 @@ def semantic_manifest_text(routes: list[dict[str, str]]) -> str:
             "route_kind",
             "router_path",
             "target_path",
+            "installed_path",
             "declared_required",
             "condition",
             "packaging",
@@ -402,8 +412,9 @@ def adapter_body(
     if adapter_routes:
         lines.extend(["", "## Semantic Practice References"])
         for route in adapter_routes:
+            locator = route["installed_path"] or route["target_path"]
             lines.append(
-                f"- {route['asset_id']} -> {route['practice_id']}: `{route['target_path']}` "
+                f"- {route['asset_id']} -> {route['practice_id']}: `{locator}` "
                 f"({route['condition']})"
             )
     lines.append("")

--- a/scripts/sync_adapters.py
+++ b/scripts/sync_adapters.py
@@ -31,6 +31,13 @@ Action = Literal["copy", "upsert-managed-block"]
 
 
 def copytree_contents(src: Path, dest: Path, apply: bool) -> list[tuple[Action, Path, Path]]:
+    copied = planned_tree_copies(src, dest)
+    if apply:
+        apply_copy_actions(copied)
+    return copied
+
+
+def planned_tree_copies(src: Path, dest: Path) -> list[tuple[Action, Path, Path]]:
     if not src.exists():
         raise SystemExit(f"Adapter source missing: {src}")
     copied: list[tuple[Action, Path, Path]] = []
@@ -40,10 +47,106 @@ def copytree_contents(src: Path, dest: Path, apply: bool) -> list[tuple[Action, 
         rel = path.relative_to(src)
         target = dest / rel
         copied.append(("copy", path, target))
-        if apply:
-            target.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(path, target)
     return copied
+
+
+def apply_copy_actions(copied: list[tuple[Action, Path, Path]]) -> None:
+    for _, source, target in copied:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+
+
+def semantic_manifest_routes(path: Path) -> list[dict[str, str]]:
+    routes: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    in_routes = False
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.rstrip()
+        if line.startswith("routes:"):
+            in_routes = line.split(":", 1)[1].strip() != "[]"
+            continue
+        if in_routes and line and not line.startswith(" "):
+            break
+        if not in_routes:
+            continue
+        stripped = line.strip()
+        if stripped.startswith("- target:"):
+            if current:
+                routes.append(current)
+            current = {"target": stripped.split(":", 1)[1].strip().strip('"').strip("'")}
+        elif current is not None and ":" in stripped:
+            key, value = stripped.split(":", 1)
+            current[key] = value.strip().strip('"').strip("'")
+    if current:
+        routes.append(current)
+    return routes
+
+
+def safe_relative_path(value: str) -> Path | None:
+    path = Path(value)
+    if not value or path.is_absolute() or ".." in path.parts:
+        return None
+    return path
+
+
+def claude_reference_actions(adapter_root: Path, dest: Path) -> list[tuple[Action, Path, Path]]:
+    manifest = adapter_root / "semantic-reachability-manifest.yaml"
+    if not manifest.is_file():
+        return []
+
+    routes = [route for route in semantic_manifest_routes(manifest) if route.get("target") == "claude-code"]
+    actions: list[tuple[Action, Path, Path]] = []
+    router = adapter_root / "claude-code" / "CLAUDE.md"
+    router_text = router.read_text(encoding="utf-8") if router.is_file() else ""
+    for route in routes:
+        installed = safe_relative_path(route.get("installed_path", ""))
+        target_path = safe_relative_path(route.get("target_path", ""))
+        if installed is None or not str(installed).startswith("references/"):
+            raise SystemExit(
+                "Claude semantic packaging requires a target-local installed_path under references/: "
+                f"{route.get('practice_id', '<unknown>')}"
+            )
+        if target_path is None or target_path != Path("claude-code") / installed:
+            raise SystemExit(
+                "Claude semantic packaging requires target_path to match the generated reference source: "
+                f"{route.get('practice_id', '<unknown>')}"
+            )
+        source = adapter_root / target_path
+        if not source.is_file():
+            raise SystemExit(
+                "Claude semantic packaging source reference is missing: "
+                f"{route.get('target_path', '<unknown>')}"
+            )
+        text = source.read_text(encoding="utf-8")
+        if route.get("practice_id", "") not in text or route.get("source_sha256", "") not in text:
+            raise SystemExit(
+                "Claude semantic packaging source reference lacks declared provenance: "
+                f"{route.get('practice_id', '<unknown>')}"
+            )
+        if route.get("practice_id", "") not in router_text or str(installed) not in router_text:
+            raise SystemExit(
+                "Claude semantic router does not declare a readable target-local reference: "
+                f"{route.get('practice_id', '<unknown>')}"
+            )
+        actions.append(("copy", source, dest / "agent-foundry" / installed))
+    return actions
+
+
+def validate_claude_reference_plan(
+    adapter_root: Path, dest: Path, copied: list[tuple[Action, Path, Path]]
+) -> None:
+    expected = claude_reference_actions(adapter_root, dest)
+    planned = {(action, source.resolve(), target.resolve()) for action, source, target in copied}
+    missing = [
+        target
+        for action, source, target in expected
+        if (action, source.resolve(), target.resolve()) not in planned
+    ]
+    if missing:
+        raise SystemExit(
+            "Claude semantic packaging plan omits declared reference copies: "
+            + ", ".join(str(path) for path in missing)
+        )
 
 
 def log_adoption(path: Path, action: str) -> None:
@@ -152,6 +255,8 @@ def sync_claude(adapter_root: Path, dest: Path, apply: bool, backup: bool) -> li
     if not claude_md.exists():
         raise SystemExit(f"Adapter source missing: {claude_md}")
     managed_claude = dest / "agent-foundry" / "CLAUDE.md"
+    reference_actions = claude_reference_actions(adapter_root, dest)
+    validate_claude_reference_plan(adapter_root, dest, [("copy", claude_md, managed_claude), *reference_actions])
     copied.append(("copy", claude_md, managed_claude))
     if apply:
         managed_claude.parent.mkdir(parents=True, exist_ok=True)
@@ -163,6 +268,9 @@ def sync_claude(adapter_root: Path, dest: Path, apply: bool, backup: bool) -> li
     commands_src = src_root / "commands"
     commands_dest = dest / "commands" / "agent-foundry"
     copied.extend(copytree_contents(commands_src, commands_dest, apply))
+    copied.extend(reference_actions)
+    if apply:
+        apply_copy_actions(reference_actions)
     return copied
 
 

--- a/scripts/test_claude_semantic_packaging.py
+++ b/scripts/test_claude_semantic_packaging.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Regression coverage for Claude target-local semantic reference packaging."""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import sync_adapters
+from foundry_config import CONFIG_PATH, parse_config
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PUBLISH = ROOT / "scripts" / "publish_adapters.py"
+QUALITY = ROOT / "scripts" / "check_adapter_quality.py"
+SYNC = ROOT / "scripts" / "sync_adapters.py"
+
+
+def configured_vault_root() -> Path:
+    data = parse_config(CONFIG_PATH)
+    vault_root = data.get("vault_root", "")
+    if isinstance(vault_root, str) and vault_root:
+        return Path(vault_root).expanduser().resolve()
+    raise RuntimeError("configured vault_root missing")
+
+
+def digest_tree(path: Path) -> dict[str, str]:
+    return {
+        str(file_path.relative_to(path)): hashlib.sha256(file_path.read_bytes()).hexdigest()
+        for file_path in sorted(candidate for candidate in path.rglob("*") if candidate.is_file())
+    }
+
+
+def run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, *args],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def output(result: subprocess.CompletedProcess[str]) -> str:
+    return result.stdout + result.stderr
+
+
+def main() -> int:
+    vault_root = configured_vault_root()
+    vault_before = digest_tree(vault_root)
+    errors: list[str] = []
+
+    with tempfile.TemporaryDirectory(prefix="agent-foundry-claude-semantic-") as tmp:
+        base = Path(tmp)
+        generated = base / "generated"
+        runtime = base / "runtime" / "claude"
+
+        publish = run(
+            [
+                str(PUBLISH),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(vault_root),
+                "--output-root",
+                str(generated),
+                "--apply",
+            ]
+        )
+        if publish.returncode != 0:
+            errors.append(f"publish failed:\n{output(publish)}")
+
+        quality = run(
+            [
+                str(QUALITY),
+                "--core-root",
+                str(ROOT),
+                "--vault-root",
+                str(vault_root),
+                "--surface",
+                "selected-output",
+                "--generated-root",
+                str(generated),
+            ]
+        )
+        if quality.returncode != 0:
+            errors.append(f"selected-output quality failed:\n{output(quality)}")
+
+        router = generated / "claude-code" / "CLAUDE.md"
+        semantic = generated / "semantic-reachability-manifest.yaml"
+        router_text = router.read_text(encoding="utf-8") if router.exists() else ""
+        semantic_text = semantic.read_text(encoding="utf-8") if semantic.exists() else ""
+        for practice_id in ["ARCH-001", "ARCH-006", "ARCH-010", "ARCH-011"]:
+            installed = f"references/architecture-design/{practice_id}.md"
+            generated_path = f"claude-code/references/architecture-design/{practice_id}.md"
+            if installed not in router_text or generated_path in router_text:
+                errors.append(f"Claude router lacks target-local locator for {practice_id}")
+            if f"installed_path: {installed}" not in semantic_text:
+                errors.append(f"semantic manifest lacks installed_path for {practice_id}")
+
+        dry_run = run(
+            [
+                str(SYNC),
+                "--target",
+                "claude-code",
+                "--adapter-root",
+                str(generated),
+                "--dest",
+                str(runtime),
+                "--dry-run",
+            ]
+        )
+        if dry_run.returncode != 0:
+            errors.append(f"Claude dry-run failed:\n{output(dry_run)}")
+        if "agent-foundry/references/architecture-design/ARCH-001.md" not in output(dry_run):
+            errors.append("Claude dry-run omitted ARCH-001 target-local reference copy")
+        if runtime.exists():
+            errors.append("Claude dry-run wrote to isolated runtime root")
+        if str(sync_adapters.DEFAULT_DESTS["claude-code"]) in output(dry_run):
+            errors.append("Claude dry-run used live runtime instead of isolated destination")
+
+        missing_reference_plan = [
+            ("copy", generated / "claude-code" / "CLAUDE.md", runtime / "agent-foundry" / "CLAUDE.md")
+        ]
+        try:
+            sync_adapters.validate_claude_reference_plan(generated, runtime, missing_reference_plan)
+        except SystemExit as error:
+            if "omits declared reference copies" not in str(error):
+                errors.append(f"Claude packaging negative control failed unexpectedly: {error}")
+        else:
+            errors.append("Claude packaging negative control did not fail closed")
+
+        runtime.mkdir(parents=True)
+        user_claude = runtime / "CLAUDE.md"
+        user_claude.write_text("# User Claude instructions\n", encoding="utf-8")
+        apply = run(
+            [
+                str(SYNC),
+                "--target",
+                "claude-code",
+                "--adapter-root",
+                str(generated),
+                "--dest",
+                str(runtime),
+                "--apply",
+            ]
+        )
+        if apply.returncode != 0:
+            errors.append(f"Claude isolated apply failed:\n{output(apply)}")
+        if str(sync_adapters.DEFAULT_DESTS["claude-code"]) in output(apply):
+            errors.append("Claude isolated apply used a live runtime destination")
+        backups = list(runtime.glob("CLAUDE.md.bak.*"))
+        if not backups:
+            errors.append("Claude isolated apply did not preserve managed-block backup behavior")
+        if not (runtime / "commands" / "agent-foundry" / "README.md").is_file():
+            errors.append("Claude isolated apply omitted commands packaging")
+        for practice_id in ["ARCH-001", "ARCH-006", "ARCH-010", "ARCH-011"]:
+            reference = runtime / "agent-foundry" / "references" / "architecture-design" / f"{practice_id}.md"
+            if not reference.is_file():
+                errors.append(f"Claude isolated apply omitted {practice_id} reference")
+                continue
+            route = next(
+                (
+                    item
+                    for item in sync_adapters.semantic_manifest_routes(semantic)
+                    if item.get("target") == "claude-code" and item.get("practice_id") == practice_id
+                ),
+                {},
+            )
+            text = reference.read_text(encoding="utf-8")
+            if practice_id not in text or route.get("source_sha256", "") not in text:
+                errors.append(f"Claude isolated apply lost provenance for {practice_id}")
+
+    if digest_tree(vault_root) != vault_before:
+        errors.append("selected Vault changed during Claude semantic packaging test")
+
+    if errors:
+        print("Claude semantic packaging tests failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("Claude semantic packaging tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary\n\nRepairs Claude target-local semantic reference packaging that blocked #410.\n\n- keeps generated target_path authoritative and adds Claude installed_path metadata\n- renders Claude router locators as target-local references paths\n- copies and validates the Claude managed references tree before writes\n- adds isolated dry-run, apply, provenance, negative-plan, no-live-write regression coverage\n\n## Execution Contract\n\nOwner role: implementer\nReview role: reviewer\nAcceptance role: architect\nCompletion handoff: to:reviewer\nBranch strategy: integration-branch\nTarget branch: codex/semantic-practice-loading-integration\n\n## Verification\n\n- python3 -m py_compile scripts/publish_adapters.py scripts/check_adapter_quality.py scripts/sync_adapters.py scripts/test_claude_semantic_packaging.py\n- python3 scripts/test_claude_semantic_packaging.py\n- python3 scripts/test_adapter_quality_split.py\n- python3 scripts/test_sync_status_report.py\n- python3 scripts/test_first_run_ux.py\n- python3 scripts/test_foundry_roots.py\n- python3 scripts/check_consistency.py\n- git diff --check origin/codex/semantic-practice-loading-integration...HEAD\n\nCloses none. #410 remains held until this change is accepted and merged, then re-preflighted.