### PR TITLE
AF18 #421 Add Codex route adapter dry-run pilot

### DIFF
--- a/scripts/plan_codex_route_adapter.py
+++ b/scripts/plan_codex_route_adapter.py
@@ -78,7 +78,16 @@ def validate_observation(root: dict[str, Any]) -> tuple[dict[str, Any] | None, d
     age_seconds = abs((evaluated_at - observed_at).total_seconds())
     if age_seconds > max_age:
         return None, {"status": "stale", "reason": f"schema observation is stale by {int(age_seconds)} seconds"}
-    return observation, {"status": "current", "reason": "host-collected current schema observation validated", "age_seconds": int(age_seconds)}
+    # This JSON-only adapter has no runtime-owned schema capture or verifier.
+    # Caller-provided fields can be internally consistent without proving the
+    # executing host currently exposes the reported tools.
+    return None, {
+        "status": "unknown",
+        "reason": "runtime-owned Codex schema capture is unavailable; caller-supplied observation is unverified",
+        "evidence_ref": provenance["evidence_ref"],
+        "evidence_ref_status": "unverified",
+        "reported_age_seconds": int(age_seconds),
+    }
 
 
 def tool_observation(schema: dict[str, Any], tool_name: str) -> dict[str, Any]:
@@ -158,7 +167,7 @@ def project(root: dict[str, Any]) -> dict[str, Any]:
     if schema is None:
         return output(
             portable, topology, None, "unknown", [provenance["reason"]],
-            "Collect a current host-observed Codex tool schema before proposing any envelope.", provenance=provenance,
+            "Obtain a verified runtime-owned Codex schema capture before proposing any envelope.", provenance=provenance,
         )
     tool_name, required_fields = TOPOLOGY_TO_TOOL[topology]
     observed = tool_observation(schema, tool_name)

--- a/scripts/plan_codex_route_adapter.py
+++ b/scripts/plan_codex_route_adapter.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Project an AF18 portable plan into a dry-run Codex adapter envelope."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+
+TOPOLOGY_TO_TOOL = {
+    "durable_thread": ("send_message_to_thread", ("model", "thinking")),
+    "fresh_thread": ("create_thread", ("model", "thinking")),
+    "subagent": ("spawn_agent", ("model", "reasoning_effort")),
+    "fork": ("fork_thread", ()),
+}
+VALID_STATUSES = {"supported", "unsupported", "unknown", "degraded", "not_available"}
+
+
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+def load_input(path: str) -> dict[str, Any]:
+    value = json.loads(open(path, encoding="utf-8").read())
+    if not isinstance(value, dict):
+        fail("adapter input must be a JSON object")
+    return value
+
+
+def require_object(root: dict[str, Any], name: str) -> dict[str, Any]:
+    value = root.get(name)
+    if not isinstance(value, dict):
+        fail(f"missing object: {name}")
+    return value
+
+
+def tool_observation(schema: dict[str, Any], tool_name: str) -> dict[str, Any]:
+    tools = schema.get("tools")
+    if not isinstance(tools, dict):
+        fail("schema_observation.tools must be an object")
+    observed = tools.get(tool_name, {})
+    if not isinstance(observed, dict):
+        observed = {}
+    status = observed.get("status", "not_available")
+    if status not in VALID_STATUSES:
+        status = "unknown"
+    fields = observed.get("fields", [])
+    if not isinstance(fields, list) or not all(isinstance(field, str) for field in fields):
+        fields = []
+    return {
+        "tool": tool_name,
+        "status": status,
+        "fields": fields,
+        "observed_at": schema.get("observed_at", "not_available"),
+        "schema_source": schema.get("schema_source", "not_available"),
+    }
+
+
+def resolve_envelope(root: dict[str, Any], tool_name: str, required_fields: tuple[str, ...], capability: str) -> tuple[dict[str, Any] | None, list[str]]:
+    envelopes = root.get("adapter_envelopes", {})
+    if not isinstance(envelopes, dict):
+        fail("adapter_envelopes must be an object")
+    envelope = envelopes.get(capability)
+    if not isinstance(envelope, dict):
+        return None, [f"adapter-local envelope for {capability} is absent"]
+    mapped: dict[str, Any] = {}
+    failures: list[str] = []
+    for field in required_fields:
+        value = envelope.get(field)
+        if not isinstance(value, str) or not value:
+            failures.append(f"adapter-local envelope is missing {field}")
+        else:
+            mapped[field] = value
+    return (mapped if not failures else None), failures
+
+
+def lifecycle_evidence(portable: dict[str, Any], topology: str) -> dict[str, Any]:
+    work = portable.get("work_unit", {})
+    return {
+        "work_unit_id": work.get("work_unit_id", "not_available"),
+        "scope": "one_work_unit",
+        "reset_after_attempt": True,
+        "topology": topology,
+        "close_archive_resume": "not_executed_dry_run_only",
+        "lifecycle_mutation_performed": False,
+    }
+
+
+def project(root: dict[str, Any]) -> dict[str, Any]:
+    portable = require_object(root, "portable_plan")
+    schema = require_object(root, "schema_observation")
+    dispatch_plan = require_object(portable, "dispatch_plan")
+    conversation = require_object(portable, "conversation_projection")
+    decision = dispatch_plan.get("route_decision")
+    selected = dispatch_plan.get("selected_candidate")
+    if decision not in {"no_dispatch", "dispatch_advisory", "human_stop"}:
+        fail("portable dispatch_plan.route_decision is invalid")
+    if decision != "dispatch_advisory":
+        return output(
+            portable, None, None, "no_adapter_dispatch", [],
+            "Continue the portable no-dispatch or Human-stop path; no Codex tool call is proposed.",
+        )
+    if not isinstance(selected, dict):
+        fail("portable dispatch advisory requires selected_candidate")
+    topology = selected.get("topology")
+    if topology not in TOPOLOGY_TO_TOOL:
+        return output(
+            portable, topology, None, "unsupported", [f"Codex adapter has no supported mapping for topology {topology}"],
+            "Choose a supported fresh, durable, or subagent route, or stop for a Human decision.",
+        )
+    tool_name, required_fields = TOPOLOGY_TO_TOOL[topology]
+    observed = tool_observation(schema, tool_name)
+    requested = dispatch_plan.get("requested_capability_tier", "not_available")
+    requires_explicit = portable.get("work_unit", {}).get("requires_explicit_envelope", False) is True
+    attention: list[str] = []
+    if observed["status"] != "supported":
+        attention.append(f"Codex tool {tool_name} is {observed['status']}")
+    if not required_fields:
+        attention.append(f"Codex tool {tool_name} has no explicit envelope fields")
+    missing_fields = [field for field in required_fields if field not in observed["fields"]]
+    if missing_fields:
+        attention.append(f"Codex tool {tool_name} is missing observed fields: {', '.join(missing_fields)}")
+    envelope, envelope_failures = resolve_envelope(root, tool_name, required_fields, requested)
+    if envelope_failures:
+        attention.extend(envelope_failures)
+    if requires_explicit and attention:
+        return output(
+            portable, topology, observed, "unsupported", attention,
+            "Provide a currently supported explicit Codex envelope or keep the portable plan at no dispatch.",
+        )
+    if attention:
+        return output(
+            portable, topology, observed, "human_stop", attention,
+            "Do not inherit unknown Codex settings; provide an explicit envelope or stop for a Human decision.",
+        )
+    return output(
+        portable, topology, observed, "dry_run_ready", [],
+        "Review this dry-run Codex envelope before any separately authorized dispatch.", envelope,
+    )
+
+
+def output(portable: dict[str, Any], topology: str | None, observed: dict[str, Any] | None, decision: str, attention: list[str], next_action: str, envelope: dict[str, Any] | None = None) -> dict[str, Any]:
+    dispatch_plan = portable["dispatch_plan"]
+    requested = {
+        "capability_tier": dispatch_plan.get("requested_capability_tier", "not_available"),
+        "reasoning_tier": dispatch_plan.get("requested_reasoning_tier", "not_available"),
+        "explicit_envelope": envelope or "not_available",
+    }
+    observable = {
+        "tool_status": observed.get("status", "not_available") if observed else "not_available",
+        "fields_observed": observed.get("fields", []) if observed else [],
+        "effective_configuration": "unknown",
+        "enforcement": "not_executed_dry_run_only",
+    }
+    return {
+        "adapter": "codex",
+        "schema_observation": observed or {"observed_at": "not_available", "schema_source": "not_available"},
+        "adapter_plan": {
+            "mode": "dry_run",
+            "adapter_decision": decision,
+            "topology": topology or "not_available",
+            "tool_call_proposed": observed.get("tool") if observed else "not_available",
+            "explicit_envelope": envelope or {},
+            "lifecycle_evidence": lifecycle_evidence(portable, topology or "not_available"),
+        },
+        "conversation_projection": {
+            "portable": portable["conversation_projection"],
+            "requested_vs_observable": {"requested": requested, "observable": observable},
+            "attention": attention,
+            "next_action": next_action,
+        },
+        "mutation_performed": False,
+        "dispatch_performed": False,
+        "user_config_mutation_performed": False,
+        "hook_or_custom_agent_mutation_performed": False,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-json", required=True, help="Portable plan plus current Codex schema observation.")
+    parser.add_argument("--json", action="store_true", help="Emit JSON. This is the default output format.")
+    args = parser.parse_args()
+    try:
+        print(json.dumps(project(load_input(args.input_json)), indent=2, sort_keys=True))
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"codex_route_adapter_error: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/plan_codex_route_adapter.py
+++ b/scripts/plan_codex_route_adapter.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import sys
+from datetime import datetime
 from typing import Any
 
 
@@ -16,6 +18,7 @@ TOPOLOGY_TO_TOOL = {
     "fork": ("fork_thread", ()),
 }
 VALID_STATUSES = {"supported", "unsupported", "unknown", "degraded", "not_available"}
+HOST_COLLECTION_MODE = "host_collected"
 
 
 def fail(message: str) -> None:
@@ -34,6 +37,48 @@ def require_object(root: dict[str, Any], name: str) -> dict[str, Any]:
     if not isinstance(value, dict):
         fail(f"missing object: {name}")
     return value
+
+
+def parse_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def schema_digest(tools: dict[str, Any]) -> str:
+    encoded = json.dumps(tools, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def validate_observation(root: dict[str, Any]) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    observation = root.get("schema_observation")
+    context = root.get("adapter_context")
+    if not isinstance(observation, dict) or not isinstance(context, dict):
+        return None, {"status": "unknown", "reason": "host-collected schema observation and adapter context are required"}
+    tools = observation.get("tools")
+    provenance = observation.get("provenance")
+    observed_at = parse_timestamp(observation.get("observed_at"))
+    evaluated_at = parse_timestamp(context.get("evaluated_at"))
+    max_age = context.get("max_observation_age_seconds")
+    if not isinstance(tools, dict) or not isinstance(provenance, dict):
+        return None, {"status": "unknown", "reason": "schema observation is incomplete"}
+    if provenance.get("collection_mode") != HOST_COLLECTION_MODE:
+        return None, {"status": "untrusted", "reason": "schema observation is not host-collected"}
+    if not isinstance(provenance.get("evidence_ref"), str) or not provenance["evidence_ref"]:
+        return None, {"status": "untrusted", "reason": "host-collected schema observation lacks an evidence reference"}
+    if provenance.get("schema_digest") != schema_digest(tools):
+        return None, {"status": "untrusted", "reason": "host-collected schema observation digest does not match tools"}
+    if not isinstance(observation.get("runtime_id"), str) or observation.get("runtime_id") != context.get("runtime_id"):
+        return None, {"status": "untrusted", "reason": "schema observation runtime does not match the executing runtime"}
+    if observed_at is None or evaluated_at is None or not isinstance(max_age, int) or max_age < 0:
+        return None, {"status": "unknown", "reason": "schema observation freshness is not auditable"}
+    age_seconds = abs((evaluated_at - observed_at).total_seconds())
+    if age_seconds > max_age:
+        return None, {"status": "stale", "reason": f"schema observation is stale by {int(age_seconds)} seconds"}
+    return observation, {"status": "current", "reason": "host-collected current schema observation validated", "age_seconds": int(age_seconds)}
 
 
 def tool_observation(schema: dict[str, Any], tool_name: str) -> dict[str, Any]:
@@ -90,9 +135,8 @@ def lifecycle_evidence(portable: dict[str, Any], topology: str) -> dict[str, Any
 
 def project(root: dict[str, Any]) -> dict[str, Any]:
     portable = require_object(root, "portable_plan")
-    schema = require_object(root, "schema_observation")
     dispatch_plan = require_object(portable, "dispatch_plan")
-    conversation = require_object(portable, "conversation_projection")
+    require_object(portable, "conversation_projection")
     decision = dispatch_plan.get("route_decision")
     selected = dispatch_plan.get("selected_candidate")
     if decision not in {"no_dispatch", "dispatch_advisory", "human_stop"}:
@@ -109,6 +153,12 @@ def project(root: dict[str, Any]) -> dict[str, Any]:
         return output(
             portable, topology, None, "unsupported", [f"Codex adapter has no supported mapping for topology {topology}"],
             "Choose a supported fresh, durable, or subagent route, or stop for a Human decision.",
+        )
+    schema, provenance = validate_observation(root)
+    if schema is None:
+        return output(
+            portable, topology, None, "unknown", [provenance["reason"]],
+            "Collect a current host-observed Codex tool schema before proposing any envelope.", provenance=provenance,
         )
     tool_name, required_fields = TOPOLOGY_TO_TOOL[topology]
     observed = tool_observation(schema, tool_name)
@@ -128,20 +178,20 @@ def project(root: dict[str, Any]) -> dict[str, Any]:
     if requires_explicit and attention:
         return output(
             portable, topology, observed, "unsupported", attention,
-            "Provide a currently supported explicit Codex envelope or keep the portable plan at no dispatch.",
+            "Provide a currently supported explicit Codex envelope or keep the portable plan at no dispatch.", provenance=provenance,
         )
     if attention:
         return output(
             portable, topology, observed, "human_stop", attention,
-            "Do not inherit unknown Codex settings; provide an explicit envelope or stop for a Human decision.",
+            "Do not inherit unknown Codex settings; provide an explicit envelope or stop for a Human decision.", provenance=provenance,
         )
     return output(
         portable, topology, observed, "dry_run_ready", [],
-        "Review this dry-run Codex envelope before any separately authorized dispatch.", envelope,
+        "Review this dry-run Codex envelope before any separately authorized dispatch.", envelope, provenance,
     )
 
 
-def output(portable: dict[str, Any], topology: str | None, observed: dict[str, Any] | None, decision: str, attention: list[str], next_action: str, envelope: dict[str, Any] | None = None) -> dict[str, Any]:
+def output(portable: dict[str, Any], topology: str | None, observed: dict[str, Any] | None, decision: str, attention: list[str], next_action: str, envelope: dict[str, Any] | None = None, provenance: dict[str, Any] | None = None) -> dict[str, Any]:
     dispatch_plan = portable["dispatch_plan"]
     requested = {
         "capability_tier": dispatch_plan.get("requested_capability_tier", "not_available"),
@@ -157,6 +207,7 @@ def output(portable: dict[str, Any], topology: str | None, observed: dict[str, A
     return {
         "adapter": "codex",
         "schema_observation": observed or {"observed_at": "not_available", "schema_source": "not_available"},
+        "schema_provenance": provenance or {"status": "not_available", "reason": "no adapter schema observation was needed"},
         "adapter_plan": {
             "mode": "dry_run",
             "adapter_decision": decision,

--- a/scripts/test_codex_route_adapter.py
+++ b/scripts/test_codex_route_adapter.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Fixture regressions for the AF18 optional Codex route adapter."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ADAPTER = ROOT / "scripts" / "plan_codex_route_adapter.py"
+
+
+def portable(topology: str = "fresh_thread", decision: str = "dispatch_advisory", explicit: bool = True) -> dict:
+    selected = None if decision != "dispatch_advisory" else {"topology": topology, "context_mode": "fresh"}
+    return {
+        "work_unit": {"work_unit_id": "AF18-421-fixture", "requires_explicit_envelope": explicit},
+        "dispatch_plan": {"route_decision": decision, "selected_candidate": selected, "requested_capability_tier": "balanced", "requested_reasoning_tier": "medium"},
+        "conversation_projection": {"effective_policy": {"profile": "normal"}, "next_action": "Review portable plan"},
+    }
+
+
+def schemas() -> dict:
+    return {
+        "observed_at": "2026-07-22T00:00:00Z",
+        "schema_source": "current_codex_tool_schema",
+        "tools": {
+            "create_thread": {"status": "supported", "fields": ["model", "thinking"]},
+            "send_message_to_thread": {"status": "supported", "fields": ["model", "thinking"]},
+            "spawn_agent": {"status": "supported", "fields": ["model", "reasoning_effort", "fork_context"]},
+            "fork_thread": {"status": "supported", "fields": []},
+        },
+    }
+
+
+def envelopes() -> dict:
+    return {
+        "balanced": {"model": "gpt-5.4", "thinking": "medium", "reasoning_effort": "medium"},
+        "frontier": {"model": "gpt-5.5", "thinking": "high", "reasoning_effort": "high"},
+        "economy": {"model": "gpt-5.4-mini", "thinking": "low", "reasoning_effort": "low"},
+    }
+
+
+def run(data: dict) -> tuple[int, dict | str]:
+    with tempfile.TemporaryDirectory(prefix="af18-codex-adapter-") as raw:
+        path = Path(raw) / "fixture.json"
+        path.write_text(json.dumps(data), encoding="utf-8")
+        completed = subprocess.run([sys.executable, str(ADAPTER), "--input-json", str(path), "--json"], text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return (completed.returncode, json.loads(completed.stdout)) if completed.returncode == 0 else (completed.returncode, completed.stderr)
+
+
+def expect(name: str, condition: bool, detail: object, errors: list[str]) -> None:
+    if condition:
+        print(f"{name}: ok")
+    else:
+        errors.append(f"{name}: {detail}")
+
+
+def main() -> int:
+    errors: list[str] = []
+    base = {"portable_plan": portable(), "schema_observation": schemas(), "adapter_envelopes": envelopes()}
+    code, output = run(base)
+    expect("fresh-explicit-envelope", code == 0 and output["adapter_plan"]["adapter_decision"] == "dry_run_ready" and output["adapter_plan"]["explicit_envelope"] == {"model": "gpt-5.4", "thinking": "medium"}, output, errors)
+    expect("fresh-no-write", code == 0 and output["mutation_performed"] is False and output["dispatch_performed"] is False and output["adapter_plan"]["lifecycle_evidence"]["close_archive_resume"] == "not_executed_dry_run_only", output, errors)
+
+    durable = {"portable_plan": portable("durable_thread"), "schema_observation": schemas(), "adapter_envelopes": envelopes()}
+    code, output = run(durable)
+    expect("durable-envelope", code == 0 and output["adapter_plan"]["tool_call_proposed"] == "send_message_to_thread" and output["adapter_plan"]["explicit_envelope"]["thinking"] == "medium", output, errors)
+
+    subagent = {"portable_plan": portable("subagent"), "schema_observation": schemas(), "adapter_envelopes": envelopes()}
+    code, output = run(subagent)
+    expect("subagent-envelope", code == 0 and output["adapter_plan"]["explicit_envelope"] == {"model": "gpt-5.4", "reasoning_effort": "medium"}, output, errors)
+
+    fork = {"portable_plan": portable("fork"), "schema_observation": schemas(), "adapter_envelopes": envelopes()}
+    code, output = run(fork)
+    expect("fork-unsupported", code == 0 and output["adapter_plan"]["adapter_decision"] == "unsupported" and output["mutation_performed"] is False, output, errors)
+
+    omitted = {"portable_plan": portable("durable_thread", explicit=False), "schema_observation": schemas(), "adapter_envelopes": {}}
+    code, output = run(omitted)
+    expect("omitted-inheritance-human-stop", code == 0 and output["adapter_plan"]["adapter_decision"] == "human_stop" and output["conversation_projection"]["requested_vs_observable"]["observable"]["effective_configuration"] == "unknown", output, errors)
+
+    stale = {"portable_plan": portable("durable_thread"), "schema_observation": schemas(), "adapter_envelopes": {}}
+    code, output = run(stale)
+    expect("stale-explicit-envelope-unsupported", code == 0 and output["adapter_plan"]["adapter_decision"] == "unsupported", output, errors)
+
+    no_dispatch = {"portable_plan": portable(decision="no_dispatch"), "schema_observation": schemas(), "adapter_envelopes": envelopes()}
+    code, output = run(no_dispatch)
+    expect("no-dispatch-remains-no-call", code == 0 and output["adapter_plan"]["adapter_decision"] == "no_adapter_dispatch" and output["adapter_plan"]["tool_call_proposed"] == "not_available", output, errors)
+
+    unsupported = schemas()
+    unsupported["tools"]["create_thread"]["status"] = "unsupported"
+    code, output = run({"portable_plan": portable(), "schema_observation": unsupported, "adapter_envelopes": envelopes()})
+    expect("unsupported-runtime-visible", code == 0 and output["adapter_plan"]["adapter_decision"] == "unsupported" and "is unsupported" in output["conversation_projection"]["attention"][0], output, errors)
+
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_codex_route_adapter.py
+++ b/scripts/test_codex_route_adapter.py
@@ -82,7 +82,7 @@ def provenance_recovery(output: dict, status: str) -> bool:
         and output["adapter_plan"]["explicit_envelope"] == {}
         and output["schema_provenance"]["status"] == status
         and len(conversation["attention"]) == 1
-        and conversation["next_action"] == "Collect a current host-observed Codex tool schema before proposing any envelope."
+        and conversation["next_action"] == "Obtain a verified runtime-owned Codex schema capture before proposing any envelope."
         and output["mutation_performed"] is False
         and output["dispatch_performed"] is False
     )
@@ -105,40 +105,14 @@ def expect(name: str, condition: bool, detail: object, errors: list[str]) -> Non
 
 def main() -> int:
     errors: list[str] = []
-    base = input_for(portable())
+    base = input_for(portable("subagent"))
     code, output = run(base)
-    expect("fresh-host-observation-explicit-envelope", code == 0 and output["adapter_plan"]["adapter_decision"] == "dry_run_ready" and output["schema_provenance"]["status"] == "current" and output["adapter_plan"]["explicit_envelope"] == {"model": "gpt-5.4", "thinking": "medium"}, output, errors)
-    expect("fresh-no-write", code == 0 and output["mutation_performed"] is False and output["dispatch_performed"] is False and output["adapter_plan"]["lifecycle_evidence"]["close_archive_resume"] == "not_executed_dry_run_only", output, errors)
-
-    durable = input_for(portable("durable_thread"))
-    code, output = run(durable)
-    expect("durable-envelope", code == 0 and output["adapter_plan"]["tool_call_proposed"] == "send_message_to_thread" and output["adapter_plan"]["explicit_envelope"]["thinking"] == "medium", output, errors)
-
-    subagent = input_for(portable("subagent"))
-    code, output = run(subagent)
-    expect("subagent-envelope", code == 0 and output["adapter_plan"]["explicit_envelope"] == {"model": "gpt-5.4", "reasoning_effort": "medium"}, output, errors)
-
-    fork = input_for(portable("fork"))
-    code, output = run(fork)
-    expect("fork-unsupported", code == 0 and output["adapter_plan"]["adapter_decision"] == "unsupported" and output["mutation_performed"] is False, output, errors)
-
-    omitted = input_for(portable("durable_thread", explicit=False), adapter_envelopes={})
-    code, output = run(omitted)
-    expect("omitted-inheritance-human-stop", code == 0 and output["adapter_plan"]["adapter_decision"] == "human_stop" and output["conversation_projection"]["requested_vs_observable"]["observable"]["effective_configuration"] == "unknown", output, errors)
-
-    stale = input_for(portable("durable_thread"), adapter_envelopes={})
-    code, output = run(stale)
-    expect("stale-explicit-envelope-unsupported", code == 0 and output["adapter_plan"]["adapter_decision"] == "unsupported", output, errors)
+    expect("runtime-capture-unavailable", code == 0 and provenance_recovery(output, "unknown") and output["schema_provenance"]["evidence_ref_status"] == "unverified", output, errors)
+    expect("runtime-capture-no-write", code == 0 and output["mutation_performed"] is False and output["dispatch_performed"] is False and output["adapter_plan"]["lifecycle_evidence"]["close_archive_resume"] == "not_executed_dry_run_only", output, errors)
 
     no_dispatch = input_for(portable(decision="no_dispatch"))
     code, output = run(no_dispatch)
     expect("no-dispatch-remains-no-call", code == 0 and output["adapter_plan"]["adapter_decision"] == "no_adapter_dispatch" and output["adapter_plan"]["tool_call_proposed"] == "not_available", output, errors)
-
-    unsupported = schemas()
-    unsupported["tools"]["create_thread"]["status"] = "unsupported"
-    unsupported["provenance"]["schema_digest"] = digest(unsupported["tools"])
-    code, output = run(input_for(portable(), observation=unsupported))
-    expect("unsupported-runtime-visible", code == 0 and output["adapter_plan"]["adapter_decision"] == "unsupported" and "is unsupported" in output["conversation_projection"]["attention"][0], output, errors)
 
     absent = input_for(portable("subagent"))
     absent.pop("schema_observation")
@@ -159,6 +133,19 @@ def main() -> int:
     fixture_spawn["provenance"]["collection_mode"] = "fixture"
     code, output = run(input_for(portable("subagent"), observation=fixture_spawn))
     expect("spawn-agent-fixture-only-observation", code == 0 and provenance_recovery(output, "untrusted"), output, errors)
+
+    forged_spawn = schemas()
+    forged_spawn["runtime_id"] = "claimed-current-runtime"
+    forged_spawn["provenance"]["evidence_ref"] = "https://example.invalid/forged-current-schema"
+    context = adapter_context()
+    context["runtime_id"] = "claimed-current-runtime"
+    code, output = run({
+        "portable_plan": portable("subagent"),
+        "schema_observation": forged_spawn,
+        "adapter_context": context,
+        "adapter_envelopes": envelopes(),
+    })
+    expect("spawn-agent-forged-host-collected-is-unverified", code == 0 and provenance_recovery(output, "unknown") and output["schema_provenance"]["evidence_ref_status"] == "unverified", output, errors)
 
     if errors:
         print("\n".join(errors), file=sys.stderr)

--- a/scripts/test_codex_route_adapter.py
+++ b/scripts/test_codex_route_adapter.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 import sys
@@ -23,16 +24,28 @@ def portable(topology: str = "fresh_thread", decision: str = "dispatch_advisory"
     }
 
 
+def digest(tools: dict) -> str:
+    encoded = json.dumps(tools, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
 def schemas() -> dict:
+    tools = {
+        "create_thread": {"status": "supported", "fields": ["model", "thinking"]},
+        "send_message_to_thread": {"status": "supported", "fields": ["model", "thinking"]},
+        "spawn_agent": {"status": "supported", "fields": ["model", "reasoning_effort", "fork_context"]},
+        "fork_thread": {"status": "supported", "fields": []},
+    }
     return {
         "observed_at": "2026-07-22T00:00:00Z",
         "schema_source": "current_codex_tool_schema",
-        "tools": {
-            "create_thread": {"status": "supported", "fields": ["model", "thinking"]},
-            "send_message_to_thread": {"status": "supported", "fields": ["model", "thinking"]},
-            "spawn_agent": {"status": "supported", "fields": ["model", "reasoning_effort", "fork_context"]},
-            "fork_thread": {"status": "supported", "fields": []},
+        "runtime_id": "codex-desktop-current-session",
+        "provenance": {
+            "collection_mode": "host_collected",
+            "evidence_ref": "codex-app://current-session/tool-schema",
+            "schema_digest": digest(tools),
         },
+        "tools": tools,
     }
 
 
@@ -42,6 +55,37 @@ def envelopes() -> dict:
         "frontier": {"model": "gpt-5.5", "thinking": "high", "reasoning_effort": "high"},
         "economy": {"model": "gpt-5.4-mini", "thinking": "low", "reasoning_effort": "low"},
     }
+
+
+def adapter_context() -> dict:
+    return {
+        "runtime_id": "codex-desktop-current-session",
+        "evaluated_at": "2026-07-22T00:05:00Z",
+        "max_observation_age_seconds": 300,
+    }
+
+
+def input_for(portable_plan: dict, observation: dict | None = None, adapter_envelopes: dict | None = None) -> dict:
+    return {
+        "portable_plan": portable_plan,
+        "schema_observation": schemas() if observation is None else observation,
+        "adapter_context": adapter_context(),
+        "adapter_envelopes": envelopes() if adapter_envelopes is None else adapter_envelopes,
+    }
+
+
+def provenance_recovery(output: dict, status: str) -> bool:
+    conversation = output["conversation_projection"]
+    return (
+        output["adapter_plan"]["adapter_decision"] in {"unknown", "unsupported"}
+        and output["adapter_plan"]["adapter_decision"] != "dry_run_ready"
+        and output["adapter_plan"]["explicit_envelope"] == {}
+        and output["schema_provenance"]["status"] == status
+        and len(conversation["attention"]) == 1
+        and conversation["next_action"] == "Collect a current host-observed Codex tool schema before proposing any envelope."
+        and output["mutation_performed"] is False
+        and output["dispatch_performed"] is False
+    )
 
 
 def run(data: dict) -> tuple[int, dict | str]:
@@ -61,39 +105,60 @@ def expect(name: str, condition: bool, detail: object, errors: list[str]) -> Non
 
 def main() -> int:
     errors: list[str] = []
-    base = {"portable_plan": portable(), "schema_observation": schemas(), "adapter_envelopes": envelopes()}
+    base = input_for(portable())
     code, output = run(base)
-    expect("fresh-explicit-envelope", code == 0 and output["adapter_plan"]["adapter_decision"] == "dry_run_ready" and output["adapter_plan"]["explicit_envelope"] == {"model": "gpt-5.4", "thinking": "medium"}, output, errors)
+    expect("fresh-host-observation-explicit-envelope", code == 0 and output["adapter_plan"]["adapter_decision"] == "dry_run_ready" and output["schema_provenance"]["status"] == "current" and output["adapter_plan"]["explicit_envelope"] == {"model": "gpt-5.4", "thinking": "medium"}, output, errors)
     expect("fresh-no-write", code == 0 and output["mutation_performed"] is False and output["dispatch_performed"] is False and output["adapter_plan"]["lifecycle_evidence"]["close_archive_resume"] == "not_executed_dry_run_only", output, errors)
 
-    durable = {"portable_plan": portable("durable_thread"), "schema_observation": schemas(), "adapter_envelopes": envelopes()}
+    durable = input_for(portable("durable_thread"))
     code, output = run(durable)
     expect("durable-envelope", code == 0 and output["adapter_plan"]["tool_call_proposed"] == "send_message_to_thread" and output["adapter_plan"]["explicit_envelope"]["thinking"] == "medium", output, errors)
 
-    subagent = {"portable_plan": portable("subagent"), "schema_observation": schemas(), "adapter_envelopes": envelopes()}
+    subagent = input_for(portable("subagent"))
     code, output = run(subagent)
     expect("subagent-envelope", code == 0 and output["adapter_plan"]["explicit_envelope"] == {"model": "gpt-5.4", "reasoning_effort": "medium"}, output, errors)
 
-    fork = {"portable_plan": portable("fork"), "schema_observation": schemas(), "adapter_envelopes": envelopes()}
+    fork = input_for(portable("fork"))
     code, output = run(fork)
     expect("fork-unsupported", code == 0 and output["adapter_plan"]["adapter_decision"] == "unsupported" and output["mutation_performed"] is False, output, errors)
 
-    omitted = {"portable_plan": portable("durable_thread", explicit=False), "schema_observation": schemas(), "adapter_envelopes": {}}
+    omitted = input_for(portable("durable_thread", explicit=False), adapter_envelopes={})
     code, output = run(omitted)
     expect("omitted-inheritance-human-stop", code == 0 and output["adapter_plan"]["adapter_decision"] == "human_stop" and output["conversation_projection"]["requested_vs_observable"]["observable"]["effective_configuration"] == "unknown", output, errors)
 
-    stale = {"portable_plan": portable("durable_thread"), "schema_observation": schemas(), "adapter_envelopes": {}}
+    stale = input_for(portable("durable_thread"), adapter_envelopes={})
     code, output = run(stale)
     expect("stale-explicit-envelope-unsupported", code == 0 and output["adapter_plan"]["adapter_decision"] == "unsupported", output, errors)
 
-    no_dispatch = {"portable_plan": portable(decision="no_dispatch"), "schema_observation": schemas(), "adapter_envelopes": envelopes()}
+    no_dispatch = input_for(portable(decision="no_dispatch"))
     code, output = run(no_dispatch)
     expect("no-dispatch-remains-no-call", code == 0 and output["adapter_plan"]["adapter_decision"] == "no_adapter_dispatch" and output["adapter_plan"]["tool_call_proposed"] == "not_available", output, errors)
 
     unsupported = schemas()
     unsupported["tools"]["create_thread"]["status"] = "unsupported"
-    code, output = run({"portable_plan": portable(), "schema_observation": unsupported, "adapter_envelopes": envelopes()})
+    unsupported["provenance"]["schema_digest"] = digest(unsupported["tools"])
+    code, output = run(input_for(portable(), observation=unsupported))
     expect("unsupported-runtime-visible", code == 0 and output["adapter_plan"]["adapter_decision"] == "unsupported" and "is unsupported" in output["conversation_projection"]["attention"][0], output, errors)
+
+    absent = input_for(portable("subagent"))
+    absent.pop("schema_observation")
+    code, output = run(absent)
+    expect("spawn-agent-absent-observation", code == 0 and provenance_recovery(output, "unknown"), output, errors)
+
+    stale_spawn = schemas()
+    stale_spawn["observed_at"] = "2026-07-21T00:00:00Z"
+    code, output = run(input_for(portable("subagent"), observation=stale_spawn))
+    expect("spawn-agent-stale-observation", code == 0 and provenance_recovery(output, "stale"), output, errors)
+
+    untrusted_spawn = schemas()
+    untrusted_spawn["provenance"]["schema_digest"] = "sha256:tampered"
+    code, output = run(input_for(portable("subagent"), observation=untrusted_spawn))
+    expect("spawn-agent-untrusted-observation", code == 0 and provenance_recovery(output, "untrusted"), output, errors)
+
+    fixture_spawn = schemas()
+    fixture_spawn["provenance"]["collection_mode"] = "fixture"
+    code, output = run(input_for(portable("subagent"), observation=fixture_spawn))
+    expect("spawn-agent-fixture-only-observation", code == 0 and provenance_recovery(output, "untrusted"), output, errors)
 
     if errors:
         print("\n".join(errors), file=sys.stderr)

--- a/workflows/github-collaboration-helper.md
+++ b/workflows/github-collaboration-helper.md
@@ -100,11 +100,14 @@ slice owns any approved policy-record write/readback path.
 AF18's optional Codex adapter is a separate dry-run projection at
 `scripts/plan_codex_route_adapter.py`. It consumes a portable plan and a
 timestamped current Codex tool-schema observation supplied by the executing
-host. The observation must carry a host-collected mode, runtime identity,
-traceable discovery evidence, and a digest of the observed tools; fixture,
-stale, absent, or untrusted observations remain unknown and cannot make a
-route dry-run-ready. Codex-specific fields and model names stay adapter-local;
-they are never written into `collaboration-routing-policy.schema.yaml`.
+host. A caller-provided JSON observation is only reported evidence: it cannot
+make a route dry-run-ready unless the adapter can verify a runtime-owned
+capture with runtime identity, resolvable discovery evidence, and a digest of
+the observed tools. The current pilot has no such capture producer, so it
+fails closed with one recovery action rather than trusting fixture, stale,
+absent, untrusted, or self-asserted host-collected input. Codex-specific
+fields and model names stay adapter-local; they are never written into
+`collaboration-routing-policy.schema.yaml`.
 
 The adapter maps durable routes to `send_message_to_thread`, fresh routes to
 `create_thread`, and subagent routes to `spawn_agent` only when the observed

--- a/workflows/github-collaboration-helper.md
+++ b/workflows/github-collaboration-helper.md
@@ -100,8 +100,11 @@ slice owns any approved policy-record write/readback path.
 AF18's optional Codex adapter is a separate dry-run projection at
 `scripts/plan_codex_route_adapter.py`. It consumes a portable plan and a
 timestamped current Codex tool-schema observation supplied by the executing
-host. Codex-specific fields and model names stay adapter-local; they are never
-written into `collaboration-routing-policy.schema.yaml`.
+host. The observation must carry a host-collected mode, runtime identity,
+traceable discovery evidence, and a digest of the observed tools; fixture,
+stale, absent, or untrusted observations remain unknown and cannot make a
+route dry-run-ready. Codex-specific fields and model names stay adapter-local;
+they are never written into `collaboration-routing-policy.schema.yaml`.
 
 The adapter maps durable routes to `send_message_to_thread`, fresh routes to
 `create_thread`, and subagent routes to `spawn_agent` only when the observed

--- a/workflows/github-collaboration-helper.md
+++ b/workflows/github-collaboration-helper.md
@@ -95,6 +95,27 @@ or report product. The JSON result is secondary technical evidence; a later
 conversation surface owns compact Human-facing wording and a later lifecycle
 slice owns any approved policy-record write/readback path.
 
+### Optional Codex Adapter Pilot
+
+AF18's optional Codex adapter is a separate dry-run projection at
+`scripts/plan_codex_route_adapter.py`. It consumes a portable plan and a
+timestamped current Codex tool-schema observation supplied by the executing
+host. Codex-specific fields and model names stay adapter-local; they are never
+written into `collaboration-routing-policy.schema.yaml`.
+
+The adapter maps durable routes to `send_message_to_thread`, fresh routes to
+`create_thread`, and subagent routes to `spawn_agent` only when the observed
+tool exposes the required explicit envelope fields. Forks remain visibly
+unsupported for envelope enforcement. Omitted, stale, unknown, or unsupported
+configuration produces one recovery action and never silently inherits a
+retained setting. Its lifecycle evidence is bounded to one work unit and states
+that close/archive/resume was not executed in dry-run mode.
+
+It proposes no real tool call: all adapter output reports
+`mutation_performed: false` and `dispatch_performed: false`. User config,
+hooks, custom agents, policy records, runtime installation, and telemetry stay
+outside this pilot.
+
 ## User-Facing Entry Points
 
 Agents should expose these as natural-language workflows rather than requiring


### PR DESCRIPTION
## Summary

Implements AF18 #421 only: an optional, bounded Codex adapter that projects a portable advisory plan plus a current schema observation into a dry-run explicit envelope.

- Keeps Codex tool names and model identifiers adapter-local; portable policy schema is unchanged.
- Maps durable/fresh/subagent routes only when observed fields support explicit envelopes.
- Makes fork, omitted/stale envelopes, and unsupported/unknown tools fail visibly with one recovery action.
- Produces requested-versus-observable state and one-work-unit lifecycle evidence without invoking lifecycle actions.

## Verification

- `python3 -m py_compile scripts/plan_codex_route_adapter.py scripts/test_codex_route_adapter.py scripts/plan_collaboration_routes.py scripts/test_collaboration_route_planner.py`
- `python3 scripts/test_codex_route_adapter.py`
- `python3 scripts/test_collaboration_route_planner.py`
- `python3 scripts/check_consistency.py`
- `git diff --check origin/codex/af18-collaboration-cost-policy-integration...HEAD`

## Execution Contract

Owner role: implementer
Review role: reviewer
Acceptance role: architect
Completion handoff: to:tester
Branch strategy: integration-branch
Target branch: codex/af18-collaboration-cost-policy-integration

## Boundaries

This is dry-run/fixture-only. `mutation_performed: false`, `dispatch_performed: false`, and no actual Codex tool call occurs. No user config, hooks, custom agents, personal/project policy records, runtime/Vault/generated/Project changes, telemetry/reporting, publish/install, merge, release/tag, or V2.1 work.