### PR TITLE
AF18 #420 Add portable collaboration route planner

### DIFF
--- a/schemas/collaboration-routing-policy.schema.yaml
+++ b/schemas/collaboration-routing-policy.schema.yaml
@@ -1,0 +1,61 @@
+# Portable Collaboration Routing Policy schema.
+# This AF18 schema is advisory and runtime-neutral. It never stores provider
+# or model identifiers and does not authorize dispatch or runtime mutation.
+
+schema_version: 1
+objects:
+  PolicySet:
+    required: [schema_version, policy_id, quality_floor, automatic_budget, allowed_tiers, enforcement]
+    rules:
+      - "portable policy uses named capability and reasoning tiers, never provider or model slugs"
+      - "lower-precedence policy cannot relax Human gates, authority boundaries, or budget limits"
+  WorkUnit:
+    required: [work_unit_id, purpose, risk, ambiguity, verification_oracle, stop_conditions]
+    rules:
+      - "one bounded issue, PR, review target, experiment, or batch only"
+      - "Human-owned actions stop advisory routing until an explicit decision exists"
+  RoleContext:
+    required: [required_role, specialization_available, continuity_value, context_relevance, independence_requirement]
+    rules:
+      - "role specialization, continuity, and independence are separate inputs"
+  RuntimeCapabilities:
+    required: [observed_at, mechanisms]
+    rules:
+      - "runtime discovery is timestamped evidence, not permanent truth"
+      - "effective retained settings are unknown when unobserved"
+      - "fork and heartbeat are non-enforcing"
+      - "hook and custom-agent enforcement are unsupported in this slice"
+  RouteCandidate:
+    required: [candidate_id, topology, context_mode, eligible, expected_cost_band, expected_quality_band, confidence]
+    rules:
+      - "at most four candidates, including serial whenever it is eligible"
+      - "eligibility failures stay visible instead of being silently repaired"
+  DispatchPlan:
+    required: [route_decision, selected_candidate, explanation, runtime_mapping, reset, stop_conditions]
+    rules:
+      - "advisory only; mutation_performed and dispatch_performed must be false"
+      - "unsupported runtime paths report enforcement_not_available"
+  OverrideGrant:
+    required: [active, scope, expires_after_work_unit, reset_required]
+    rules:
+      - "an override is scoped to one work unit and never follows a target thread implicitly"
+  EvaluationRecord:
+    required: [work_unit_id, outcome, estimate_band, confidence, quality_guardrails]
+    rules:
+      - "ordinal estimates are not billing-grade token or cost claims"
+
+allowed_values:
+  capability_tier: [economy, balanced, frontier]
+  reasoning_tier: [low, medium, high]
+  topology: [serial, durable_thread, fresh_thread, fork, subagent, team, batch, portable]
+  context_mode: [fresh, compact, filtered_history, full_continuity, artifact_reference]
+  independence_requirement: [none, separate_context, separate_evidence]
+  confidence: [high, medium, low, unknown]
+  runtime_status: [supported, unsupported, unknown, degraded, not_available]
+  effective_configuration: [observed, unknown, not_available]
+  route_decision: [no_dispatch, dispatch_advisory, human_stop]
+
+forbidden:
+  - "provider, provider_slug, model, or model_slug fields in PolicySet"
+  - "dispatch, thread, subagent, automation, runtime, config, hook, custom-agent, Vault, generated, or Project mutation"
+  - "claims that omitted runtime envelope fields reveal effective retained settings"

--- a/schemas/collaboration-routing-policy.schema.yaml
+++ b/schemas/collaboration-routing-policy.schema.yaml
@@ -9,11 +9,14 @@ objects:
     rules:
       - "portable policy uses named capability and reasoning tiers, never provider or model slugs"
       - "lower-precedence policy cannot relax Human gates, authority boundaries, or budget limits"
+      - "effective policy precedence is current-work-unit Human grant, then project record, then personal record, then unsaved normal default"
+      - "invalid, missing, or drifted records remain visible and are never represented as valid persisted policy"
   WorkUnit:
     required: [work_unit_id, purpose, risk, ambiguity, verification_oracle, stop_conditions]
     rules:
       - "one bounded issue, PR, review target, experiment, or batch only"
       - "Human-owned actions stop advisory routing until an explicit decision exists"
+      - "task_class is routine, standard, complex, or human_owned; any correction is bounded to one work unit and resets afterward"
   RoleContext:
     required: [required_role, specialization_available, continuity_value, context_relevance, independence_requirement]
     rules:
@@ -35,6 +38,13 @@ objects:
     rules:
       - "advisory only; mutation_performed and dispatch_performed must be false"
       - "unsupported runtime paths report enforcement_not_available"
+  ConversationProjection:
+    required: [effective_policy, work_unit, recommendation, runtime_projection, attention, evidence, next_action]
+    rules:
+      - "primary fields are compact conversation guidance; JSON stays secondary technical evidence"
+      - "routine serial/no_dispatch paths emit no separate marker unless attention or a material correction exists"
+      - "runtime projection distinguishes requested abstract tier from observable, unknown, or unsupported runtime configuration"
+      - "explicit set up collaboration policy intent is a no-write handoff to the later lifecycle slice"
   OverrideGrant:
     required: [active, scope, expires_after_work_unit, reset_required]
     rules:
@@ -54,8 +64,12 @@ allowed_values:
   runtime_status: [supported, unsupported, unknown, degraded, not_available]
   effective_configuration: [observed, unknown, not_available]
   route_decision: [no_dispatch, dispatch_advisory, human_stop]
+  policy_profile: [economy, normal, high_performance]
+  policy_validity: [valid, invalid, drifted, missing, unsaved_default]
+  task_class: [routine, standard, complex, human_owned]
 
 forbidden:
   - "provider, provider_slug, model, or model_slug fields in PolicySet"
   - "dispatch, thread, subagent, automation, runtime, config, hook, custom-agent, Vault, generated, or Project mutation"
   - "claims that omitted runtime envelope fields reveal effective retained settings"
+  - "policy record writes, readback writes, telemetry persistence, monitoring, dashboards, or report products in this advisory planner"

