### PR TITLE
Implement AF18 lifecycle route planner

### DIFF
--- a/schemas/collaboration-routing-policy.schema.yaml
+++ b/schemas/collaboration-routing-policy.schema.yaml
@@ -11,16 +11,19 @@ objects:
       - "lower-precedence policy cannot relax Human gates, authority boundaries, or budget limits"
       - "effective policy precedence is current-work-unit Human grant, then project record, then personal record, then unsaved normal default"
       - "invalid, missing, or drifted records remain visible and are never represented as valid persisted policy"
+      - "effective policy mode is economy, normal, performance, or temporary low_limit"
   WorkUnit:
     required: [work_unit_id, purpose, risk, ambiguity, verification_oracle, stop_conditions]
     rules:
       - "one bounded issue, PR, review target, experiment, or batch only"
       - "Human-owned actions stop advisory routing until an explicit decision exists"
       - "task_class is routine, standard, complex, or human_owned; any correction is bounded to one work unit and resets afterward"
+      - "bounded work-unit lifecycle actions are advisory only and never create, resume, archive, or dispatch context"
   RoleContext:
     required: [required_role, specialization_available, continuity_value, context_relevance, independence_requirement]
     rules:
       - "role specialization, continuity, and independence are separate inputs"
+      - "specialization value, project continuity relevance, and independent-review value are not inferred from role label or thread age alone"
   RuntimeCapabilities:
     required: [observed_at, mechanisms]
     rules:
@@ -38,13 +41,16 @@ objects:
     rules:
       - "advisory only; mutation_performed and dispatch_performed must be false"
       - "unsupported runtime paths report enforcement_not_available"
+      - "route_decision is one bounded route, never an instruction to execute dispatch"
   ConversationProjection:
-    required: [effective_policy, work_unit, recommendation, runtime_projection, attention, evidence, next_action]
+    required: [effective_policy, work_unit, recommendation, lifecycle, runtime_projection, attention, evidence, next_action]
     rules:
       - "primary fields are compact conversation guidance; JSON stays secondary technical evidence"
-      - "routine serial/no_dispatch paths emit no separate marker unless attention or a material correction exists"
+      - "routine serial_current_session paths emit no separate marker unless attention or a material correction exists"
       - "runtime projection distinguishes requested abstract tier from observable, unknown, or unsupported runtime configuration"
       - "explicit set up collaboration policy intent is a no-write handoff to the later lifecycle slice"
+      - "lifecycle models collaboration operating mode, execution-context lifecycle, and bounded work-unit lifecycle"
+      - "create, reuse, compact-rehydrate, callback, cooldown, and archive eligibility are reported only as next-action guidance"
   OverrideGrant:
     required: [active, scope, expires_after_work_unit, reset_required]
     rules:
@@ -63,8 +69,8 @@ allowed_values:
   confidence: [high, medium, low, unknown]
   runtime_status: [supported, unsupported, unknown, degraded, not_available]
   effective_configuration: [observed, unknown, not_available]
-  route_decision: [no_dispatch, dispatch_advisory, human_stop]
-  policy_profile: [economy, normal, high_performance]
+  route_decision: [serial_current_session, reuse_relevant_thread, fresh_bounded_thread, bounded_subagent, batch_checkpoint, hold_for_decision]
+  policy_profile: [economy, normal, performance, low_limit]
   policy_validity: [valid, invalid, drifted, missing, unsaved_default]
   task_class: [routine, standard, complex, human_owned]
 

--- a/scripts/plan_codex_route_adapter.py
+++ b/scripts/plan_codex_route_adapter.py
@@ -17,6 +17,19 @@ TOPOLOGY_TO_TOOL = {
     "subagent": ("spawn_agent", ("model", "reasoning_effort")),
     "fork": ("fork_thread", ()),
 }
+ROUTE_DECISION_TO_TOPOLOGY = {
+    "reuse_relevant_thread": "durable_thread",
+    "fresh_bounded_thread": "fresh_thread",
+    "bounded_subagent": "subagent",
+}
+NO_ADAPTER_ROUTES = {
+    "no_dispatch",
+    "human_stop",
+    "serial_current_session",
+    "batch_checkpoint",
+    "hold_for_decision",
+}
+DISPATCH_ADVISORY_ROUTES = {"dispatch_advisory"} | set(ROUTE_DECISION_TO_TOPOLOGY)
 VALID_STATUSES = {"supported", "unsupported", "unknown", "degraded", "not_available"}
 HOST_COLLECTION_MODE = "host_collected"
 
@@ -148,16 +161,16 @@ def project(root: dict[str, Any]) -> dict[str, Any]:
     require_object(portable, "conversation_projection")
     decision = dispatch_plan.get("route_decision")
     selected = dispatch_plan.get("selected_candidate")
-    if decision not in {"no_dispatch", "dispatch_advisory", "human_stop"}:
+    if decision not in NO_ADAPTER_ROUTES | DISPATCH_ADVISORY_ROUTES:
         fail("portable dispatch_plan.route_decision is invalid")
-    if decision != "dispatch_advisory":
+    if decision in NO_ADAPTER_ROUTES:
         return output(
             portable, None, None, "no_adapter_dispatch", [],
             "Continue the portable no-dispatch or Human-stop path; no Codex tool call is proposed.",
         )
     if not isinstance(selected, dict):
         fail("portable dispatch advisory requires selected_candidate")