--- a/scripts/plan_collaboration_routes.py
+++ b/scripts/plan_collaboration_routes.py
@@ -307,7 +307,10 @@ def conversation_projection(policy_resolution: dict[str, Any], task_class: str, 
     elif decision == "human_stop":
         next_action = "Provide the single Human decision or inspect the invalid policy source before continuing"
     elif source_attention:
-        next_action = "Inspect the invalid or drifted policy source; ordinary work may continue only with the labelled unsaved normal default"
+        if policy_resolution["source"] == "unsaved_normal_default":
+            next_action = "Inspect the invalid or drifted policy source; ordinary work may continue only with the labelled unsaved normal default"
+        else:
+            next_action = "Inspect the invalid or drifted policy source; continue with the retained valid policy shown above"
     elif decision == "no_dispatch":
         next_action = "Continue serial work; no dispatch action is requested"
     else:

--- a/scripts/plan_collaboration_routes.py
+++ b/scripts/plan_collaboration_routes.py
@@ -11,6 +11,8 @@ from typing import Any
 
 CAPABILITY_TIERS = {"economy", "balanced", "frontier"}
 REASONING_TIERS = {"low", "medium", "high"}
+POLICY_PROFILES = {"economy", "normal", "high_performance"}
+TASK_CLASSES = {"routine", "standard", "complex", "human_owned"}
 RUNTIME_STATUSES = {"supported", "unsupported", "unknown", "degraded", "not_available"}
 TOPOLOGY_MECHANISMS = {
     "durable_thread": "send_message_to_thread",
@@ -78,7 +80,114 @@ def validate_input(root: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
         fail("role_context.independence_requirement is invalid")
     if not isinstance(runtime.get("mechanisms"), dict):
         fail("runtime_capabilities.mechanisms must be an object")
+    if not isinstance(root.get("policy_sources", {}), dict):
+        fail("policy_sources must be an object")
     return policy, work, role, runtime
+
+
+def validate_policy(policy: dict[str, Any]) -> None:
+    forbidden = nested_forbidden_keys(policy)
+    if forbidden:
+        fail(f"portable policy forbids provider/model identifiers: {', '.join(forbidden)}")
+    allowed = policy.get("allowed_tiers", {})
+    if not set(allowed.get("capability", [])).issubset(CAPABILITY_TIERS):
+        fail("policy_set allowed capability tiers are invalid")
+    if not set(allowed.get("reasoning", [])).issubset(REASONING_TIERS):
+        fail("policy_set allowed reasoning tiers are invalid")
+
+
+def resolve_policy(root: dict[str, Any], fallback_policy: dict[str, Any]) -> dict[str, Any]:
+    sources = root.get("policy_sources", {})
+    checks: list[dict[str, Any]] = []
+    selected: dict[str, Any] | None = None
+    for source_name in ("current_work_unit_grant", "project", "personal"):
+        record = sources.get(source_name)
+        if record is None:
+            checks.append({"source": source_name, "validity": "missing"})
+            continue
+        if not isinstance(record, dict):
+            checks.append({"source": source_name, "validity": "invalid", "reason": "record is not an object"})
+            continue
+        validity = record.get("validity", "invalid")
+        profile = record.get("profile")
+        fingerprint = record.get("fingerprint")
+        if validity != "valid" or profile not in POLICY_PROFILES or not isinstance(fingerprint, str) or not fingerprint:
+            checks.append({"source": source_name, "validity": validity if validity in {"invalid", "drifted", "missing"} else "invalid", "reason": "profile or fingerprint is unavailable"})
+            continue
+        source_policy = record.get("policy_set", fallback_policy)
+        if not isinstance(source_policy, dict):
+            checks.append({"source": source_name, "validity": "invalid", "reason": "policy_set is not an object"})
+            continue
+        validate_policy(source_policy)
+        checks.append({"source": source_name, "validity": "valid", "fingerprint": fingerprint})
+        if selected is None:
+            selected = {
+                "profile": profile,
+                "source": source_name,
+                "validity": "valid",
+                "fingerprint_or_unsaved_default": fingerprint,
+                "policy_set": source_policy,
+            }
+    if selected is not None:
+        selected["source_checks"] = checks
+        return selected
+    return {
+        "profile": "normal",
+        "source": "unsaved_normal_default",
+        "validity": "unsaved_default",
+        "fingerprint_or_unsaved_default": "unsaved-normal-default",
+        "policy_set": fallback_policy,
+        "source_checks": checks,
+    }
+
+
+def resolve_task_class(work: dict[str, Any]) -> tuple[str, dict[str, Any], str | None]:
+    task_class = work.get("task_class", "standard")
+    if task_class not in TASK_CLASSES:
+        fail("work_unit.task_class is invalid")
+    signals = work.get("material_signals", [])
+    if not isinstance(signals, list) or not all(isinstance(signal, str) and signal for signal in signals):
+        fail("work_unit.material_signals must be a list of strings")
+    correction = work.get("task_class_correction")
+    state = {"applied": False, "bounded_to_work_unit": True, "material_signals": signals[:3]}
+    if correction is None:
+        return task_class, state, None
+    if not isinstance(correction, dict):
+        fail("work_unit.task_class_correction must be an object")
+    corrected_class = correction.get("task_class")
+    if corrected_class not in TASK_CLASSES:
+        return task_class, state, "Task-class correction is invalid; inspect and correct the current work-unit input"
+    if correction.get("scope") != work["work_unit_id"] or correction.get("expires_after_work_unit") is not True:
+        return task_class, state, "Task-class correction is not bounded to this work unit; Human decision required"
+    state.update({"applied": True, "from": task_class, "to": corrected_class, "bounded_to_work_unit": True})
+    return corrected_class, state, None
+
+
+def profile_tier(policy: dict[str, Any], profile: str, task_class: str, signal_count: int, root: dict[str, Any]) -> tuple[str, str, dict[str, Any], str | None]:
+    thresholds = policy.get("material_thresholds", {})
+    if not isinstance(thresholds, dict):
+        thresholds = {}
+    economy_complex = thresholds.get("economy_complex", 2)
+    high_performance_complex = thresholds.get("high_performance_complex", 1)
+    reset = {"required": True, "persists": False, "after_work_unit": True}
+    if task_class == "human_owned":
+        return "balanced", "medium", reset, "Human-owned task class requires a Human decision"
+    if task_class == "routine":
+        return "economy", "low", reset, None
+    if task_class == "standard":
+        return ("economy", "low", reset, None) if profile == "economy" else ("balanced", "medium", reset, None)
+    if profile == "economy":
+        return ("balanced", "medium", reset, None) if signal_count >= economy_complex else ("economy", "low", reset, None)
+    if profile == "high_performance" and signal_count >= high_performance_complex:
+        return "frontier", "high", reset, None
+    attempt = root.get("attempt_state", {})
+    if isinstance(attempt, dict) and attempt.get("outcome") == "escalation_candidate":
+        if not attempt.get("evidence"):
+            return "balanced", "medium", reset, "Escalation lacks explicit evidence"
+        if not isinstance(attempt.get("escalation_count", 0), int) or attempt.get("escalation_count", 0) >= policy.get("automatic_budget", {}).get("max_escalations_per_work_unit", 0):
+            return "balanced", "medium", reset, "Escalation budget exhausted; Human decision required"
+        return "frontier", "high", reset, None
+    return "balanced", "medium", reset, None
 
 
 def mechanism(runtime: dict[str, Any], name: str) -> dict[str, Any]:
@@ -94,26 +203,6 @@ def mechanism(runtime: dict[str, Any], name: str) -> dict[str, Any]:
         "supports_explicit_envelope": value.get("supports_explicit_envelope", False) is True,
         "effective_configuration": value.get("effective_configuration", "unknown"),
     }
-
-
-def escalation(policy: dict[str, Any], root: dict[str, Any]) -> tuple[str, str, dict[str, Any], str | None]:
-    attempt = root.get("attempt_state", {})
-    if not isinstance(attempt, dict):
-        attempt = {}
-    state = attempt.get("outcome", "planned")
-    count = attempt.get("escalation_count", 0)
-    max_count = policy.get("automatic_budget", {}).get("max_escalations_per_work_unit", 0)
-    if state == "human_owned":
-        return "balanced", "medium", {"required": True, "persists": False}, "Human-owned action requires a Human decision"
-    if state == "escalation_candidate":
-        if not attempt.get("evidence"):
-            return "balanced", "medium", {"required": True, "persists": False}, "Escalation lacks explicit evidence"
-        if not isinstance(count, int) or count >= max_count:
-            return "balanced", "medium", {"required": True, "persists": False}, "Escalation budget exhausted; Human decision required"
-        return "frontier", "high", {"required": True, "persists": False, "after_work_unit": True}, None
-    if state == "downgrade_candidate":
-        return "economy", "low", {"required": True, "persists": False, "after_work_unit": True}, None
-    return "balanced", "medium", {"required": True, "persists": False, "after_work_unit": True}, None
 
 
 def candidate(
@@ -204,16 +293,71 @@ def validate_override(root: dict[str, Any], work: dict[str, Any]) -> tuple[dict[
     return normalized, None
 
 
+def conversation_projection(policy_resolution: dict[str, Any], task_class: str, task_state: dict[str, Any], decision: str, selected: dict[str, Any] | None, candidates: list[dict[str, Any]], stops: list[str], tier: str, reasoning: str, setup_requested: bool) -> dict[str, Any]:
+    source_attention = [check for check in policy_resolution["source_checks"] if check["validity"] in {"invalid", "drifted"}]
+    observed_candidate = selected or next((item for item in candidates if item["topology"] != "serial"), None)
+    runtime_mapping = observed_candidate.get("runtime_mapping") if observed_candidate else {"status": "not_available", "effective_configuration": "unknown", "enforcement": "not_available"}
+    attention = list(stops)
+    if source_attention:
+        attention.append("One or more explicit policy sources are invalid or drifted; no persisted policy is assumed valid")
+    if decision != "no_dispatch" and (runtime_mapping.get("status") != "supported" or runtime_mapping.get("effective_configuration") != "observed"):
+        attention.append("Runtime projection is requested versus observable evidence; retained settings are not assumed")
+    if setup_requested:
+        next_action = "Set up collaboration policy requires the later lifecycle write/readback flow; this planner will not write a record"
+    elif decision == "human_stop":
+        next_action = "Provide the single Human decision or inspect the invalid policy source before continuing"
+    elif source_attention:
+        next_action = "Inspect the invalid or drifted policy source; ordinary work may continue only with the labelled unsaved normal default"
+    elif decision == "no_dispatch":
+        next_action = "Continue serial work; no dispatch action is requested"
+    else:
+        next_action = "Review the advisory route before any later runtime adapter action"
+    emit = not (task_class == "routine" and decision == "no_dispatch" and not attention and not task_state["applied"])
+    return {
+        "effective_policy": {
+            "profile": policy_resolution["profile"],
+            "source": policy_resolution["source"],
+            "validity": policy_resolution["validity"],
+            "fingerprint_or_unsaved_default": policy_resolution["fingerprint_or_unsaved_default"],
+        },
+        "work_unit": {"task_class": task_class, "material_signals": task_state["material_signals"], "correction": task_state},
+        "recommendation": {
+            "route_decision": decision,
+            "role": selected.get("topology") if selected else "not_available",
+            "topology": selected.get("topology") if selected else "not_available",
+            "context_mode": selected.get("context_mode") if selected else "not_available",
+            "abstract_tier": {"capability": tier, "reasoning": reasoning},
+        },
+        "runtime_projection": {
+            "requested": {"capability_tier": tier, "reasoning_tier": reasoning},
+            "observable": {
+                "status": runtime_mapping.get("status", "not_available"),
+                "effective_configuration": runtime_mapping.get("effective_configuration", "unknown"),
+                "enforcement": runtime_mapping.get("enforcement", "not_available"),
+            },
+        },
+        "attention": attention,
+        "evidence": {"policy_source_checks": policy_resolution["source_checks"], "json_is_secondary_debug": True},
+        "next_action": next_action,
+        "policy_setup_intent": {"requested": setup_requested, "apply_supported_now": False, "write_performed": False},
+        "emit_compact_marker": emit,
+        "recovery": {"writes_performed": False, "retains_prior_valid_policy": policy_resolution["source"] in {"current_work_unit_grant", "project", "personal"}},
+    }
+
+
 def plan(root: dict[str, Any]) -> dict[str, Any]:
     policy, work, role, runtime = validate_input(root)
+    policy_resolution = resolve_policy(root, policy)
+    policy = policy_resolution["policy_set"]
+    task_class, task_state, correction_stop = resolve_task_class(work)
     override, override_stop = validate_override(root, work)
-    tier, reasoning, reset, early_stop = escalation(policy, root)
+    tier, reasoning, reset, early_stop = profile_tier(policy, policy_resolution["profile"], task_class, len(task_state["material_signals"]), root)
     human_actions = work.get("human_owned_actions", [])
     if not isinstance(human_actions, list):
         fail("work_unit.human_owned_actions must be a list")
-    if human_actions or work.get("requires_human_decision") is True or early_stop or override_stop:
-        reason = early_stop or override_stop or "Human-owned action requires a Human decision"
-        return result(root, [], "human_stop", None, [reason], reset, tier, reasoning, override)
+    if human_actions or work.get("requires_human_decision") is True or early_stop or override_stop or correction_stop:
+        reason = early_stop or override_stop or correction_stop or "Human-owned action requires a Human decision"
+        return result(root, policy_resolution, task_class, task_state, [], "human_stop", None, [reason], reset, tier, reasoning, override)
 
     required_independence = role.get("independence_requirement", "none")
     envelope_required = work.get("requires_explicit_envelope", False) is True
@@ -251,16 +395,16 @@ def plan(root: dict[str, Any]) -> dict[str, Any]:
     candidates = candidates[:4]
     eligible = [item for item in candidates if item["eligible"]]
     if not eligible:
-        return result(root, candidates, "human_stop", None, ["No route meets the authority, evidence, and runtime quality floor."], reset, tier, reasoning, override)
+        return result(root, policy_resolution, task_class, task_state, candidates, "human_stop", None, ["No route meets the authority, evidence, and runtime quality floor."], reset, tier, reasoning, override)
     material_benefit = any((role.get("specialization_available") is True, continuity in {"medium", "high"} and relevance in {"medium", "high"}, required_independence != "none", work.get("safe_parallelism") is True))
     selected = sorted(eligible, key=lambda item: (COST_RANK[item["expected_cost_band"]], -{"low": 1, "medium": 2, "high": 3}[item["expected_quality_band"]], item["candidate_id"]))[0]
     decision = "dispatch_advisory" if material_benefit and selected["topology"] != "serial" else "no_dispatch"
     if decision == "no_dispatch":
         selected = next(item for item in eligible if item["topology"] == "serial")
-    return result(root, candidates, decision, selected, [], reset, tier, reasoning, override)
+    return result(root, policy_resolution, task_class, task_state, candidates, decision, selected, [], reset, tier, reasoning, override)
 
 
-def result(root: dict[str, Any], candidates: list[dict[str, Any]], decision: str, selected: dict[str, Any] | None, stops: list[str], reset: dict[str, Any], tier: str, reasoning: str, override: dict[str, Any]) -> dict[str, Any]:
+def result(root: dict[str, Any], policy_resolution: dict[str, Any], task_class: str, task_state: dict[str, Any], candidates: list[dict[str, Any]], decision: str, selected: dict[str, Any] | None, stops: list[str], reset: dict[str, Any], tier: str, reasoning: str, override: dict[str, Any]) -> dict[str, Any]:
     runtime = root["runtime_capabilities"]
     confidence = "low" if any(item.get("runtime_mapping", {}).get("effective_configuration") == "unknown" for item in candidates) else "medium"
     return {
@@ -269,6 +413,8 @@ def result(root: dict[str, Any], candidates: list[dict[str, Any]], decision: str
         "role_context": root["role_context"],
         "runtime_capabilities": {"observed_at": runtime.get("observed_at", "not_available"), "mechanisms": runtime.get("mechanisms", {})},
         "runtime_limitations": runtime_limitations(runtime),
+        "policy_resolution": {key: value for key, value in policy_resolution.items() if key != "policy_set"},
+        "conversation_projection": conversation_projection(policy_resolution, task_class, task_state, decision, selected, candidates, stops, tier, reasoning, root.get("policy_setup_requested") is True),
         "route_candidates": candidates,
         "dispatch_plan": {
             "route_decision": decision,

--- a/scripts/plan_collaboration_routes.py
+++ b/scripts/plan_collaboration_routes.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Plan portable collaboration routes without dispatching work."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+
+CAPABILITY_TIERS = {"economy", "balanced", "frontier"}
+REASONING_TIERS = {"low", "medium", "high"}
+RUNTIME_STATUSES = {"supported", "unsupported", "unknown", "degraded", "not_available"}
+TOPOLOGY_MECHANISMS = {
+    "durable_thread": "send_message_to_thread",
+    "fresh_thread": "create_thread",
+    "subagent": "spawn_agent",
+    "fork": "fork_thread",
+    "team": "team",
+    "batch": "worktree_batch",
+    "portable": "portable_prompt",
+}
+FORBIDDEN_POLICY_KEYS = {"provider", "provider_slug", "model", "model_slug"}
+COST_RANK = {"low": 1, "medium": 2, "high": 3}
+
+
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+def load_input(path: str) -> dict[str, Any]:
+    value = json.loads(open(path, encoding="utf-8").read())
+    if not isinstance(value, dict):
+        fail("planner input must be a JSON object")
+    return value
+
+
+def nested_forbidden_keys(value: Any, path: str = "") -> list[str]:
+    if not isinstance(value, dict):
+        return []
+    findings: list[str] = []
+    for key, child in value.items():
+        child_path = f"{path}.{key}" if path else key
+        if key in FORBIDDEN_POLICY_KEYS:
+            findings.append(child_path)
+        findings.extend(nested_forbidden_keys(child, child_path))
+    return findings
+
+
+def require_object(root: dict[str, Any], name: str) -> dict[str, Any]:
+    value = root.get(name)
+    if not isinstance(value, dict):
+        fail(f"missing object: {name}")
+    return value
+
+
+def validate_input(root: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
+    policy = require_object(root, "policy_set")
+    work = require_object(root, "work_unit")
+    role = require_object(root, "role_context")
+    runtime = require_object(root, "runtime_capabilities")
+    if policy.get("schema_version") != 1:
+        fail("policy_set.schema_version must be 1")
+    forbidden = nested_forbidden_keys(policy)
+    if forbidden:
+        fail(f"portable policy forbids provider/model identifiers: {', '.join(forbidden)}")
+    allowed = policy.get("allowed_tiers", {})
+    if not set(allowed.get("capability", [])).issubset(CAPABILITY_TIERS):
+        fail("policy_set allowed capability tiers are invalid")
+    if not set(allowed.get("reasoning", [])).issubset(REASONING_TIERS):
+        fail("policy_set allowed reasoning tiers are invalid")
+    if not work.get("work_unit_id") or not work.get("purpose"):
+        fail("work_unit requires work_unit_id and purpose")
+    if not isinstance(work.get("stop_conditions", []), list):
+        fail("work_unit.stop_conditions must be a list")
+    if role.get("independence_requirement", "none") not in {"none", "separate_context", "separate_evidence"}:
+        fail("role_context.independence_requirement is invalid")
+    if not isinstance(runtime.get("mechanisms"), dict):
+        fail("runtime_capabilities.mechanisms must be an object")
+    return policy, work, role, runtime
+
+
+def mechanism(runtime: dict[str, Any], name: str) -> dict[str, Any]:
+    value = runtime.get("mechanisms", {}).get(name, {})
+    if not isinstance(value, dict):
+        value = {}
+    status = value.get("status", "not_available")
+    if status not in RUNTIME_STATUSES:
+        status = "unknown"
+    return {
+        "name": name,
+        "status": status,
+        "supports_explicit_envelope": value.get("supports_explicit_envelope", False) is True,
+        "effective_configuration": value.get("effective_configuration", "unknown"),
+    }
+
+
+def escalation(policy: dict[str, Any], root: dict[str, Any]) -> tuple[str, str, dict[str, Any], str | None]:
+    attempt = root.get("attempt_state", {})
+    if not isinstance(attempt, dict):
+        attempt = {}
+    state = attempt.get("outcome", "planned")
+    count = attempt.get("escalation_count", 0)
+    max_count = policy.get("automatic_budget", {}).get("max_escalations_per_work_unit", 0)
+    if state == "human_owned":
+        return "balanced", "medium", {"required": True, "persists": False}, "Human-owned action requires a Human decision"
+    if state == "escalation_candidate":
+        if not attempt.get("evidence"):
+            return "balanced", "medium", {"required": True, "persists": False}, "Escalation lacks explicit evidence"
+        if not isinstance(count, int) or count >= max_count:
+            return "balanced", "medium", {"required": True, "persists": False}, "Escalation budget exhausted; Human decision required"
+        return "frontier", "high", {"required": True, "persists": False, "after_work_unit": True}, None
+    if state == "downgrade_candidate":
+        return "economy", "low", {"required": True, "persists": False, "after_work_unit": True}, None
+    return "balanced", "medium", {"required": True, "persists": False, "after_work_unit": True}, None
+
+
+def candidate(
+    candidate_id: str,
+    topology: str,
+    context_mode: str,
+    reason: str,
+    cost: str,
+    quality: int,
+    tier: str,
+    reasoning: str,
+    runtime_mapping: dict[str, Any],
+    eligible: bool = True,
+    failures: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "candidate_id": candidate_id,
+        "topology": topology,
+        "context_mode": context_mode,
+        "reason": reason,
+        "eligible": eligible,
+        "ineligible_reasons": failures or [],
+        "expected_cost_band": cost,
+        "expected_quality_band": {1: "low", 2: "medium", 3: "high"}[quality],
+        "expected_evidence_strength": {1: "low", 2: "medium", 3: "high"}[quality],
+        "requested_capability_tier": tier,
+        "requested_reasoning_tier": reasoning,
+        "runtime_mapping": runtime_mapping,
+        "confidence": "low" if runtime_mapping.get("effective_configuration") != "observed" else "medium",
+    }
+
+
+def route_runtime(runtime: dict[str, Any], topology: str, envelope_required: bool) -> tuple[dict[str, Any], list[str]]:
+    if topology == "serial":
+        return {"mechanism": "current_session", "status": "supported", "effective_configuration": "unknown", "enforcement": "not_required"}, []
+    found = mechanism(runtime, TOPOLOGY_MECHANISMS[topology])
+    failures: list[str] = []
+    if found["status"] != "supported":
+        failures.append(f"runtime mechanism {found['name']} is {found['status']}")
+    if topology in {"fork"}:
+        failures.append("fork is non-enforcing under the current capability evidence")
+    if envelope_required and not found["supports_explicit_envelope"]:
+        failures.append("explicit runtime envelope required but unsupported")
+    found["enforcement"] = "requested_explicit_envelope" if found["supports_explicit_envelope"] else "enforcement_not_available"
+    if found["effective_configuration"] not in {"observed", "unknown", "not_available"}:
+        found["effective_configuration"] = "unknown"
+    return found, failures
+
+
+def runtime_limitations(runtime: dict[str, Any]) -> list[dict[str, Any]]:
+    limitations: list[dict[str, Any]] = []
+    for mechanism_name, posture in (
+        ("fork_thread", "non_enforcing"),
+        ("heartbeat", "non_enforcing"),
+        ("hook", "unsupported"),
+        ("custom_agent", "unsupported"),
+    ):
+        found = mechanism(runtime, mechanism_name)
+        limitations.append(
+            {
+                "mechanism": mechanism_name,
+                "runtime_status": found["status"],
+                "enforcement": posture,
+                "effective_configuration": found["effective_configuration"],
+            }
+        )
+    return limitations
+
+
+def validate_override(root: dict[str, Any], work: dict[str, Any]) -> tuple[dict[str, Any], str | None]:
+    override = root.get("override_grant")
+    if override is None:
+        return {"active": False, "scope": "not_available", "expires_after_work_unit": True, "reset_required": True}, None
+    if not isinstance(override, dict):
+        fail("override_grant must be an object")
+    normalized = {
+        "active": override.get("active", False) is True,
+        "scope": override.get("scope", "not_available"),
+        "expires_after_work_unit": override.get("expires_after_work_unit", True) is True,
+        "reset_required": override.get("reset_required", True) is True,
+    }
+    if not normalized["active"]:
+        return normalized, None
+    if normalized["scope"] != work["work_unit_id"]:
+        return normalized, "Active override grant scope does not match this work unit"
+    if not normalized["expires_after_work_unit"] or not normalized["reset_required"]:
+        return normalized, "Active override grant must expire and reset after this work unit"
+    return normalized, None
+
+
+def plan(root: dict[str, Any]) -> dict[str, Any]:
+    policy, work, role, runtime = validate_input(root)
+    override, override_stop = validate_override(root, work)
+    tier, reasoning, reset, early_stop = escalation(policy, root)
+    human_actions = work.get("human_owned_actions", [])
+    if not isinstance(human_actions, list):
+        fail("work_unit.human_owned_actions must be a list")
+    if human_actions or work.get("requires_human_decision") is True or early_stop or override_stop:
+        reason = early_stop or override_stop or "Human-owned action requires a Human decision"
+        return result(root, [], "human_stop", None, [reason], reset, tier, reasoning, override)
+
+    required_independence = role.get("independence_requirement", "none")
+    envelope_required = work.get("requires_explicit_envelope", False) is True
+    quality_floor = 3 if required_independence != "none" or role.get("specialization_available") is True else 2
+    candidates: list[dict[str, Any]] = []
+    serial_quality = 1 if required_independence != "none" else 2
+    serial = candidate(
+        "serial-current-session", "serial", "compact", "No material dispatch benefit is assumed by default.", "low", serial_quality,
+        tier, reasoning, {"mechanism": "current_session", "status": "supported", "effective_configuration": "unknown", "enforcement": "not_required"},
+        eligible=serial_quality >= quality_floor,
+        failures=[] if serial_quality >= quality_floor else ["required independent context/evidence cannot be provided by serial work"],
+    )
+    candidates.append(serial)
+
+    continuity = role.get("continuity_value", "none")
+    relevance = role.get("context_relevance", "low")
+    if continuity in {"medium", "high"} and relevance in {"medium", "high"}:
+        mapping, failures = route_runtime(runtime, "durable_thread", envelope_required)
+        candidates.append(candidate("durable-relevant-role-context", "durable_thread", "filtered_history", "Relevant durable continuity can reduce rehydration cost.", "low", 3, tier, reasoning, mapping, not failures, failures))
+
+    needs_fresh = role.get("specialization_available") is True or required_independence != "none" or relevance == "low"
+    if needs_fresh:
+        mapping, failures = route_runtime(runtime, "fresh_thread", envelope_required)
+        quality = 3 if role.get("specialization_available") is True or required_independence != "none" else 2
+        candidates.append(candidate("fresh-specialized-or-independent", "fresh_thread", "fresh", "Fresh context avoids unrelated retained history and supports specialization or independence.", "medium", quality, tier, reasoning, mapping, not failures and quality >= quality_floor, failures + ([] if quality >= quality_floor else ["quality floor not met"])))
+
+    if work.get("safe_parallelism") is True:
+        mapping, failures = route_runtime(runtime, "subagent", envelope_required)
+        candidates.append(candidate("bounded-subagent", "subagent", "artifact_reference", "Safe disjoint side work may reduce critical-path latency.", "medium", 2, tier, reasoning, mapping, not failures and 2 >= quality_floor, failures + ([] if 2 >= quality_floor else ["quality floor not met"])))
+
+    for topology, reason in (("fork", "Fork route is recorded as non-enforcing."), ("portable", "Portable fallback cannot enforce runtime settings.")):
+        mapping, failures = route_runtime(runtime, topology, envelope_required)
+        candidates.append(candidate(f"{topology}-negative-control", topology, "full_continuity" if topology == "fork" else "artifact_reference", reason, "medium", 1, tier, reasoning, mapping, False, failures or ["unsupported advisory fallback below quality floor"]))
+
+    candidates = candidates[:4]
+    eligible = [item for item in candidates if item["eligible"]]
+    if not eligible:
+        return result(root, candidates, "human_stop", None, ["No route meets the authority, evidence, and runtime quality floor."], reset, tier, reasoning, override)
+    material_benefit = any((role.get("specialization_available") is True, continuity in {"medium", "high"} and relevance in {"medium", "high"}, required_independence != "none", work.get("safe_parallelism") is True))
+    selected = sorted(eligible, key=lambda item: (COST_RANK[item["expected_cost_band"]], -{"low": 1, "medium": 2, "high": 3}[item["expected_quality_band"]], item["candidate_id"]))[0]
+    decision = "dispatch_advisory" if material_benefit and selected["topology"] != "serial" else "no_dispatch"
+    if decision == "no_dispatch":
+        selected = next(item for item in eligible if item["topology"] == "serial")
+    return result(root, candidates, decision, selected, [], reset, tier, reasoning, override)
+
+
+def result(root: dict[str, Any], candidates: list[dict[str, Any]], decision: str, selected: dict[str, Any] | None, stops: list[str], reset: dict[str, Any], tier: str, reasoning: str, override: dict[str, Any]) -> dict[str, Any]:
+    runtime = root["runtime_capabilities"]
+    confidence = "low" if any(item.get("runtime_mapping", {}).get("effective_configuration") == "unknown" for item in candidates) else "medium"
+    return {
+        "policy_set": root["policy_set"],
+        "work_unit": root["work_unit"],
+        "role_context": root["role_context"],
+        "runtime_capabilities": {"observed_at": runtime.get("observed_at", "not_available"), "mechanisms": runtime.get("mechanisms", {})},
+        "runtime_limitations": runtime_limitations(runtime),
+        "route_candidates": candidates,
+        "dispatch_plan": {
+            "route_decision": decision,
+            "selected_candidate": selected,
+            "explanation": pareto_explanation(candidates, selected, decision),
+            "runtime_mapping": selected.get("runtime_mapping") if selected else {"enforcement": "not_available"},
+            "requested_capability_tier": tier,
+            "requested_reasoning_tier": reasoning,
+            "reset": reset,
+            "stop_conditions": stops + root["work_unit"].get("stop_conditions", []),
+            "confidence": confidence,
+        },
+        "override_grant": override,
+        "evaluation_record": {
+            "work_unit_id": root["work_unit"]["work_unit_id"],
+            "outcome": "not_executed",
+            "estimate_band": selected.get("expected_cost_band") if selected else "not_available",
+            "confidence": confidence,
+            "quality_guardrails": ["authority", "verification", "independence", "runtime_capability"],
+            "prior_records_considered": len(root.get("evaluation_records", [])) if isinstance(root.get("evaluation_records", []), list) else "not_available",
+        },
+        "mutation_performed": False,
+        "dispatch_performed": False,
+        "enforcement_posture": root["policy_set"].get("enforcement", {}).get("mode", "advisory"),
+    }
+
+
+def pareto_explanation(candidates: list[dict[str, Any]], selected: dict[str, Any] | None, decision: str) -> list[str]:
+    eligible = [item for item in candidates if item["eligible"]]
+    explanation = [f"candidate_set={len(candidates)}; eligible={len(eligible)}; limit=4"]
+    if decision == "human_stop":
+        explanation.append("No eligible advisory route clears the required authority/evidence/runtime floor.")
+    elif decision == "no_dispatch":
+        explanation.append("Serial is selected because no material dispatch benefit clears its handoff and context cost.")
+    elif selected:
+        explanation.append(f"Selected {selected['candidate_id']} as the least-cost eligible route that clears the quality floor.")
+    return explanation
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-json", required=True, help="Portable route-planning input JSON.")
+    parser.add_argument("--json", action="store_true", help="Emit JSON. This is the default output format.")
+    args = parser.parse_args()
+    try:
+        output = plan(load_input(args.input_json))
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"route_planner_error: {error}", file=sys.stderr)
+        return 2
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_collaboration_route_planner.py
+++ b/scripts/test_collaboration_route_planner.py
@@ -51,7 +51,7 @@ def expect(name: str, condition: bool, detail: object) -> list[str]:
 def main() -> int:
     errors: list[str] = []
     schema = SCHEMA.read_text(encoding="utf-8")
-    for anchor in ("PolicySet", "WorkUnit", "RoleContext", "RuntimeCapabilities", "RouteCandidate", "DispatchPlan", "OverrideGrant", "EvaluationRecord", "provider, provider_slug, model, or model_slug"):
+    for anchor in ("PolicySet", "WorkUnit", "RoleContext", "RuntimeCapabilities", "RouteCandidate", "DispatchPlan", "OverrideGrant", "EvaluationRecord", "ConversationProjection", "policy_profile", "task_class", "provider, provider_slug, model, or model_slug"):
         errors.extend(expect(f"schema-{anchor}", anchor in schema, "missing schema anchor"))
 
     no_dispatch = base_fixture()
@@ -61,6 +61,57 @@ def main() -> int:
         errors.extend(expect("no-dispatch", output["dispatch_plan"]["route_decision"] == "no_dispatch", output))
         errors.extend(expect("no-mutation", output["mutation_performed"] is False and output["dispatch_performed"] is False, output))
         errors.extend(expect("candidate-limit", len(output["route_candidates"]) <= 4, output))
+        projection = output["conversation_projection"]
+        errors.extend(expect("unsaved-normal-default", projection["effective_policy"] == {"profile": "normal", "source": "unsaved_normal_default", "validity": "unsaved_default", "fingerprint_or_unsaved_default": "unsaved-normal-default"}, projection))
+
+    routine = base_fixture()
+    routine["work_unit"].update({"task_class": "routine", "material_signals": []})
+    code, output = run_fixture(routine)
+    if code == 0:
+        errors.extend(expect("routine-quiet", output["conversation_projection"]["emit_compact_marker"] is False and output["conversation_projection"]["next_action"] == "Continue serial work; no dispatch action is requested", output))
+
+    setup_intent = base_fixture()
+    setup_intent["policy_setup_requested"] = True
+    code, output = run_fixture(setup_intent)
+    if code == 0:
+        intent = output["conversation_projection"]["policy_setup_intent"]
+        errors.extend(expect("setup-intent-no-write", intent == {"requested": True, "apply_supported_now": False, "write_performed": False} and output["conversation_projection"]["next_action"].startswith("Set up collaboration policy"), output))
+
+    material = base_fixture()
+    material["work_unit"].update({"task_class": "complex", "material_signals": ["cross_boundary", "contradictory_evidence"], "task_class_correction": {"task_class": "complex", "scope": "AF18-fixture", "expires_after_work_unit": True}})
+    material["policy_sources"] = {"personal": {"validity": "valid", "profile": "high_performance", "fingerprint": "sha256:personal", "policy_set": material["policy_set"]}}
+    code, output = run_fixture(material)
+    if code == 0:
+        projection = output["conversation_projection"]
+        errors.extend(expect("material-correction", projection["work_unit"]["correction"]["applied"] is True and projection["recommendation"]["abstract_tier"] == {"capability": "frontier", "reasoning": "high"}, output))
+        errors.extend(expect("material-marker", projection["emit_compact_marker"] is True, projection))
+
+    retained = base_fixture()
+    retained["policy_sources"] = {
+        "project": {"validity": "drifted", "profile": "high_performance", "fingerprint": "sha256:drifted"},
+        "personal": {"validity": "valid", "profile": "economy", "fingerprint": "sha256:prior", "policy_set": retained["policy_set"]},
+    }
+    code, output = run_fixture(retained)
+    if code == 0:
+        projection = output["conversation_projection"]
+        errors.extend(expect("prior-policy-retention", projection["effective_policy"]["source"] == "personal" and projection["effective_policy"]["fingerprint_or_unsaved_default"] == "sha256:prior", output))
+        errors.extend(expect("drifted-source-visible", any(item["validity"] == "drifted" for item in projection["evidence"]["policy_source_checks"]) and projection["recovery"]["writes_performed"] is False, output))
+
+    invalid = base_fixture()
+    invalid["policy_sources"] = {"project": {"validity": "invalid", "profile": "normal"}}
+    code, output = run_fixture(invalid)
+    if code == 0:
+        errors.extend(expect("invalid-source-unsaved-recovery", output["conversation_projection"]["effective_policy"]["source"] == "unsaved_normal_default" and any("invalid or drifted" in attention for attention in output["conversation_projection"]["attention"]), output))
+
+    precedence = base_fixture()
+    precedence["policy_sources"] = {
+        "current_work_unit_grant": {"validity": "valid", "profile": "high_performance", "fingerprint": "sha256:grant", "policy_set": precedence["policy_set"]},
+        "project": {"validity": "valid", "profile": "economy", "fingerprint": "sha256:project", "policy_set": precedence["policy_set"]},
+        "personal": {"validity": "valid", "profile": "normal", "fingerprint": "sha256:personal", "policy_set": precedence["policy_set"]},
+    }
+    code, output = run_fixture(precedence)
+    if code == 0:
+        errors.extend(expect("policy-precedence", output["conversation_projection"]["effective_policy"]["source"] == "current_work_unit_grant" and output["conversation_projection"]["effective_policy"]["fingerprint_or_unsaved_default"] == "sha256:grant", output))
 
     durable = base_fixture()
     durable["role_context"].update({"continuity_value": "high", "context_relevance": "high"})
@@ -96,6 +147,14 @@ def main() -> int:
     code, output = run_fixture(omitted)
     if code == 0:
         errors.extend(expect("omitted-envelope-human-stop", output["dispatch_plan"]["route_decision"] == "human_stop", output))
+        errors.extend(expect("omitted-envelope-observable-unknown", output["conversation_projection"]["runtime_projection"]["observable"]["effective_configuration"] == "unknown", output))
+
+    unknown_runtime = base_fixture()
+    unknown_runtime["role_context"].update({"specialization_available": True})
+    unknown_runtime["runtime_capabilities"]["mechanisms"]["create_thread"]["status"] = "unknown"
+    code, output = run_fixture(unknown_runtime)
+    if code == 0:
+        errors.extend(expect("unknown-runtime-human-stop", output["dispatch_plan"]["route_decision"] == "human_stop" and output["conversation_projection"]["runtime_projection"]["observable"]["status"] == "unknown", output))
 
     unsupported = base_fixture()
     unsupported["runtime_capabilities"]["mechanisms"]["fork_thread"]["status"] = "unsupported"
@@ -110,6 +169,7 @@ def main() -> int:
 
     escalation = base_fixture()
     escalation["role_context"].update({"specialization_available": True})
+    escalation["work_unit"].update({"task_class": "complex", "material_signals": ["contradictory_evidence"]})
     escalation["attempt_state"] = {"outcome": "escalation_candidate", "escalation_count": 0, "evidence": "contradictory verification"}
     code, output = run_fixture(escalation)
     if code == 0:

--- a/scripts/test_collaboration_route_planner.py
+++ b/scripts/test_collaboration_route_planner.py
@@ -96,6 +96,7 @@ def main() -> int:
         projection = output["conversation_projection"]
         errors.extend(expect("prior-policy-retention", projection["effective_policy"]["source"] == "personal" and projection["effective_policy"]["fingerprint_or_unsaved_default"] == "sha256:prior", output))
         errors.extend(expect("drifted-source-visible", any(item["validity"] == "drifted" for item in projection["evidence"]["policy_source_checks"]) and projection["recovery"]["writes_performed"] is False, output))
+        errors.extend(expect("retained-policy-recovery-action", projection["next_action"] == "Inspect the invalid or drifted policy source; continue with the retained valid policy shown above", projection))
 
     invalid = base_fixture()
     invalid["policy_sources"] = {"project": {"validity": "invalid", "profile": "normal"}}

--- a/scripts/test_collaboration_route_planner.py
+++ b/scripts/test_collaboration_route_planner.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Fixture regressions for the AF18 portable route planner."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PLANNER = ROOT / "scripts" / "plan_collaboration_routes.py"
+SCHEMA = ROOT / "schemas" / "collaboration-routing-policy.schema.yaml"
+
+
+def base_fixture() -> dict:
+    return {
+        "policy_set": {
+            "schema_version": 1,
+            "policy_id": "af18-test",
+            "quality_floor": {"required_verification": "task_risk_based"},
+            "automatic_budget": {"max_escalations_per_work_unit": 1},
+            "allowed_tiers": {"capability": ["economy", "balanced", "frontier"], "reasoning": ["low", "medium", "high"]},
+            "enforcement": {"mode": "advisory"},
+        },
+        "work_unit": {"work_unit_id": "AF18-fixture", "purpose": "bounded planner fixture", "risk": "medium", "ambiguity": "low", "verification_oracle": "fixture assertions", "stop_conditions": ["contract drift"]},
+        "role_context": {"required_role": "implementer", "specialization_available": False, "continuity_value": "none", "context_relevance": "low", "independence_requirement": "none"},
+        "runtime_capabilities": {"observed_at": "2026-07-21T00:00:00Z", "mechanisms": {"create_thread": {"status": "supported", "supports_explicit_envelope": True, "effective_configuration": "unknown"}, "send_message_to_thread": {"status": "supported", "supports_explicit_envelope": True, "effective_configuration": "unknown"}, "spawn_agent": {"status": "supported", "supports_explicit_envelope": True, "effective_configuration": "unknown"}, "fork_thread": {"status": "supported", "supports_explicit_envelope": False, "effective_configuration": "unknown"}, "portable_prompt": {"status": "supported", "supports_explicit_envelope": False, "effective_configuration": "not_available"}}},
+    }
+
+
+def run_fixture(data: dict) -> tuple[int, dict | str]:
+    with tempfile.TemporaryDirectory(prefix="af18-route-") as tmp:
+        path = Path(tmp) / "fixture.json"
+        path.write_text(json.dumps(data), encoding="utf-8")
+        result = subprocess.run([sys.executable, str(PLANNER), "--input-json", str(path), "--json"], text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if result.returncode:
+            return result.returncode, result.stderr
+        return 0, json.loads(result.stdout)
+
+
+def expect(name: str, condition: bool, detail: object) -> list[str]:
+    if condition:
+        print(f"{name}: ok")
+        return []
+    return [f"{name}: {detail}"]
+
+
+def main() -> int:
+    errors: list[str] = []
+    schema = SCHEMA.read_text(encoding="utf-8")
+    for anchor in ("PolicySet", "WorkUnit", "RoleContext", "RuntimeCapabilities", "RouteCandidate", "DispatchPlan", "OverrideGrant", "EvaluationRecord", "provider, provider_slug, model, or model_slug"):
+        errors.extend(expect(f"schema-{anchor}", anchor in schema, "missing schema anchor"))
+
+    no_dispatch = base_fixture()
+    code, output = run_fixture(no_dispatch)
+    errors.extend(expect("no-dispatch-exit", code == 0, output))
+    if code == 0:
+        errors.extend(expect("no-dispatch", output["dispatch_plan"]["route_decision"] == "no_dispatch", output))
+        errors.extend(expect("no-mutation", output["mutation_performed"] is False and output["dispatch_performed"] is False, output))
+        errors.extend(expect("candidate-limit", len(output["route_candidates"]) <= 4, output))
+
+    durable = base_fixture()
+    durable["role_context"].update({"continuity_value": "high", "context_relevance": "high"})
+    durable["work_unit"]["requires_explicit_envelope"] = True
+    code, output = run_fixture(durable)
+    if code == 0:
+        errors.extend(expect("durable-route", output["dispatch_plan"]["selected_candidate"]["topology"] == "durable_thread", output))
+
+    fresh = base_fixture()
+    fresh["role_context"].update({"specialization_available": True, "continuity_value": "none", "context_relevance": "low"})
+    code, output = run_fixture(fresh)
+    if code == 0:
+        errors.extend(expect("specialist-fresh-route", output["dispatch_plan"]["selected_candidate"]["topology"] == "fresh_thread", output))
+
+    unrelated = base_fixture()
+    unrelated["role_context"].update({"continuity_value": "high", "context_relevance": "low"})
+    code, output = run_fixture(unrelated)
+    if code == 0:
+        topologies = {item["topology"] for item in output["route_candidates"]}
+        errors.extend(expect("unrelated-history-avoids-durable", "durable_thread" not in topologies and "fresh_thread" in topologies, output))
+        errors.extend(expect("unrelated-history-no-dispatch", output["dispatch_plan"]["route_decision"] == "no_dispatch", output))
+
+    review = base_fixture()
+    review["role_context"].update({"required_role": "reviewer", "specialization_available": True, "independence_requirement": "separate_evidence"})
+    code, output = run_fixture(review)
+    if code == 0:
+        errors.extend(expect("independent-review", output["dispatch_plan"]["selected_candidate"]["topology"] == "fresh_thread", output))
+
+    omitted = base_fixture()
+    omitted["role_context"].update({"specialization_available": True, "independence_requirement": "separate_context"})
+    omitted["work_unit"]["requires_explicit_envelope"] = True
+    omitted["runtime_capabilities"]["mechanisms"]["create_thread"]["supports_explicit_envelope"] = False
+    code, output = run_fixture(omitted)
+    if code == 0:
+        errors.extend(expect("omitted-envelope-human-stop", output["dispatch_plan"]["route_decision"] == "human_stop", output))
+
+    unsupported = base_fixture()
+    unsupported["runtime_capabilities"]["mechanisms"]["fork_thread"]["status"] = "unsupported"
+    code, output = run_fixture(unsupported)
+    if code == 0:
+        fork = next(item for item in output["route_candidates"] if item["topology"] == "fork")
+        errors.extend(expect("fork-non-enforcing", fork["eligible"] is False and fork["runtime_mapping"]["enforcement"] == "enforcement_not_available", fork))
+        limitations = {item["mechanism"]: item for item in output["runtime_limitations"]}
+        errors.extend(expect("heartbeat-non-enforcing", limitations["heartbeat"]["enforcement"] == "non_enforcing", limitations))
+        errors.extend(expect("hook-unsupported", limitations["hook"]["enforcement"] == "unsupported", limitations))
+        errors.extend(expect("custom-agent-unsupported", limitations["custom_agent"]["enforcement"] == "unsupported", limitations))
+
+    escalation = base_fixture()
+    escalation["role_context"].update({"specialization_available": True})
+    escalation["attempt_state"] = {"outcome": "escalation_candidate", "escalation_count": 0, "evidence": "contradictory verification"}
+    code, output = run_fixture(escalation)
+    if code == 0:
+        plan = output["dispatch_plan"]
+        errors.extend(expect("escalation-reset", plan["requested_capability_tier"] == "frontier" and plan["reset"]["persists"] is False, plan))
+
+    human = base_fixture()
+    human["work_unit"]["human_owned_actions"] = ["approve external cost"]
+    code, output = run_fixture(human)
+    if code == 0:
+        errors.extend(expect("human-stop", output["dispatch_plan"]["route_decision"] == "human_stop" and output["route_candidates"] == [], output))
+
+    invalid_override = base_fixture()
+    invalid_override["override_grant"] = {"active": True, "scope": "another-work-unit", "expires_after_work_unit": True, "reset_required": True}
+    code, output = run_fixture(invalid_override)
+    if code == 0:
+        errors.extend(expect("override-scope-human-stop", output["dispatch_plan"]["route_decision"] == "human_stop" and "scope does not match" in output["dispatch_plan"]["stop_conditions"][0], output))
+
+    forbidden = base_fixture()
+    forbidden["policy_set"]["model_slug"] = "not-portable"
+    code, output = run_fixture(forbidden)
+    errors.extend(expect("portable-policy-rejects-model", code != 0 and "forbids provider/model identifiers" in str(output), output))
+
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflows/github-collaboration-helper.md
+++ b/workflows/github-collaboration-helper.md
@@ -52,6 +52,33 @@ Useful smoke commands:
 The last command must fail closed because `agent-label` mutates scheduler
 ownership and is outside AF11 activation scope.
 
+## Portable Route Planning
+
+AF18 provides a read-only, portable route-planning surface at
+`scripts/plan_collaboration_routes.py`. It consumes a JSON fixture containing
+PolicySet, WorkUnit, RoleContext, RuntimeCapabilities, an optional
+OverrideGrant, and prior EvaluationRecord evidence. It returns a bounded
+DispatchPlan with at most four candidates, a Pareto-style explanation, explicit
+confidence, reset, and Human-stop conditions.
+
+The planner is advisory only: it always reports `mutation_performed: false` and
+`dispatch_performed: false`. It does not create, fork, resume, or message a
+thread; it does not start subagents or automation; and it does not change
+runtime settings. Portable policy uses named capability/reasoning tiers rather
+than provider or model identifiers. Missing effective retained settings remain
+`unknown`; fork and heartbeat are non-enforcing; hook and custom-agent
+enforcement remain unsupported until a later Human-gated adapter scope.
+
+Example:
+
+```bash
+python3 scripts/plan_collaboration_routes.py --input-json route-fixture.json --json
+```
+
+Treat a `human_stop` result as a decision boundary, not a failed dispatch. A
+later runtime adapter may map an accepted advisory plan to supported tool calls;
+that adapter is outside this workflow slice.
+
 ## User-Facing Entry Points
 
 Agents should expose these as natural-language workflows rather than requiring

--- a/workflows/github-collaboration-helper.md
+++ b/workflows/github-collaboration-helper.md
@@ -61,6 +61,16 @@ OverrideGrant, and prior EvaluationRecord evidence. It returns a bounded
 DispatchPlan with at most four candidates, a Pareto-style explanation, explicit
 confidence, reset, and Human-stop conditions.
 
+The conversation-facing projection resolves policy deterministically: current
+work-unit Human grant, project record, personal record, then an explicitly
+labelled unsaved `normal` default. It exposes the selected profile, source,
+validity, and fingerprint or `unsaved-normal-default`; invalid or drifted
+sources remain visible. It also projects task class, bounded one-work-unit
+corrections, material signals, a compact recommendation, requested-versus-
+observable runtime state, attention, and exactly one next action. Routine
+serial/no-dispatch work suppresses a separate marker unless attention or a
+material correction exists.
+
 The planner is advisory only: it always reports `mutation_performed: false` and
 `dispatch_performed: false`. It does not create, fork, resume, or message a
 thread; it does not start subagents or automation; and it does not change
@@ -78,6 +88,12 @@ python3 scripts/plan_collaboration_routes.py --input-json route-fixture.json --j
 Treat a `human_stop` result as a decision boundary, not a failed dispatch. A
 later runtime adapter may map an accepted advisory plan to supported tool calls;
 that adapter is outside this workflow slice.
+
+This planner does not set up, write, read back, or retain personal/project
+policy records. It does not create telemetry, a monitoring history, dashboard,
+or report product. The JSON result is secondary technical evidence; a later
+conversation surface owns compact Human-facing wording and a later lifecycle
+slice owns any approved policy-record write/readback path.
 
 ## User-Facing Entry Points
 


### PR DESCRIPTION
## Summary

Implements AF18 #420 only: a versioned portable policy schema and deterministic advisory route planner.

- Adds portable PolicySet, WorkUnit, RoleContext, RuntimeCapabilities, RouteCandidate, DispatchPlan, OverrideGrant, and EvaluationRecord schema anchors.
- Adds a read-only JSON planner with bounded candidate selection, Human stops, escalation/reset, runtime limitations, and provider/model-slug rejection.
- Adds fixture regressions for no-dispatch, durable/fresh routes, unrelated history, independent review, omitted envelopes, fork/heartbeat/hook/custom-agent limitations, escalation/reset, Human stops, and override scope.

## Verification

- `python3 -m py_compile scripts/plan_collaboration_routes.py scripts/test_collaboration_route_planner.py`
- `python3 scripts/test_collaboration_route_planner.py`
- `python3 scripts/check_consistency.py`
- `git diff --check origin/codex/af18-collaboration-cost-policy-integration...HEAD`

## Execution Contract

Owner role: implementer
Review role: reviewer
Acceptance role: architect
Completion handoff: to:tester
Branch strategy: integration-branch
Target branch: codex/af18-collaboration-cost-policy-integration

## Boundaries

The planner is advisory only: `mutation_performed: false` and `dispatch_performed: false`. It does not invoke, create, fork, or send threads/subagents; it does not implement #421 adapters or mutate runtime, configuration, Vault, generated output, or Project state.