-    topology = selected.get("topology")
+    topology = selected.get("topology") or ROUTE_DECISION_TO_TOPOLOGY.get(str(decision))
     if topology not in TOPOLOGY_TO_TOOL:
         return output(
             portable, topology, None, "unsupported", [f"Codex adapter has no supported mapping for topology {topology}"],

--- a/scripts/plan_collaboration_routes.py
+++ b/scripts/plan_collaboration_routes.py
@@ -11,7 +11,7 @@ from typing import Any
 
 CAPABILITY_TIERS = {"economy", "balanced", "frontier"}
 REASONING_TIERS = {"low", "medium", "high"}
-POLICY_PROFILES = {"economy", "normal", "high_performance"}
+POLICY_PROFILES = {"economy", "normal", "performance", "low_limit"}
 TASK_CLASSES = {"routine", "standard", "complex", "human_owned"}
 RUNTIME_STATUSES = {"supported", "unsupported", "unknown", "degraded", "not_available"}
 TOPOLOGY_MECHANISMS = {
@@ -22,6 +22,14 @@ TOPOLOGY_MECHANISMS = {
     "team": "team",
     "batch": "worktree_batch",
     "portable": "portable_prompt",
+}
+BOUNDED_ROUTES = {
+    "serial_current_session",
+    "reuse_relevant_thread",
+    "fresh_bounded_thread",
+    "bounded_subagent",
+    "batch_checkpoint",
+    "hold_for_decision",
 }
 FORBIDDEN_POLICY_KEYS = {"provider", "provider_slug", "model", "model_slug"}
 COST_RANK = {"low": 1, "medium": 2, "high": 3}
@@ -168,17 +176,19 @@ def profile_tier(policy: dict[str, Any], profile: str, task_class: str, signal_c
     if not isinstance(thresholds, dict):
         thresholds = {}
     economy_complex = thresholds.get("economy_complex", 2)
-    high_performance_complex = thresholds.get("high_performance_complex", 1)
-    reset = {"required": True, "persists": False, "after_work_unit": True}
+    performance_complex = thresholds.get("performance_complex", 1)
+    reset = {"required": True, "persists": False, "after_work_unit": True, "mode": profile}
     if task_class == "human_owned":
         return "balanced", "medium", reset, "Human-owned task class requires a Human decision"
+    if profile == "low_limit":
+        return "economy", "low", reset, None
     if task_class == "routine":
         return "economy", "low", reset, None
     if task_class == "standard":
         return ("economy", "low", reset, None) if profile == "economy" else ("balanced", "medium", reset, None)
     if profile == "economy":
         return ("balanced", "medium", reset, None) if signal_count >= economy_complex else ("economy", "low", reset, None)
-    if profile == "high_performance" and signal_count >= high_performance_complex:
+    if profile == "performance" and signal_count >= performance_complex:
         return "frontier", "high", reset, None
     attempt = root.get("attempt_state", {})
     if isinstance(attempt, dict) and attempt.get("outcome") == "escalation_candidate":
@@ -207,6 +217,7 @@ def mechanism(runtime: dict[str, Any], name: str) -> dict[str, Any]:
 
 def candidate(
     candidate_id: str,
+    route: str,
     topology: str,
     context_mode: str,
     reason: str,
@@ -218,8 +229,11 @@ def candidate(
     eligible: bool = True,
     failures: list[str] | None = None,
 ) -> dict[str, Any]:
+    if route not in BOUNDED_ROUTES:
+        fail(f"unsupported bounded route: {route}")
     return {
         "candidate_id": candidate_id,
+        "route": route,
         "topology": topology,
         "context_mode": context_mode,
         "reason": reason,
@@ -293,6 +307,67 @@ def validate_override(root: dict[str, Any], work: dict[str, Any]) -> tuple[dict[
     return normalized, None
 
 
+def next_action_for(decision: str, setup_requested: bool, source_attention: list[dict[str, Any]], policy_resolution: dict[str, Any]) -> str:
+    if setup_requested:
+        return "Set up collaboration policy requires the later lifecycle write/readback flow; this planner will not write a record"
+    if decision == "hold_for_decision":
+        return "Resolve the listed decision before creating, reusing, or dispatching any context"
+    if source_attention:
+        if policy_resolution["source"] == "unsaved_normal_default":
+            return "Inspect the invalid or drifted policy source; ordinary work may continue only with the labelled unsaved normal default"
+        return "Inspect the invalid or drifted policy source; continue with the retained valid policy shown above"
+    if decision == "serial_current_session":
+        return "Continue serial work in the current session; record a compact callback at the work-unit checkpoint"
+    if decision == "reuse_relevant_thread":
+        return "Send only compact rehydration and callback instructions to the relevant durable thread after the normal dispatch gate"
+    if decision == "fresh_bounded_thread":
+        return "Create a fresh bounded thread only through a later approved dispatch step with compact rehydration"
+    if decision == "bounded_subagent":
+        return "Use a bounded subagent only through a later approved dispatch step with artifact-scoped instructions"
+    if decision == "batch_checkpoint":
+        return "Batch related evidence into one checkpoint before any further role dispatch"
+    return "Hold for Architect review of the unsupported route"
+
+
+def lifecycle_projection(decision: str, selected: dict[str, Any] | None, policy_resolution: dict[str, Any], task_class: str, next_action: str) -> dict[str, Any]:
+    lifecycle_state = {
+        "serial_current_session": "current_session_active",
+        "reuse_relevant_thread": "reuse_candidate",
+        "fresh_bounded_thread": "create_candidate",
+        "bounded_subagent": "bounded_work_unit_candidate",
+        "batch_checkpoint": "checkpoint_candidate",
+        "hold_for_decision": "blocked_waiting_for_decision",
+    }[decision]
+    eligibility = {
+        "create": decision == "fresh_bounded_thread",
+        "reuse": decision == "reuse_relevant_thread",
+        "compact_rehydrate": decision in {"reuse_relevant_thread", "fresh_bounded_thread", "bounded_subagent"},
+        "callback": decision != "hold_for_decision",
+        "cooldown": decision in {"serial_current_session", "batch_checkpoint"},
+        "archive": decision == "batch_checkpoint",
+    }
+    return {
+        "collaboration_operating_mode": {
+            "effective_mode": policy_resolution["profile"],
+            "temporary": policy_resolution["profile"] == "low_limit",
+            "source": policy_resolution["source"],
+        },
+        "execution_context_lifecycle": {
+            "state": lifecycle_state,
+            "route": decision,
+            "context_mode": selected.get("context_mode") if selected else "not_available",
+            "eligible_actions": eligibility,
+        },
+        "bounded_work_unit_lifecycle": {
+            "task_class": task_class,
+            "state": "advisory_planned" if decision != "hold_for_decision" else "held",
+            "mutation_scope": "none",
+            "dispatch_scope": "none",
+        },
+        "next_action": next_action,
+    }
+
+
 def conversation_projection(policy_resolution: dict[str, Any], task_class: str, task_state: dict[str, Any], decision: str, selected: dict[str, Any] | None, candidates: list[dict[str, Any]], stops: list[str], tier: str, reasoning: str, setup_requested: bool) -> dict[str, Any]:
     source_attention = [check for check in policy_resolution["source_checks"] if check["validity"] in {"invalid", "drifted"}]
     observed_candidate = selected or next((item for item in candidates if item["topology"] != "serial"), None)
@@ -300,22 +375,10 @@ def conversation_projection(policy_resolution: dict[str, Any], task_class: str, 
     attention = list(stops)
     if source_attention:
         attention.append("One or more explicit policy sources are invalid or drifted; no persisted policy is assumed valid")
-    if decision != "no_dispatch" and (runtime_mapping.get("status") != "supported" or runtime_mapping.get("effective_configuration") != "observed"):
+    if decision not in {"serial_current_session", "hold_for_decision"} and (runtime_mapping.get("status") != "supported" or runtime_mapping.get("effective_configuration") != "observed"):
         attention.append("Runtime projection is requested versus observable evidence; retained settings are not assumed")
-    if setup_requested:
-        next_action = "Set up collaboration policy requires the later lifecycle write/readback flow; this planner will not write a record"
-    elif decision == "human_stop":
-        next_action = "Provide the single Human decision or inspect the invalid policy source before continuing"
-    elif source_attention:
-        if policy_resolution["source"] == "unsaved_normal_default":
-            next_action = "Inspect the invalid or drifted policy source; ordinary work may continue only with the labelled unsaved normal default"
-        else:
-            next_action = "Inspect the invalid or drifted policy source; continue with the retained valid policy shown above"
-    elif decision == "no_dispatch":
-        next_action = "Continue serial work; no dispatch action is requested"
-    else:
-        next_action = "Review the advisory route before any later runtime adapter action"
-    emit = not (task_class == "routine" and decision == "no_dispatch" and not attention and not task_state["applied"])
+    next_action = next_action_for(decision, setup_requested, source_attention, policy_resolution)
+    emit = not (task_class == "routine" and decision == "serial_current_session" and not attention and not task_state["applied"])
     return {
         "effective_policy": {
             "profile": policy_resolution["profile"],
@@ -326,11 +389,13 @@ def conversation_projection(policy_resolution: dict[str, Any], task_class: str, 
         "work_unit": {"task_class": task_class, "material_signals": task_state["material_signals"], "correction": task_state},
         "recommendation": {
             "route_decision": decision,
+            "route": selected.get("route") if selected else decision,
             "role": selected.get("topology") if selected else "not_available",
             "topology": selected.get("topology") if selected else "not_available",
             "context_mode": selected.get("context_mode") if selected else "not_available",
             "abstract_tier": {"capability": tier, "reasoning": reasoning},
         },
+        "lifecycle": lifecycle_projection(decision, selected, policy_resolution, task_class, next_action),
         "runtime_projection": {
             "requested": {"capability_tier": tier, "reasoning_tier": reasoning},
             "observable": {
@@ -360,7 +425,7 @@ def plan(root: dict[str, Any]) -> dict[str, Any]:
         fail("work_unit.human_owned_actions must be a list")
     if human_actions or work.get("requires_human_decision") is True or early_stop or override_stop or correction_stop:
         reason = early_stop or override_stop or correction_stop or "Human-owned action requires a Human decision"
-        return result(root, policy_resolution, task_class, task_state, [], "human_stop", None, [reason], reset, tier, reasoning, override)
+        return result(root, policy_resolution, task_class, task_state, [], "hold_for_decision", None, [reason], reset, tier, reasoning, override)
 
     required_independence = role.get("independence_requirement", "none")
     envelope_required = work.get("requires_explicit_envelope", False) is True
@@ -368,7 +433,7 @@ def plan(root: dict[str, Any]) -> dict[str, Any]:
     candidates: list[dict[str, Any]] = []
     serial_quality = 1 if required_independence != "none" else 2
     serial = candidate(
-        "serial-current-session", "serial", "compact", "No material dispatch benefit is assumed by default.", "low", serial_quality,
+        "serial-current-session", "serial_current_session", "serial", "compact", "No material dispatch benefit is assumed by default.", "low", serial_quality,
         tier, reasoning, {"mechanism": "current_session", "status": "supported", "effective_configuration": "unknown", "enforcement": "not_required"},
         eligible=serial_quality >= quality_floor,
         failures=[] if serial_quality >= quality_floor else ["required independent context/evidence cannot be provided by serial work"],
@@ -379,30 +444,33 @@ def plan(root: dict[str, Any]) -> dict[str, Any]:
     relevance = role.get("context_relevance", "low")
     if continuity in {"medium", "high"} and relevance in {"medium", "high"}:
         mapping, failures = route_runtime(runtime, "durable_thread", envelope_required)
-        candidates.append(candidate("durable-relevant-role-context", "durable_thread", "filtered_history", "Relevant durable continuity can reduce rehydration cost.", "low", 3, tier, reasoning, mapping, not failures, failures))
+        candidates.append(candidate("durable-relevant-role-context", "reuse_relevant_thread", "durable_thread", "filtered_history", "Relevant durable continuity can reduce rehydration cost.", "low", 3, tier, reasoning, mapping, not failures, failures))
 
     needs_fresh = role.get("specialization_available") is True or required_independence != "none" or relevance == "low"
     if needs_fresh:
         mapping, failures = route_runtime(runtime, "fresh_thread", envelope_required)
         quality = 3 if role.get("specialization_available") is True or required_independence != "none" else 2
-        candidates.append(candidate("fresh-specialized-or-independent", "fresh_thread", "fresh", "Fresh context avoids unrelated retained history and supports specialization or independence.", "medium", quality, tier, reasoning, mapping, not failures and quality >= quality_floor, failures + ([] if quality >= quality_floor else ["quality floor not met"])))
+        candidates.append(candidate("fresh-specialized-or-independent", "fresh_bounded_thread", "fresh_thread", "fresh", "Fresh context avoids unrelated retained history and supports specialization or independence.", "medium", quality, tier, reasoning, mapping, not failures and quality >= quality_floor, failures + ([] if quality >= quality_floor else ["quality floor not met"])))
 
     if work.get("safe_parallelism") is True:
         mapping, failures = route_runtime(runtime, "subagent", envelope_required)
-        candidates.append(candidate("bounded-subagent", "subagent", "artifact_reference", "Safe disjoint side work may reduce critical-path latency.", "medium", 2, tier, reasoning, mapping, not failures and 2 >= quality_floor, failures + ([] if 2 >= quality_floor else ["quality floor not met"])))
+        candidates.append(candidate("bounded-subagent", "bounded_subagent", "subagent", "artifact_reference", "Safe disjoint side work may reduce critical-path latency.", "medium", 2, tier, reasoning, mapping, not failures and 2 >= quality_floor, failures + ([] if 2 >= quality_floor else ["quality floor not met"])))
 
-    for topology, reason in (("fork", "Fork route is recorded as non-enforcing."), ("portable", "Portable fallback cannot enforce runtime settings.")):
-        mapping, failures = route_runtime(runtime, topology, envelope_required)
-        candidates.append(candidate(f"{topology}-negative-control", topology, "full_continuity" if topology == "fork" else "artifact_reference", reason, "medium", 1, tier, reasoning, mapping, False, failures or ["unsupported advisory fallback below quality floor"]))
+    if work.get("batch_checkpoint_safe") is True:
+        mapping, failures = route_runtime(runtime, "batch", False)
+        candidates.append(candidate("batch-checkpoint", "batch_checkpoint", "batch", "artifact_reference", "Related findings can be reviewed together without losing exact-head safety.", "low", 2, tier, reasoning, mapping, not failures and 2 >= quality_floor, failures + ([] if 2 >= quality_floor else ["quality floor not met"])))
 
     candidates = candidates[:4]
     eligible = [item for item in candidates if item["eligible"]]
     if not eligible:
-        return result(root, policy_resolution, task_class, task_state, candidates, "human_stop", None, ["No route meets the authority, evidence, and runtime quality floor."], reset, tier, reasoning, override)
-    material_benefit = any((role.get("specialization_available") is True, continuity in {"medium", "high"} and relevance in {"medium", "high"}, required_independence != "none", work.get("safe_parallelism") is True))
-    selected = sorted(eligible, key=lambda item: (COST_RANK[item["expected_cost_band"]], -{"low": 1, "medium": 2, "high": 3}[item["expected_quality_band"]], item["candidate_id"]))[0]
-    decision = "dispatch_advisory" if material_benefit and selected["topology"] != "serial" else "no_dispatch"
-    if decision == "no_dispatch":
+        return result(root, policy_resolution, task_class, task_state, candidates, "hold_for_decision", None, ["No route meets the authority, evidence, and runtime quality floor."], reset, tier, reasoning, override)
+    material_benefit = any((role.get("specialization_available") is True, continuity in {"medium", "high"} and relevance in {"medium", "high"}, required_independence != "none", work.get("safe_parallelism") is True, work.get("batch_checkpoint_safe") is True))
+    selection_pool = [item for item in eligible if item["route"] != "serial_current_session"] if material_benefit else eligible
+    if not selection_pool:
+        selection_pool = eligible
+    selected = sorted(selection_pool, key=lambda item: (COST_RANK[item["expected_cost_band"]], -{"low": 1, "medium": 2, "high": 3}[item["expected_quality_band"]], item["candidate_id"]))[0]
+    decision = selected["route"] if material_benefit and selected["route"] != "serial_current_session" else "serial_current_session"
+    if decision == "serial_current_session":
         selected = next(item for item in eligible if item["topology"] == "serial")
     return result(root, policy_resolution, task_class, task_state, candidates, decision, selected, [], reset, tier, reasoning, override)
 
@@ -448,12 +516,12 @@ def result(root: dict[str, Any], policy_resolution: dict[str, Any], task_class: 
 def pareto_explanation(candidates: list[dict[str, Any]], selected: dict[str, Any] | None, decision: str) -> list[str]:
     eligible = [item for item in candidates if item["eligible"]]
     explanation = [f"candidate_set={len(candidates)}; eligible={len(eligible)}; limit=4"]
-    if decision == "human_stop":
+    if decision == "hold_for_decision":
         explanation.append("No eligible advisory route clears the required authority/evidence/runtime floor.")
-    elif decision == "no_dispatch":
+    elif decision == "serial_current_session":
         explanation.append("Serial is selected because no material dispatch benefit clears its handoff and context cost.")
     elif selected:
-        explanation.append(f"Selected {selected['candidate_id']} as the least-cost eligible route that clears the quality floor.")
+        explanation.append(f"Selected {selected['route']} via {selected['candidate_id']} as the least-cost eligible route that clears the quality floor.")
     return explanation
 
 

--- a/scripts/test_codex_route_adapter.py
+++ b/scripts/test_codex_route_adapter.py
@@ -16,7 +16,7 @@ ADAPTER = ROOT / "scripts" / "plan_codex_route_adapter.py"
 
 
 def portable(topology: str = "fresh_thread", decision: str = "dispatch_advisory", explicit: bool = True) -> dict:
-    selected = None if decision != "dispatch_advisory" else {"topology": topology, "context_mode": "fresh"}
+    selected = None if decision in {"no_dispatch", "human_stop", "serial_current_session", "batch_checkpoint", "hold_for_decision"} else {"topology": topology, "context_mode": "fresh", "route": decision}
     return {
         "work_unit": {"work_unit_id": "AF18-421-fixture", "requires_explicit_envelope": explicit},
         "dispatch_plan": {"route_decision": decision, "selected_candidate": selected, "requested_capability_tier": "balanced", "requested_reasoning_tier": "medium"},
@@ -113,6 +113,14 @@ def main() -> int:
     no_dispatch = input_for(portable(decision="no_dispatch"))
     code, output = run(no_dispatch)
     expect("no-dispatch-remains-no-call", code == 0 and output["adapter_plan"]["adapter_decision"] == "no_adapter_dispatch" and output["adapter_plan"]["tool_call_proposed"] == "not_available", output, errors)
+
+    serial_route = input_for(portable(decision="serial_current_session"))
+    code, output = run(serial_route)
+    expect("serial-route-remains-no-call", code == 0 and output["adapter_plan"]["adapter_decision"] == "no_adapter_dispatch" and output["mutation_performed"] is False and output["dispatch_performed"] is False, output, errors)
+
+    bounded_subagent = input_for(portable("subagent", decision="bounded_subagent"))
+    code, output = run(bounded_subagent)
+    expect("bounded-subagent-new-route-fails-closed", code == 0 and provenance_recovery(output, "unknown"), output, errors)
 
     absent = input_for(portable("subagent"))
     absent.pop("schema_observation")

--- a/scripts/test_collaboration_route_planner.py
+++ b/scripts/test_collaboration_route_planner.py
@@ -27,7 +27,7 @@ def base_fixture() -> dict:
         },
         "work_unit": {"work_unit_id": "AF18-fixture", "purpose": "bounded planner fixture", "risk": "medium", "ambiguity": "low", "verification_oracle": "fixture assertions", "stop_conditions": ["contract drift"]},
         "role_context": {"required_role": "implementer", "specialization_available": False, "continuity_value": "none", "context_relevance": "low", "independence_requirement": "none"},
-        "runtime_capabilities": {"observed_at": "2026-07-21T00:00:00Z", "mechanisms": {"create_thread": {"status": "supported", "supports_explicit_envelope": True, "effective_configuration": "unknown"}, "send_message_to_thread": {"status": "supported", "supports_explicit_envelope": True, "effective_configuration": "unknown"}, "spawn_agent": {"status": "supported", "supports_explicit_envelope": True, "effective_configuration": "unknown"}, "fork_thread": {"status": "supported", "supports_explicit_envelope": False, "effective_configuration": "unknown"}, "portable_prompt": {"status": "supported", "supports_explicit_envelope": False, "effective_configuration": "not_available"}}},
+        "runtime_capabilities": {"observed_at": "2026-07-21T00:00:00Z", "mechanisms": {"create_thread": {"status": "supported", "supports_explicit_envelope": True, "effective_configuration": "unknown"}, "send_message_to_thread": {"status": "supported", "supports_explicit_envelope": True, "effective_configuration": "unknown"}, "spawn_agent": {"status": "supported", "supports_explicit_envelope": True, "effective_configuration": "unknown"}, "fork_thread": {"status": "supported", "supports_explicit_envelope": False, "effective_configuration": "unknown"}, "portable_prompt": {"status": "supported", "supports_explicit_envelope": False, "effective_configuration": "not_available"}, "worktree_batch": {"status": "supported", "supports_explicit_envelope": False, "effective_configuration": "unknown"}}},
     }
 
 
@@ -54,21 +54,23 @@ def main() -> int:
     for anchor in ("PolicySet", "WorkUnit", "RoleContext", "RuntimeCapabilities", "RouteCandidate", "DispatchPlan", "OverrideGrant", "EvaluationRecord", "ConversationProjection", "policy_profile", "task_class", "provider, provider_slug, model, or model_slug"):
         errors.extend(expect(f"schema-{anchor}", anchor in schema, "missing schema anchor"))
 
-    no_dispatch = base_fixture()
-    code, output = run_fixture(no_dispatch)
-    errors.extend(expect("no-dispatch-exit", code == 0, output))
+    serial_fixture = base_fixture()
+    code, output = run_fixture(serial_fixture)
+    errors.extend(expect("serial-exit", code == 0, output))
     if code == 0:
-        errors.extend(expect("no-dispatch", output["dispatch_plan"]["route_decision"] == "no_dispatch", output))
+        errors.extend(expect("serial-route", output["dispatch_plan"]["route_decision"] == "serial_current_session", output))
         errors.extend(expect("no-mutation", output["mutation_performed"] is False and output["dispatch_performed"] is False, output))
         errors.extend(expect("candidate-limit", len(output["route_candidates"]) <= 4, output))
         projection = output["conversation_projection"]
         errors.extend(expect("unsaved-normal-default", projection["effective_policy"] == {"profile": "normal", "source": "unsaved_normal_default", "validity": "unsaved_default", "fingerprint_or_unsaved_default": "unsaved-normal-default"}, projection))
+        errors.extend(expect("three-level-lifecycle", set(projection["lifecycle"]) == {"collaboration_operating_mode", "execution_context_lifecycle", "bounded_work_unit_lifecycle", "next_action"}, projection))
+        errors.extend(expect("single-next-action", isinstance(projection["next_action"], str) and projection["next_action"] == projection["lifecycle"]["next_action"], projection))
 
     routine = base_fixture()
     routine["work_unit"].update({"task_class": "routine", "material_signals": []})
     code, output = run_fixture(routine)
     if code == 0:
-        errors.extend(expect("routine-quiet", output["conversation_projection"]["emit_compact_marker"] is False and output["conversation_projection"]["next_action"] == "Continue serial work; no dispatch action is requested", output))
+        errors.extend(expect("routine-quiet", output["conversation_projection"]["emit_compact_marker"] is False and output["dispatch_plan"]["route_decision"] == "serial_current_session", output))
 
     setup_intent = base_fixture()
     setup_intent["policy_setup_requested"] = True
@@ -79,7 +81,7 @@ def main() -> int:
 
     material = base_fixture()
     material["work_unit"].update({"task_class": "complex", "material_signals": ["cross_boundary", "contradictory_evidence"], "task_class_correction": {"task_class": "complex", "scope": "AF18-fixture", "expires_after_work_unit": True}})
-    material["policy_sources"] = {"personal": {"validity": "valid", "profile": "high_performance", "fingerprint": "sha256:personal", "policy_set": material["policy_set"]}}
+    material["policy_sources"] = {"personal": {"validity": "valid", "profile": "performance", "fingerprint": "sha256:personal", "policy_set": material["policy_set"]}}
     code, output = run_fixture(material)
     if code == 0:
         projection = output["conversation_projection"]
@@ -88,7 +90,7 @@ def main() -> int:
 
     retained = base_fixture()
     retained["policy_sources"] = {
-        "project": {"validity": "drifted", "profile": "high_performance", "fingerprint": "sha256:drifted"},
+        "project": {"validity": "drifted", "profile": "performance", "fingerprint": "sha256:drifted"},
         "personal": {"validity": "valid", "profile": "economy", "fingerprint": "sha256:prior", "policy_set": retained["policy_set"]},
     }
     code, output = run_fixture(retained)
@@ -106,7 +108,7 @@ def main() -> int:
 
     precedence = base_fixture()
     precedence["policy_sources"] = {
-        "current_work_unit_grant": {"validity": "valid", "profile": "high_performance", "fingerprint": "sha256:grant", "policy_set": precedence["policy_set"]},
+        "current_work_unit_grant": {"validity": "valid", "profile": "performance", "fingerprint": "sha256:grant", "policy_set": precedence["policy_set"]},
         "project": {"validity": "valid", "profile": "economy", "fingerprint": "sha256:project", "policy_set": precedence["policy_set"]},
         "personal": {"validity": "valid", "profile": "normal", "fingerprint": "sha256:personal", "policy_set": precedence["policy_set"]},
     }
@@ -114,18 +116,38 @@ def main() -> int:
     if code == 0:
         errors.extend(expect("policy-precedence", output["conversation_projection"]["effective_policy"]["source"] == "current_work_unit_grant" and output["conversation_projection"]["effective_policy"]["fingerprint_or_unsaved_default"] == "sha256:grant", output))
 
+    economy = base_fixture()
+    economy["policy_sources"] = {"project": {"validity": "valid", "profile": "economy", "fingerprint": "sha256:economy", "policy_set": economy["policy_set"]}}
+    economy["work_unit"].update({"task_class": "standard"})
+    code, output = run_fixture(economy)
+    if code == 0:
+        errors.extend(expect("economy-mode", output["conversation_projection"]["effective_policy"]["profile"] == "economy" and output["conversation_projection"]["recommendation"]["abstract_tier"] == {"capability": "economy", "reasoning": "low"}, output))
+
     durable = base_fixture()
     durable["role_context"].update({"continuity_value": "high", "context_relevance": "high"})
     durable["work_unit"]["requires_explicit_envelope"] = True
     code, output = run_fixture(durable)
     if code == 0:
-        errors.extend(expect("durable-route", output["dispatch_plan"]["selected_candidate"]["topology"] == "durable_thread", output))
+        errors.extend(expect("durable-route", output["dispatch_plan"]["route_decision"] == "reuse_relevant_thread" and output["dispatch_plan"]["selected_candidate"]["topology"] == "durable_thread", output))
 
     fresh = base_fixture()
     fresh["role_context"].update({"specialization_available": True, "continuity_value": "none", "context_relevance": "low"})
     code, output = run_fixture(fresh)
     if code == 0:
-        errors.extend(expect("specialist-fresh-route", output["dispatch_plan"]["selected_candidate"]["topology"] == "fresh_thread", output))
+        errors.extend(expect("specialist-fresh-route", output["dispatch_plan"]["route_decision"] == "fresh_bounded_thread" and output["dispatch_plan"]["selected_candidate"]["topology"] == "fresh_thread", output))
+
+    subagent = base_fixture()
+    subagent["work_unit"]["safe_parallelism"] = True
+    code, output = run_fixture(subagent)
+    if code == 0:
+        errors.extend(expect("bounded-subagent-route", output["dispatch_plan"]["route_decision"] == "bounded_subagent" and output["dispatch_plan"]["selected_candidate"]["topology"] == "subagent", output))
+        errors.extend(expect("subagent-no-dispatch", output["mutation_performed"] is False and output["dispatch_performed"] is False, output))
+
+    batch = base_fixture()
+    batch["work_unit"]["batch_checkpoint_safe"] = True
+    code, output = run_fixture(batch)
+    if code == 0:
+        errors.extend(expect("batch-checkpoint-route", output["dispatch_plan"]["route_decision"] == "batch_checkpoint" and output["conversation_projection"]["lifecycle"]["execution_context_lifecycle"]["eligible_actions"]["archive"] is True, output))
 
     unrelated = base_fixture()
     unrelated["role_context"].update({"continuity_value": "high", "context_relevance": "low"})
@@ -133,13 +155,13 @@ def main() -> int:
     if code == 0:
         topologies = {item["topology"] for item in output["route_candidates"]}
         errors.extend(expect("unrelated-history-avoids-durable", "durable_thread" not in topologies and "fresh_thread" in topologies, output))
-        errors.extend(expect("unrelated-history-no-dispatch", output["dispatch_plan"]["route_decision"] == "no_dispatch", output))
+        errors.extend(expect("unrelated-history-serial", output["dispatch_plan"]["route_decision"] == "serial_current_session", output))
 
     review = base_fixture()
     review["role_context"].update({"required_role": "reviewer", "specialization_available": True, "independence_requirement": "separate_evidence"})
     code, output = run_fixture(review)
     if code == 0:
-        errors.extend(expect("independent-review", output["dispatch_plan"]["selected_candidate"]["topology"] == "fresh_thread", output))
+        errors.extend(expect("independent-review", output["dispatch_plan"]["route_decision"] == "fresh_bounded_thread" and output["dispatch_plan"]["selected_candidate"]["topology"] == "fresh_thread", output))
 
     omitted = base_fixture()
     omitted["role_context"].update({"specialization_available": True, "independence_requirement": "separate_context"})
@@ -147,7 +169,7 @@ def main() -> int:
     omitted["runtime_capabilities"]["mechanisms"]["create_thread"]["supports_explicit_envelope"] = False
     code, output = run_fixture(omitted)
     if code == 0:
-        errors.extend(expect("omitted-envelope-human-stop", output["dispatch_plan"]["route_decision"] == "human_stop", output))
+        errors.extend(expect("omitted-envelope-hold", output["dispatch_plan"]["route_decision"] == "hold_for_decision", output))
         errors.extend(expect("omitted-envelope-observable-unknown", output["conversation_projection"]["runtime_projection"]["observable"]["effective_configuration"] == "unknown", output))
 
     unknown_runtime = base_fixture()
@@ -155,14 +177,12 @@ def main() -> int:
     unknown_runtime["runtime_capabilities"]["mechanisms"]["create_thread"]["status"] = "unknown"
     code, output = run_fixture(unknown_runtime)
     if code == 0:
-        errors.extend(expect("unknown-runtime-human-stop", output["dispatch_plan"]["route_decision"] == "human_stop" and output["conversation_projection"]["runtime_projection"]["observable"]["status"] == "unknown", output))
+        errors.extend(expect("unknown-runtime-hold", output["dispatch_plan"]["route_decision"] == "hold_for_decision" and output["conversation_projection"]["runtime_projection"]["observable"]["status"] == "unknown", output))
 
     unsupported = base_fixture()
     unsupported["runtime_capabilities"]["mechanisms"]["fork_thread"]["status"] = "unsupported"
     code, output = run_fixture(unsupported)
     if code == 0:
-        fork = next(item for item in output["route_candidates"] if item["topology"] == "fork")
-        errors.extend(expect("fork-non-enforcing", fork["eligible"] is False and fork["runtime_mapping"]["enforcement"] == "enforcement_not_available", fork))
         limitations = {item["mechanism"]: item for item in output["runtime_limitations"]}
         errors.extend(expect("heartbeat-non-enforcing", limitations["heartbeat"]["enforcement"] == "non_enforcing", limitations))
         errors.extend(expect("hook-unsupported", limitations["hook"]["enforcement"] == "unsupported", limitations))
@@ -177,17 +197,26 @@ def main() -> int:
         plan = output["dispatch_plan"]
         errors.extend(expect("escalation-reset", plan["requested_capability_tier"] == "frontier" and plan["reset"]["persists"] is False, plan))
 
+    low_limit = base_fixture()
+    low_limit["policy_sources"] = {"current_work_unit_grant": {"validity": "valid", "profile": "low_limit", "fingerprint": "sha256:low-limit", "policy_set": low_limit["policy_set"]}}
+    low_limit["work_unit"].update({"task_class": "complex", "material_signals": ["cost_spike", "callback_recovery"]})
+    code, output = run_fixture(low_limit)
+    if code == 0:
+        projection = output["conversation_projection"]
+        errors.extend(expect("low-limit-mode", projection["effective_policy"]["profile"] == "low_limit" and projection["lifecycle"]["collaboration_operating_mode"]["temporary"] is True, output))
+        errors.extend(expect("low-limit-tier", projection["recommendation"]["abstract_tier"] == {"capability": "economy", "reasoning": "low"}, output))
+
     human = base_fixture()
     human["work_unit"]["human_owned_actions"] = ["approve external cost"]
     code, output = run_fixture(human)
     if code == 0:
-        errors.extend(expect("human-stop", output["dispatch_plan"]["route_decision"] == "human_stop" and output["route_candidates"] == [], output))
+        errors.extend(expect("human-stop", output["dispatch_plan"]["route_decision"] == "hold_for_decision" and output["route_candidates"] == [], output))
 
     invalid_override = base_fixture()
     invalid_override["override_grant"] = {"active": True, "scope": "another-work-unit", "expires_after_work_unit": True, "reset_required": True}
     code, output = run_fixture(invalid_override)
     if code == 0:
-        errors.extend(expect("override-scope-human-stop", output["dispatch_plan"]["route_decision"] == "human_stop" and "scope does not match" in output["dispatch_plan"]["stop_conditions"][0], output))
+        errors.extend(expect("override-scope-hold", output["dispatch_plan"]["route_decision"] == "hold_for_decision" and "scope does not match" in output["dispatch_plan"]["stop_conditions"][0], output))
 
     forbidden = base_fixture()
     forbidden["policy_set"]["model_slug"] = "not-portable"

--- a/workflows/github-collaboration-helper.md
+++ b/workflows/github-collaboration-helper.md
@@ -54,12 +54,12 @@ ownership and is outside AF11 activation scope.
 
 ## Portable Route Planning
 
-AF18 provides a read-only, portable route-planning surface at
+AF18 provides a read-only, portable lifecycle route-planning surface at
 `scripts/plan_collaboration_routes.py`. It consumes a JSON fixture containing
 PolicySet, WorkUnit, RoleContext, RuntimeCapabilities, an optional
 OverrideGrant, and prior EvaluationRecord evidence. It returns a bounded
 DispatchPlan with at most four candidates, a Pareto-style explanation, explicit
-confidence, reset, and Human-stop conditions.
+confidence, reset, and hold-for-decision conditions.
 
 The conversation-facing projection resolves policy deterministically: current
 work-unit Human grant, project record, personal record, then an explicitly
@@ -67,9 +67,20 @@ labelled unsaved `normal` default. It exposes the selected profile, source,
 validity, and fingerprint or `unsaved-normal-default`; invalid or drifted
 sources remain visible. It also projects task class, bounded one-work-unit
 corrections, material signals, a compact recommendation, requested-versus-
-observable runtime state, attention, and exactly one next action. Routine
-serial/no-dispatch work suppresses a separate marker unless attention or a
-material correction exists.
+observable runtime state, attention, and exactly one next action. The portable
+mode is one of `economy`, `normal`, `performance`, or temporary `low_limit`.
+The lifecycle section models three aligned levels: collaboration operating
+mode, execution-context lifecycle, and bounded work-unit lifecycle. It reports
+create/reuse/compact-rehydrate/callback/cooldown/archive eligibility as
+guidance only. Routine `serial_current_session` work suppresses a separate
+marker unless attention or a material correction exists.
+
+The planner recommends only these bounded routes:
+`serial_current_session`, `reuse_relevant_thread`, `fresh_bounded_thread`,
+`bounded_subagent`, `batch_checkpoint`, or `hold_for_decision`. Role
+specialization value, project continuity relevance, and independent-review
+value are explicit inputs; the planner must not infer them from role label or
+thread age alone.
 
 The planner is advisory only: it always reports `mutation_performed: false` and
 `dispatch_performed: false`. It does not create, fork, resume, or message a
@@ -85,9 +96,9 @@ Example:
 python3 scripts/plan_collaboration_routes.py --input-json route-fixture.json --json
 ```
 
-Treat a `human_stop` result as a decision boundary, not a failed dispatch. A
-later runtime adapter may map an accepted advisory plan to supported tool calls;
-that adapter is outside this workflow slice.
+Treat `hold_for_decision` as a decision boundary, not a failed dispatch. A later
+runtime adapter may map an accepted advisory plan to supported tool calls; that
+adapter is outside this workflow slice.
 
 This planner does not set up, write, read back, or retain personal/project
 policy records. It does not create telemetry, a monitoring history, dashboard,


### PR DESCRIPTION
## Summary

Implements #434 as a portable, read-only context-aware lifecycle planner extension for AF18.

Changed surfaces:
- `scripts/plan_collaboration_routes.py`
- `scripts/test_collaboration_route_planner.py`
- `schemas/collaboration-routing-policy.schema.yaml`
- `workflows/github-collaboration-helper.md`
- `scripts/plan_codex_route_adapter.py`
- `scripts/test_codex_route_adapter.py`

## Execution Contract

Owner role: implementer
Review role: reviewer
Acceptance role: architect
Completion handoff: to:reviewer
Branch strategy: integration-branch
Target branch: codex/af18-collaboration-cost-policy-integration
Base branch: codex/af18-collaboration-cost-policy-integration
Reviewer target: separate reviewer role
Risk class: high
Depends on: #420, #429, #433

## Scope

- Adds #434 bounded route vocabulary: `serial_current_session`, `reuse_relevant_thread`, `fresh_bounded_thread`, `bounded_subagent`, `batch_checkpoint`, `hold_for_decision`.
- Aligns effective policy modes to `economy`, `normal`, `performance`, and temporary `low_limit`.
- Adds lifecycle projection across collaboration operating mode, execution-context lifecycle, and bounded work-unit lifecycle.
- Reports create/reuse/compact-rehydrate/callback/cooldown/archive eligibility and exactly one next action.
- Keeps role specialization value, continuity relevance, and independent-review value as explicit inputs.
- Preserves advisory behavior: `mutation_performed:false` and `dispatch_performed:false`.
- Adds minimal Codex adapter compatibility for the new portable route vocabulary while preserving #421 fail-closed/no-dispatch behavior.

## Verification

- `python3 -m py_compile scripts/plan_collaboration_routes.py scripts/test_collaboration_route_planner.py scripts/plan_codex_route_adapter.py scripts/test_codex_route_adapter.py`
- `python3 scripts/test_collaboration_route_planner.py`
- `python3 scripts/test_codex_route_adapter.py`
- `python3 scripts/check_consistency.py`
- `git diff --check origin/codex/af18-collaboration-cost-policy-integration...HEAD`
- targeted grep/read-through for removed old planner route/profile terms and no mutation/dispatch behavior

## Boundaries

No policy-record write, runtime/config/hook/custom-agent mutation, actual dispatch/fork/thread lifecycle action, telemetry/report product, Vault/generated/Project mutation, main merge, release/tag, V2.1 work, destructive action, or release of #430/#435/#436/#426 Stage D/#427.
