### PR TITLE
Implement AF18 collaboration policy lifecycle

### DIFF
--- a/schemas/collaboration-routing-policy.schema.yaml
+++ b/schemas/collaboration-routing-policy.schema.yaml
@@ -48,9 +48,19 @@ objects:
       - "primary fields are compact conversation guidance; JSON stays secondary technical evidence"
       - "routine serial_current_session paths emit no separate marker unless attention or a material correction exists"
       - "runtime projection distinguishes requested abstract tier from observable, unknown, or unsupported runtime configuration"
-      - "explicit set up collaboration policy intent is a no-write handoff to the later lifecycle slice"
+      - "explicit set up collaboration policy intent is distinct from guided-onboarding and follows preflight, preview, one confirmation, one selected policy-record write, and same-conversation readback"
       - "lifecycle models collaboration operating mode, execution-context lifecycle, and bounded work-unit lifecycle"
       - "create, reuse, compact-rehydrate, callback, cooldown, and archive eligibility are reported only as next-action guidance"
+      - "fixed setup profiles are 节俭, 正常, and 高性能"
+  PolicyRecordLifecycle:
+    required: [action, scope, path, diff, confirmation_required, write_performed, readback]
+    rules:
+      - "personal path is ~/.agent-foundry/collaboration-routing-policy.yaml"
+      - "project path is <repo>/.agent-foundry/collaboration-routing-policy.yaml"
+      - "policy record is versioned and contains policy data only"
+      - "invalid input, failed write, failed validation/readback, or fingerprint mismatch preserves the prior effective state and shows one recovery action"
+      - "read-only inspection and dry-run preview perform no writes"
+      - "new Agent Foundry role task creation prefers project-scoped Codex tasks under local-eb6e22ec0d00ef785d687022be1b433d when creating a new role task"
   OverrideGrant:
     required: [active, scope, expires_after_work_unit, reset_required]
     rules:
@@ -73,9 +83,12 @@ allowed_values:
   policy_profile: [economy, normal, performance, low_limit]
   policy_validity: [valid, invalid, drifted, missing, unsaved_default]
   task_class: [routine, standard, complex, human_owned]
+  policy_lifecycle_action: [inspect, preview, apply]
+  policy_lifecycle_scope: [personal, project]
 
 forbidden:
   - "provider, provider_slug, model, or model_slug fields in PolicySet"
-  - "dispatch, thread, subagent, automation, runtime, config, hook, custom-agent, Vault, generated, or Project mutation"
+  - "dispatch, thread, subagent, automation, runtime, config, hook, custom-agent, Vault, generated, GitHub Project, or telemetry mutation"
   - "claims that omitted runtime envelope fields reveal effective retained settings"
-  - "policy record writes, readback writes, telemetry persistence, monitoring, dashboards, or report products in this advisory planner"
+  - "live personal or live repository policy writes outside an explicit confirmed setup action or isolated test root"
+  - "telemetry persistence, monitoring, dashboards, or report products"

--- a/scripts/plan_codex_route_adapter.py
+++ b/scripts/plan_codex_route_adapter.py
@@ -155,6 +155,37 @@ def lifecycle_evidence(portable: dict[str, Any], topology: str) -> dict[str, Any
     }
 
 
+def role_task_dispatch_evidence(portable: dict[str, Any], root: dict[str, Any]) -> dict[str, Any]:
+    projection = portable.get("conversation_projection", {})
+    policy = projection.get("role_task_dispatch_policy", {}) if isinstance(projection, dict) else {}
+    if not isinstance(policy, dict):
+        policy = {}
+    requested = portable.get("dispatch_plan", {})
+    adapter_context = root.get("adapter_context", {})
+    project_id = policy.get("project_id") or adapter_context.get("project_id") or "not_available"
+    project_root = policy.get("project_root") or adapter_context.get("project_root") or "not_available"
+    project_scoped = policy.get("project_scoped_creation", "unknown") != "unavailable" and project_id != "not_available"
+    fallback = policy.get("degraded_projectless_fallback", {})
+    if not isinstance(fallback, dict):
+        fallback = {}
+    return {
+        "mechanism": "dry_run_codex_adapter",
+        "project_scoped_vs_projectless": "project_scoped" if project_scoped else "projectless_degraded",
+        "model_thinking_envelope": {
+            "capability_tier": requested.get("requested_capability_tier", "not_available"),
+            "reasoning_tier": requested.get("requested_reasoning_tier", "not_available"),
+        },
+        "target_project": {"project_id": project_id, "project_root": project_root},
+        "existing_healthy_role_task_preferred": policy.get("existing_healthy_role_task_preferred", True),
+        "fallback": {
+            "used": not project_scoped,
+            "allowed": fallback.get("allowed", not project_scoped),
+            "bounded_to": fallback.get("bounded_to", "one_work_unit"),
+            "reason": "project-scoped task creation unavailable or unsafe" if not project_scoped else "not_used",
+        },
+    }
+
+
 def project(root: dict[str, Any]) -> dict[str, Any]:
     portable = require_object(root, "portable_plan")
     dispatch_plan = require_object(portable, "dispatch_plan")
@@ -166,7 +197,7 @@ def project(root: dict[str, Any]) -> dict[str, Any]:
     if decision in NO_ADAPTER_ROUTES:
         return output(
             portable, None, None, "no_adapter_dispatch", [],
-            "Continue the portable no-dispatch or Human-stop path; no Codex tool call is proposed.",
+            "Continue the portable no-dispatch or Human-stop path; no Codex tool call is proposed.", root=root,
         )
     if not isinstance(selected, dict):
         fail("portable dispatch advisory requires selected_candidate")
@@ -174,13 +205,13 @@ def project(root: dict[str, Any]) -> dict[str, Any]:
     if topology not in TOPOLOGY_TO_TOOL:
         return output(
             portable, topology, None, "unsupported", [f"Codex adapter has no supported mapping for topology {topology}"],
-            "Choose a supported fresh, durable, or subagent route, or stop for a Human decision.",
+            "Choose a supported fresh, durable, or subagent route, or stop for a Human decision.", root=root,
         )
     schema, provenance = validate_observation(root)
     if schema is None:
         return output(
             portable, topology, None, "unknown", [provenance["reason"]],
-            "Obtain a verified runtime-owned Codex schema capture before proposing any envelope.", provenance=provenance,
+            "Obtain a verified runtime-owned Codex schema capture before proposing any envelope.", provenance=provenance, root=root,
         )
     tool_name, required_fields = TOPOLOGY_TO_TOOL[topology]
     observed = tool_observation(schema, tool_name)
@@ -200,21 +231,22 @@ def project(root: dict[str, Any]) -> dict[str, Any]:
     if requires_explicit and attention:
         return output(
             portable, topology, observed, "unsupported", attention,
-            "Provide a currently supported explicit Codex envelope or keep the portable plan at no dispatch.", provenance=provenance,
+            "Provide a currently supported explicit Codex envelope or keep the portable plan at no dispatch.", provenance=provenance, root=root,
         )
     if attention:
         return output(
             portable, topology, observed, "human_stop", attention,
-            "Do not inherit unknown Codex settings; provide an explicit envelope or stop for a Human decision.", provenance=provenance,
+            "Do not inherit unknown Codex settings; provide an explicit envelope or stop for a Human decision.", provenance=provenance, root=root,
         )
     return output(
         portable, topology, observed, "dry_run_ready", [],
-        "Review this dry-run Codex envelope before any separately authorized dispatch.", envelope, provenance,
+        "Review this dry-run Codex envelope before any separately authorized dispatch.", envelope, provenance, root=root,
     )
 
 
-def output(portable: dict[str, Any], topology: str | None, observed: dict[str, Any] | None, decision: str, attention: list[str], next_action: str, envelope: dict[str, Any] | None = None, provenance: dict[str, Any] | None = None) -> dict[str, Any]:
+def output(portable: dict[str, Any], topology: str | None, observed: dict[str, Any] | None, decision: str, attention: list[str], next_action: str, envelope: dict[str, Any] | None = None, provenance: dict[str, Any] | None = None, root: dict[str, Any] | None = None) -> dict[str, Any]:
     dispatch_plan = portable["dispatch_plan"]
+    adapter_root = root or {}
     requested = {
         "capability_tier": dispatch_plan.get("requested_capability_tier", "not_available"),
         "reasoning_tier": dispatch_plan.get("requested_reasoning_tier", "not_available"),
@@ -237,6 +269,7 @@ def output(portable: dict[str, Any], topology: str | None, observed: dict[str, A
             "tool_call_proposed": observed.get("tool") if observed else "not_available",
             "explicit_envelope": envelope or {},
             "lifecycle_evidence": lifecycle_evidence(portable, topology or "not_available"),
+            "role_task_dispatch_evidence": role_task_dispatch_evidence(portable, adapter_root),
         },
         "conversation_projection": {
             "portable": portable["conversation_projection"],

--- a/scripts/plan_collaboration_routes.py
+++ b/scripts/plan_collaboration_routes.py
@@ -371,7 +371,8 @@ def lifecycle_action(root: dict[str, Any], fallback_policy: dict[str, Any], prio
     selected_profile = lifecycle.get("profile", prior_resolution["profile"])
     path = policy_record_path(root, scope)
     existing = read_record(path, scope, fallback_policy)
-    desired = policy_record(selected_profile, scope, fallback_policy, root) if action in {"preview", "apply"} else None
+    invalid_profile = action in {"preview", "apply"} and selected_profile not in SETUP_PROFILES
+    desired = None if invalid_profile or action == "inspect" else policy_record(selected_profile, scope, fallback_policy, root)
     diff = {
         "before": {
             "profile": existing.get("profile", prior_resolution["profile"] if prior_resolution["source"] == scope else "not_available"),
@@ -380,8 +381,8 @@ def lifecycle_action(root: dict[str, Any], fallback_policy: dict[str, Any], prio
             "path": str(path),
         },
         "after": {
-            "profile": desired.get("profile") if desired else "not_changed",
-            "validity": "valid" if desired else existing.get("validity", "missing"),
+            "profile": selected_profile if invalid_profile else (desired.get("profile") if desired else "not_changed"),
+            "validity": "invalid" if invalid_profile else ("valid" if desired else existing.get("validity", "missing")),
             "fingerprint": desired.get("fingerprint") if desired else existing.get("fingerprint", "not_available"),
             "path": str(path),
         },
@@ -401,6 +402,15 @@ def lifecycle_action(root: dict[str, Any], fallback_policy: dict[str, Any], prio
         "effective_next_dispatch": resolve_project_dispatch_context(root),
         "recovery_action": "Keep the prior effective state and retry with a valid profile/scope after inspecting the shown path.",
     }
+    if invalid_profile:
+        common.update(
+            {
+                "failure": "invalid policy_lifecycle.profile",
+                "invalid_input": {"field": "policy_lifecycle.profile", "value": selected_profile, "allowed_values": sorted(SETUP_PROFILES)},
+                "next_action": common["recovery_action"],
+            }
+        )
+        return common
     if action != "apply":
         common["next_action"] = "Review the read-only policy inspection." if action == "inspect" else "Confirm once to write exactly the selected policy record."
         return common

--- a/scripts/plan_collaboration_routes.py
+++ b/scripts/plan_collaboration_routes.py
@@ -4,14 +4,19 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import os
 import sys
+from pathlib import Path
 from typing import Any
 
 
 CAPABILITY_TIERS = {"economy", "balanced", "frontier"}
 REASONING_TIERS = {"low", "medium", "high"}
 POLICY_PROFILES = {"economy", "normal", "performance", "low_limit"}
+SETUP_PROFILES = {"economy", "normal", "performance"}
+PROFILE_LABELS = {"economy": "节俭", "normal": "正常", "performance": "高性能", "low_limit": "临时低限"}
 TASK_CLASSES = {"routine", "standard", "complex", "human_owned"}
 RUNTIME_STATUSES = {"supported", "unsupported", "unknown", "degraded", "not_available"}
 TOPOLOGY_MECHANISMS = {
@@ -33,6 +38,9 @@ BOUNDED_ROUTES = {
 }
 FORBIDDEN_POLICY_KEYS = {"provider", "provider_slug", "model", "model_slug"}
 COST_RANK = {"low": 1, "medium": 2, "high": 3}
+DEFAULT_PROJECT_ID = "local-eb6e22ec0d00ef785d687022be1b433d"
+PERSONAL_POLICY_RELATIVE = Path(".agent-foundry") / "collaboration-routing-policy.yaml"
+PROJECT_POLICY_RELATIVE = Path(".agent-foundry") / "collaboration-routing-policy.yaml"
 
 
 def fail(message: str) -> None:
@@ -104,8 +112,326 @@ def validate_policy(policy: dict[str, Any]) -> None:
         fail("policy_set allowed reasoning tiers are invalid")
 
 
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def fingerprint_for(record_without_fingerprint: dict[str, Any]) -> str:
+    return f"sha256:{hashlib.sha256(canonical_json(record_without_fingerprint).encode('utf-8')).hexdigest()}"
+
+
+def yaml_scalar(value: Any) -> str:
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if value is None:
+        return "null"
+    text = str(value)
+    if not text or any(ch in text for ch in ":#{}[],&*?|-<>=!%@\\\"'") or text.strip() != text:
+        return json.dumps(text, ensure_ascii=False)
+    return text
+
+
+def yaml_dump(value: Any, indent: int = 0) -> list[str]:
+    prefix = " " * indent
+    if isinstance(value, dict):
+        lines: list[str] = []
+        for key in sorted(value):
+            child = value[key]
+            if isinstance(child, dict):
+                lines.append(f"{prefix}{key}:")
+                lines.extend(yaml_dump(child, indent + 2))
+            else:
+                lines.append(f"{prefix}{key}: {yaml_scalar(child)}")
+        return lines
+    if isinstance(value, list):
+        return [f"{prefix}{yaml_scalar(value)}"]
+    return [f"{prefix}{yaml_scalar(value)}"]
+
+
+def render_record(record: dict[str, Any]) -> str:
+    return "\n".join(yaml_dump(record)) + "\n"
+
+
+def parse_scalar(text: str) -> Any:
+    text = text.strip()
+    if text == "true":
+        return True
+    if text == "false":
+        return False
+    if text == "null":
+        return None
+    if text.startswith('"') and text.endswith('"'):
+        return json.loads(text)
+    if text.startswith("[") or text.startswith("{"):
+        return json.loads(text)
+    try:
+        return int(text)
+    except ValueError:
+        return text
+
+
+def parse_simple_yaml(text: str) -> dict[str, Any]:
+    root: dict[str, Any] = {}
+    stack: list[tuple[int, dict[str, Any]]] = [(-1, root)]
+    for raw in text.splitlines():
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        indent = len(raw) - len(raw.lstrip(" "))
+        stripped = raw.strip()
+        if stripped.startswith("-"):
+            fail("policy record parser does not support list records")
+        if ":" not in stripped:
+            fail("policy record line is not key/value YAML")
+        key, raw_value = stripped.split(":", 1)
+        while stack and indent <= stack[-1][0]:
+            stack.pop()
+        parent = stack[-1][1]
+        if raw_value.strip():
+            parent[key] = parse_scalar(raw_value)
+        else:
+            child: dict[str, Any] = {}
+            parent[key] = child
+            stack.append((indent, child))
+    return root
+
+
+def policy_record_path(root: dict[str, Any], scope: str) -> Path:
+    lifecycle = root.get("policy_lifecycle", {})
+    paths = lifecycle.get("paths", {}) if isinstance(lifecycle, dict) else {}
+    if not isinstance(paths, dict):
+        paths = {}
+    if scope == "personal":
+        return Path(paths.get("personal") or Path(os.environ.get("HOME", str(Path.home()))) / PERSONAL_POLICY_RELATIVE).expanduser()
+    if scope == "project":
+        project_root = paths.get("project_root") or os.getcwd()
+        return Path(paths.get("project") or Path(project_root) / PROJECT_POLICY_RELATIVE).expanduser()
+    fail("policy lifecycle scope must be personal or project")
+
+
+def default_profile_policy(profile: str, fallback_policy: dict[str, Any]) -> dict[str, Any]:
+    policy = json.loads(canonical_json(fallback_policy))
+    thresholds = policy.setdefault("material_thresholds", {})
+    if profile == "economy":
+        thresholds.update({"economy_complex": 2, "performance_complex": 99})
+        policy["automatic_budget"] = {"max_escalations_per_work_unit": 0}
+    elif profile == "performance":
+        thresholds.update({"economy_complex": 1, "performance_complex": 1})
+        policy["automatic_budget"] = {"max_escalations_per_work_unit": max(1, int(policy.get("automatic_budget", {}).get("max_escalations_per_work_unit", 1)))}
+    else:
+        thresholds.update({"economy_complex": 2, "performance_complex": 1})
+        policy["automatic_budget"] = {"max_escalations_per_work_unit": int(policy.get("automatic_budget", {}).get("max_escalations_per_work_unit", 1))}
+    policy["policy_id"] = f"collaboration-routing-{profile}"
+    return policy
+
+
+def policy_record(profile: str, scope: str, fallback_policy: dict[str, Any], root: dict[str, Any]) -> dict[str, Any]:
+    if profile not in SETUP_PROFILES:
+        fail("policy lifecycle profile must be economy, normal, or performance")
+    project_context = resolve_project_dispatch_context(root)
+    record = {
+        "schema_version": 1,
+        "record_type": "collaboration-routing-policy",
+        "scope": scope,
+        "profile": profile,
+        "profile_label": PROFILE_LABELS[profile],
+        "policy_set": default_profile_policy(profile, fallback_policy),
+        "dispatch_management": project_context,
+    }
+    record["fingerprint"] = fingerprint_for(record)
+    return record
+
+
+def validate_policy_record(record: dict[str, Any], expected_scope: str | None = None) -> tuple[bool, str]:
+    if record.get("schema_version") != 1 or record.get("record_type") != "collaboration-routing-policy":
+        return False, "record version or type is invalid"
+    if record.get("scope") not in {"personal", "project"}:
+        return False, "record scope is invalid"
+    if expected_scope and record.get("scope") != expected_scope:
+        return False, "record scope does not match selected write path"
+    if record.get("profile") not in SETUP_PROFILES:
+        return False, "record profile is invalid"
+    policy = record.get("policy_set")
+    if not isinstance(policy, dict):
+        return False, "record policy_set is invalid"
+    try:
+        validate_policy(policy)
+    except ValueError as error:
+        return False, str(error)
+    expected = record.get("fingerprint")
+    without = {key: value for key, value in record.items() if key != "fingerprint"}
+    if expected != fingerprint_for(without):
+        return False, "record fingerprint mismatch"
+    dispatch = record.get("dispatch_management", {})
+    if not isinstance(dispatch, dict) or dispatch.get("new_role_task_preference") != "project_scoped_codex_task":
+        return False, "project-scoped role task preference is missing"
+    return True, "valid"
+
+
+def read_record(path: Path, source: str, fallback_policy: dict[str, Any]) -> dict[str, Any]:
+    if not path.exists():
+        return {"source": source, "validity": "missing", "path": str(path)}
+    try:
+        record = parse_simple_yaml(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        return {"source": source, "validity": "invalid", "path": str(path), "reason": str(error)}
+    valid, reason = validate_policy_record(record, "personal" if source == "personal" else "project")
+    if not valid:
+        return {"source": source, "validity": "invalid", "path": str(path), "reason": reason}
+    return {
+        "source": source,
+        "validity": "valid",
+        "profile": record["profile"],
+        "fingerprint": record["fingerprint"],
+        "path": str(path),
+        "policy_set": record.get("policy_set", fallback_policy),
+        "dispatch_management": record.get("dispatch_management", {}),
+    }
+
+
+def resolve_project_dispatch_context(root: dict[str, Any]) -> dict[str, Any]:
+    context = root.get("codex_project_context", {})
+    if not isinstance(context, dict):
+        context = {}
+    project_id = context.get("project_id") or DEFAULT_PROJECT_ID
+    project_root = context.get("project_root") or "/Users/jinghuliu/Desktop/Code/Personal Projects/agent-foundry"
+    surface = context.get("tool_surface", "unknown")
+    project_scoped_available = context.get("project_scoped_task_creation") is not False
+    return {
+        "existing_healthy_role_task_preferred": True,
+        "new_role_task_preference": "project_scoped_codex_task",
+        "project_scoped_creation": "preferred" if project_scoped_available else "unavailable",
+        "degraded_projectless_fallback": {
+            "allowed": not project_scoped_available,
+            "bounded_to": "one_work_unit",
+            "must_record_evidence": True,
+            "default_policy": False,
+        },
+        "project_id": project_id,
+        "project_root": project_root,
+        "tool_surface": surface,
+    }
+
+
+def profile_catalog(root: dict[str, Any]) -> list[dict[str, Any]]:
+    project_context = resolve_project_dispatch_context(root)
+    return [
+        {
+            "profile": "economy",
+            "label": PROFILE_LABELS["economy"],
+            "scope_options": ["personal", "project"],
+            "task_class_rules": {
+                "routine": "economy/low",
+                "standard": "economy/low",
+                "complex": "balanced/medium only when material signals meet threshold",
+                "human_owned": "hold_for_decision",
+            },
+            "dispatch_management": project_context,
+        },
+        {
+            "profile": "normal",
+            "label": PROFILE_LABELS["normal"],
+            "scope_options": ["personal", "project"],
+            "task_class_rules": {
+                "routine": "economy/low",
+                "standard": "balanced/medium",
+                "complex": "balanced/medium unless bounded escalation evidence applies",
+                "human_owned": "hold_for_decision",
+            },
+            "dispatch_management": project_context,
+        },
+        {
+            "profile": "performance",
+            "label": PROFILE_LABELS["performance"],
+            "scope_options": ["personal", "project"],
+            "task_class_rules": {
+                "routine": "economy/low",
+                "standard": "balanced/medium",
+                "complex": "frontier/high when material signals meet threshold",
+                "human_owned": "hold_for_decision",
+            },
+            "dispatch_management": project_context,
+        },
+    ]
+
+
+def lifecycle_action(root: dict[str, Any], fallback_policy: dict[str, Any], prior_resolution: dict[str, Any]) -> dict[str, Any]:
+    lifecycle = root.get("policy_lifecycle")
+    if lifecycle is None:
+        return {"mode": "not_requested", "write_performed": False, "selected_record": None, "effective_next_dispatch": resolve_project_dispatch_context(root)}
+    if not isinstance(lifecycle, dict):
+        fail("policy_lifecycle must be an object")
+    action = lifecycle.get("action", "inspect")
+    if action not in {"inspect", "preview", "apply"}:
+        fail("policy_lifecycle.action must be inspect, preview, or apply")
+    scope = lifecycle.get("scope", "project")
+    selected_profile = lifecycle.get("profile", prior_resolution["profile"])
+    path = policy_record_path(root, scope)
+    existing = read_record(path, scope, fallback_policy)
+    desired = policy_record(selected_profile, scope, fallback_policy, root) if action in {"preview", "apply"} else None
+    diff = {
+        "before": {
+            "profile": existing.get("profile", prior_resolution["profile"] if prior_resolution["source"] == scope else "not_available"),
+            "validity": existing.get("validity", "missing"),
+            "fingerprint": existing.get("fingerprint", "not_available"),
+            "path": str(path),
+        },
+        "after": {
+            "profile": desired.get("profile") if desired else "not_changed",
+            "validity": "valid" if desired else existing.get("validity", "missing"),
+            "fingerprint": desired.get("fingerprint") if desired else existing.get("fingerprint", "not_available"),
+            "path": str(path),
+        },
+    }
+    common = {
+        "mode": action,
+        "action_name": "set up collaboration policy" if action in {"preview", "apply"} else "inspect collaboration policy",
+        "scope": scope,
+        "path": str(path),
+        "profile_catalog": profile_catalog(root),
+        "preflight": {"existing_record": existing, "prior_effective_state": {key: value for key, value in prior_resolution.items() if key != "policy_set"}},
+        "diff": diff,
+        "confirmation_required": action == "apply",
+        "write_performed": False,
+        "readback": existing,
+        "selected_record": desired,
+        "effective_next_dispatch": resolve_project_dispatch_context(root),
+        "recovery_action": "Keep the prior effective state and retry with a valid profile/scope after inspecting the shown path.",
+    }
+    if action != "apply":
+        common["next_action"] = "Review the read-only policy inspection." if action == "inspect" else "Confirm once to write exactly the selected policy record."
+        return common
+    if lifecycle.get("confirmed") is not True:
+        common["next_action"] = "Confirm once before writing the selected policy record."
+        return common
+    before_text: str | None = None
+    try:
+        before_text = path.read_text(encoding="utf-8") if path.exists() and path.is_file() else None
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(render_record(desired), encoding="utf-8")
+        readback = read_record(path, scope, fallback_policy)
+    except OSError as error:
+        common.update({"failure": str(error), "next_action": common["recovery_action"]})
+        return common
+    if readback.get("validity") != "valid" or readback.get("fingerprint") != desired["fingerprint"]:
+        if before_text is not None:
+            path.write_text(before_text, encoding="utf-8")
+        else:
+            try:
+                path.unlink()
+            except OSError:
+                pass
+        common.update({"readback": readback, "failure": "failed validation/readback or fingerprint mismatch", "next_action": common["recovery_action"]})
+        return common
+    common.update({"write_performed": True, "readback": readback, "next_action": "Selected policy record is valid and effective for the next eligible dispatch."})
+    return common
+
+
 def resolve_policy(root: dict[str, Any], fallback_policy: dict[str, Any]) -> dict[str, Any]:
-    sources = root.get("policy_sources", {})
+    sources = collect_policy_sources(root, fallback_policy)
     checks: list[dict[str, Any]] = []
     selected: dict[str, Any] | None = None
     for source_name in ("current_work_unit_grant", "project", "personal"):
@@ -147,6 +473,21 @@ def resolve_policy(root: dict[str, Any], fallback_policy: dict[str, Any]) -> dic
         "policy_set": fallback_policy,
         "source_checks": checks,
     }
+
+
+def collect_policy_sources(root: dict[str, Any], fallback_policy: dict[str, Any]) -> dict[str, Any]:
+    sources = root.get("policy_sources", {})
+    if not isinstance(sources, dict):
+        fail("policy_sources must be an object")
+    merged = dict(sources)
+    lifecycle = root.get("policy_lifecycle")
+    if isinstance(lifecycle, dict):
+        for source in ("project", "personal"):
+            if source not in merged:
+                readback = read_record(policy_record_path(root, source), source, fallback_policy)
+                if readback["validity"] != "missing":
+                    merged[source] = readback
+    return merged
 
 
 def resolve_task_class(work: dict[str, Any]) -> tuple[str, dict[str, Any], str | None]:
@@ -307,7 +648,10 @@ def validate_override(root: dict[str, Any], work: dict[str, Any]) -> tuple[dict[
     return normalized, None
 
 
-def next_action_for(decision: str, setup_requested: bool, source_attention: list[dict[str, Any]], policy_resolution: dict[str, Any]) -> str:
+def next_action_for(decision: str, lifecycle: dict[str, Any], source_attention: list[dict[str, Any]], policy_resolution: dict[str, Any]) -> str:
+    if lifecycle["mode"] != "not_requested":
+        return lifecycle["next_action"]
+    setup_requested = lifecycle.get("legacy_setup_requested") is True
     if setup_requested:
         return "Set up collaboration policy requires the later lifecycle write/readback flow; this planner will not write a record"
     if decision == "hold_for_decision":
@@ -329,7 +673,7 @@ def next_action_for(decision: str, setup_requested: bool, source_attention: list
     return "Hold for Architect review of the unsupported route"
 
 
-def lifecycle_projection(decision: str, selected: dict[str, Any] | None, policy_resolution: dict[str, Any], task_class: str, next_action: str) -> dict[str, Any]:
+def lifecycle_projection(decision: str, selected: dict[str, Any] | None, policy_resolution: dict[str, Any], task_class: str, next_action: str, lifecycle: dict[str, Any]) -> dict[str, Any]:
     lifecycle_state = {
         "serial_current_session": "current_session_active",
         "reuse_relevant_thread": "reuse_candidate",
@@ -360,15 +704,22 @@ def lifecycle_projection(decision: str, selected: dict[str, Any] | None, policy_
         },
         "bounded_work_unit_lifecycle": {
             "task_class": task_class,
-            "state": "advisory_planned" if decision != "hold_for_decision" else "held",
-            "mutation_scope": "none",
+            "state": "policy_record_validated" if lifecycle.get("write_performed") else ("advisory_planned" if decision != "hold_for_decision" else "held"),
+            "mutation_scope": lifecycle.get("scope", "none") if lifecycle.get("write_performed") else "none",
             "dispatch_scope": "none",
+        },
+        "policy_record_lifecycle": {
+            "action": lifecycle["mode"],
+            "write_performed": lifecycle.get("write_performed", False),
+            "scope": lifecycle.get("scope", "not_available"),
+            "path": lifecycle.get("path", "not_available"),
+            "fingerprint": lifecycle.get("readback", {}).get("fingerprint", "not_available"),
         },
         "next_action": next_action,
     }
 
 
-def conversation_projection(policy_resolution: dict[str, Any], task_class: str, task_state: dict[str, Any], decision: str, selected: dict[str, Any] | None, candidates: list[dict[str, Any]], stops: list[str], tier: str, reasoning: str, setup_requested: bool) -> dict[str, Any]:
+def conversation_projection(policy_resolution: dict[str, Any], task_class: str, task_state: dict[str, Any], decision: str, selected: dict[str, Any] | None, candidates: list[dict[str, Any]], stops: list[str], tier: str, reasoning: str, lifecycle: dict[str, Any]) -> dict[str, Any]:
     source_attention = [check for check in policy_resolution["source_checks"] if check["validity"] in {"invalid", "drifted"}]
     observed_candidate = selected or next((item for item in candidates if item["topology"] != "serial"), None)
     runtime_mapping = observed_candidate.get("runtime_mapping") if observed_candidate else {"status": "not_available", "effective_configuration": "unknown", "enforcement": "not_available"}
@@ -377,11 +728,12 @@ def conversation_projection(policy_resolution: dict[str, Any], task_class: str, 
         attention.append("One or more explicit policy sources are invalid or drifted; no persisted policy is assumed valid")
     if decision not in {"serial_current_session", "hold_for_decision"} and (runtime_mapping.get("status") != "supported" or runtime_mapping.get("effective_configuration") != "observed"):
         attention.append("Runtime projection is requested versus observable evidence; retained settings are not assumed")
-    next_action = next_action_for(decision, setup_requested, source_attention, policy_resolution)
+    next_action = next_action_for(decision, lifecycle, source_attention, policy_resolution)
     emit = not (task_class == "routine" and decision == "serial_current_session" and not attention and not task_state["applied"])
     return {
         "effective_policy": {
             "profile": policy_resolution["profile"],
+            "label": PROFILE_LABELS.get(policy_resolution["profile"], policy_resolution["profile"]),
             "source": policy_resolution["source"],
             "validity": policy_resolution["validity"],
             "fingerprint_or_unsaved_default": policy_resolution["fingerprint_or_unsaved_default"],
@@ -395,7 +747,8 @@ def conversation_projection(policy_resolution: dict[str, Any], task_class: str, 
             "context_mode": selected.get("context_mode") if selected else "not_available",
             "abstract_tier": {"capability": tier, "reasoning": reasoning},
         },
-        "lifecycle": lifecycle_projection(decision, selected, policy_resolution, task_class, next_action),
+        "profile_catalog": lifecycle.get("profile_catalog", profile_catalog({})),
+        "lifecycle": lifecycle_projection(decision, selected, policy_resolution, task_class, next_action, lifecycle),
         "runtime_projection": {
             "requested": {"capability_tier": tier, "reasoning_tier": reasoning},
             "observable": {
@@ -407,15 +760,37 @@ def conversation_projection(policy_resolution: dict[str, Any], task_class: str, 
         "attention": attention,
         "evidence": {"policy_source_checks": policy_resolution["source_checks"], "json_is_secondary_debug": True},
         "next_action": next_action,
-        "policy_setup_intent": {"requested": setup_requested, "apply_supported_now": False, "write_performed": False},
+        "policy_setup_intent": {
+            "requested": lifecycle["mode"] in {"preview", "apply"} or lifecycle.get("legacy_setup_requested") is True,
+            "apply_supported_now": lifecycle["mode"] == "apply",
+            "write_performed": lifecycle.get("write_performed", False),
+            "confirmation_required": lifecycle.get("confirmation_required", False),
+        },
+        "policy_record": {
+            "mode": lifecycle["mode"],
+            "preflight": lifecycle.get("preflight", {}),
+            "diff": lifecycle.get("diff", {}),
+            "readback": lifecycle.get("readback", {}),
+            "recovery_action": lifecycle.get("recovery_action", "not_available"),
+        },
+        "role_task_dispatch_policy": lifecycle.get("effective_next_dispatch", {}),
         "emit_compact_marker": emit,
-        "recovery": {"writes_performed": False, "retains_prior_valid_policy": policy_resolution["source"] in {"current_work_unit_grant", "project", "personal"}},
+        "recovery": {"writes_performed": lifecycle.get("write_performed", False), "retains_prior_valid_policy": policy_resolution["source"] in {"current_work_unit_grant", "project", "personal"}},
     }
 
 
 def plan(root: dict[str, Any]) -> dict[str, Any]:
     policy, work, role, runtime = validate_input(root)
     policy_resolution = resolve_policy(root, policy)
+    lifecycle = lifecycle_action(root, policy, policy_resolution)
+    lifecycle["legacy_setup_requested"] = root.get("policy_setup_requested") is True
+    if lifecycle.get("write_performed") and lifecycle.get("scope") in {"project", "personal"}:
+        readback = lifecycle["readback"]
+        policy_resolution = resolve_policy(
+            {**root, "policy_sources": {**collect_policy_sources(root, policy), lifecycle["scope"]: readback}},
+            policy,
+        )
+        lifecycle["preflight"]["prior_effective_state"] = {key: value for key, value in policy_resolution.items() if key != "policy_set"}
     policy = policy_resolution["policy_set"]
     task_class, task_state, correction_stop = resolve_task_class(work)
     override, override_stop = validate_override(root, work)
@@ -425,7 +800,7 @@ def plan(root: dict[str, Any]) -> dict[str, Any]:
         fail("work_unit.human_owned_actions must be a list")
     if human_actions or work.get("requires_human_decision") is True or early_stop or override_stop or correction_stop:
         reason = early_stop or override_stop or correction_stop or "Human-owned action requires a Human decision"
-        return result(root, policy_resolution, task_class, task_state, [], "hold_for_decision", None, [reason], reset, tier, reasoning, override)
+        return result(root, policy_resolution, task_class, task_state, [], "hold_for_decision", None, [reason], reset, tier, reasoning, override, lifecycle)
 
     required_independence = role.get("independence_requirement", "none")
     envelope_required = work.get("requires_explicit_envelope", False) is True
@@ -463,7 +838,7 @@ def plan(root: dict[str, Any]) -> dict[str, Any]:
     candidates = candidates[:4]
     eligible = [item for item in candidates if item["eligible"]]
     if not eligible:
-        return result(root, policy_resolution, task_class, task_state, candidates, "hold_for_decision", None, ["No route meets the authority, evidence, and runtime quality floor."], reset, tier, reasoning, override)
+        return result(root, policy_resolution, task_class, task_state, candidates, "hold_for_decision", None, ["No route meets the authority, evidence, and runtime quality floor."], reset, tier, reasoning, override, lifecycle)
     material_benefit = any((role.get("specialization_available") is True, continuity in {"medium", "high"} and relevance in {"medium", "high"}, required_independence != "none", work.get("safe_parallelism") is True, work.get("batch_checkpoint_safe") is True))
     selection_pool = [item for item in eligible if item["route"] != "serial_current_session"] if material_benefit else eligible
     if not selection_pool:
@@ -472,10 +847,10 @@ def plan(root: dict[str, Any]) -> dict[str, Any]:
     decision = selected["route"] if material_benefit and selected["route"] != "serial_current_session" else "serial_current_session"
     if decision == "serial_current_session":
         selected = next(item for item in eligible if item["topology"] == "serial")
-    return result(root, policy_resolution, task_class, task_state, candidates, decision, selected, [], reset, tier, reasoning, override)
+    return result(root, policy_resolution, task_class, task_state, candidates, decision, selected, [], reset, tier, reasoning, override, lifecycle)
 
 
-def result(root: dict[str, Any], policy_resolution: dict[str, Any], task_class: str, task_state: dict[str, Any], candidates: list[dict[str, Any]], decision: str, selected: dict[str, Any] | None, stops: list[str], reset: dict[str, Any], tier: str, reasoning: str, override: dict[str, Any]) -> dict[str, Any]:
+def result(root: dict[str, Any], policy_resolution: dict[str, Any], task_class: str, task_state: dict[str, Any], candidates: list[dict[str, Any]], decision: str, selected: dict[str, Any] | None, stops: list[str], reset: dict[str, Any], tier: str, reasoning: str, override: dict[str, Any], lifecycle: dict[str, Any]) -> dict[str, Any]:
     runtime = root["runtime_capabilities"]
     confidence = "low" if any(item.get("runtime_mapping", {}).get("effective_configuration") == "unknown" for item in candidates) else "medium"
     return {
@@ -485,7 +860,8 @@ def result(root: dict[str, Any], policy_resolution: dict[str, Any], task_class: 
         "runtime_capabilities": {"observed_at": runtime.get("observed_at", "not_available"), "mechanisms": runtime.get("mechanisms", {})},
         "runtime_limitations": runtime_limitations(runtime),
         "policy_resolution": {key: value for key, value in policy_resolution.items() if key != "policy_set"},
-        "conversation_projection": conversation_projection(policy_resolution, task_class, task_state, decision, selected, candidates, stops, tier, reasoning, root.get("policy_setup_requested") is True),
+        "conversation_projection": conversation_projection(policy_resolution, task_class, task_state, decision, selected, candidates, stops, tier, reasoning, lifecycle),
+        "policy_lifecycle": lifecycle,
         "route_candidates": candidates,
         "dispatch_plan": {
             "route_decision": decision,

--- a/scripts/test_codex_route_adapter.py
+++ b/scripts/test_codex_route_adapter.py
@@ -20,7 +20,18 @@ def portable(topology: str = "fresh_thread", decision: str = "dispatch_advisory"
     return {
         "work_unit": {"work_unit_id": "AF18-421-fixture", "requires_explicit_envelope": explicit},
         "dispatch_plan": {"route_decision": decision, "selected_candidate": selected, "requested_capability_tier": "balanced", "requested_reasoning_tier": "medium"},
-        "conversation_projection": {"effective_policy": {"profile": "normal"}, "next_action": "Review portable plan"},
+        "conversation_projection": {
+            "effective_policy": {"profile": "normal"},
+            "next_action": "Review portable plan",
+            "role_task_dispatch_policy": {
+                "existing_healthy_role_task_preferred": True,
+                "new_role_task_preference": "project_scoped_codex_task",
+                "project_scoped_creation": "preferred",
+                "project_id": "local-eb6e22ec0d00ef785d687022be1b433d",
+                "project_root": "/Users/jinghuliu/Desktop/Code/Personal Projects/agent-foundry",
+                "degraded_projectless_fallback": {"allowed": False, "bounded_to": "one_work_unit", "default_policy": False},
+            },
+        },
     }
 
 
@@ -62,6 +73,8 @@ def adapter_context() -> dict:
         "runtime_id": "codex-desktop-current-session",
         "evaluated_at": "2026-07-22T00:05:00Z",
         "max_observation_age_seconds": 300,
+        "project_id": "local-eb6e22ec0d00ef785d687022be1b433d",
+        "project_root": "/Users/jinghuliu/Desktop/Code/Personal Projects/agent-foundry",
     }
 
 
@@ -109,6 +122,13 @@ def main() -> int:
     code, output = run(base)
     expect("runtime-capture-unavailable", code == 0 and provenance_recovery(output, "unknown") and output["schema_provenance"]["evidence_ref_status"] == "unverified", output, errors)
     expect("runtime-capture-no-write", code == 0 and output["mutation_performed"] is False and output["dispatch_performed"] is False and output["adapter_plan"]["lifecycle_evidence"]["close_archive_resume"] == "not_executed_dry_run_only", output, errors)
+    expect("project-scoped-dispatch-evidence", code == 0 and output["adapter_plan"]["role_task_dispatch_evidence"]["project_scoped_vs_projectless"] == "project_scoped" and output["adapter_plan"]["role_task_dispatch_evidence"]["target_project"]["project_id"] == "local-eb6e22ec0d00ef785d687022be1b433d", output, errors)
+
+    degraded = portable("fresh_thread")
+    degraded["conversation_projection"]["role_task_dispatch_policy"]["project_scoped_creation"] = "unavailable"
+    degraded["conversation_projection"]["role_task_dispatch_policy"]["degraded_projectless_fallback"]["allowed"] = True
+    code, output = run(input_for(degraded))
+    expect("projectless-fallback-degraded-bounded", code == 0 and output["adapter_plan"]["role_task_dispatch_evidence"]["project_scoped_vs_projectless"] == "projectless_degraded" and output["adapter_plan"]["role_task_dispatch_evidence"]["fallback"]["bounded_to"] == "one_work_unit", output, errors)
 
     no_dispatch = input_for(portable(decision="no_dispatch"))
     code, output = run(no_dispatch)

--- a/scripts/test_collaboration_route_planner.py
+++ b/scripts/test_collaboration_route_planner.py
@@ -41,6 +41,30 @@ def run_fixture(data: dict) -> tuple[int, dict | str]:
         return 0, json.loads(result.stdout)
 
 
+def run_fixture_with_tmp(data: dict) -> tuple[int, dict | str, Path]:
+    with tempfile.TemporaryDirectory(prefix="af18-policy-lifecycle-") as raw:
+        root = Path(raw)
+        data = json.loads(json.dumps(data))
+        lifecycle = data.setdefault("policy_lifecycle", {})
+        paths = lifecycle.setdefault("paths", {})
+        paths.setdefault("personal", str(root / "home" / ".agent-foundry" / "collaboration-routing-policy.yaml"))
+        paths.setdefault("project_root", str(root / "project"))
+        paths.setdefault("project", str(root / "project" / ".agent-foundry" / "collaboration-routing-policy.yaml"))
+        path = root / "fixture.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data), encoding="utf-8")
+        result = subprocess.run([sys.executable, str(PLANNER), "--input-json", str(path), "--json"], text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if result.returncode:
+            return result.returncode, result.stderr, root
+        return 0, json.loads(result.stdout), root
+
+
+def run_fixture_path(data: dict, fixture_path: Path) -> tuple[int, dict | str]:
+    fixture_path.write_text(json.dumps(data), encoding="utf-8")
+    completed = subprocess.run([sys.executable, str(PLANNER), "--input-json", str(fixture_path), "--json"], text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return (completed.returncode, json.loads(completed.stdout)) if completed.returncode == 0 else (completed.returncode, completed.stderr)
+
+
 def expect(name: str, condition: bool, detail: object) -> list[str]:
     if condition:
         print(f"{name}: ok")
@@ -62,8 +86,9 @@ def main() -> int:
         errors.extend(expect("no-mutation", output["mutation_performed"] is False and output["dispatch_performed"] is False, output))
         errors.extend(expect("candidate-limit", len(output["route_candidates"]) <= 4, output))
         projection = output["conversation_projection"]
-        errors.extend(expect("unsaved-normal-default", projection["effective_policy"] == {"profile": "normal", "source": "unsaved_normal_default", "validity": "unsaved_default", "fingerprint_or_unsaved_default": "unsaved-normal-default"}, projection))
-        errors.extend(expect("three-level-lifecycle", set(projection["lifecycle"]) == {"collaboration_operating_mode", "execution_context_lifecycle", "bounded_work_unit_lifecycle", "next_action"}, projection))
+        errors.extend(expect("unsaved-normal-default", projection["effective_policy"]["profile"] == "normal" and projection["effective_policy"]["label"] == "正常" and projection["effective_policy"]["source"] == "unsaved_normal_default" and projection["effective_policy"]["fingerprint_or_unsaved_default"] == "unsaved-normal-default", projection))
+        errors.extend(expect("fixed-profile-catalog", [item["label"] for item in projection["profile_catalog"]] == ["节俭", "正常", "高性能"], projection))
+        errors.extend(expect("lifecycle-levels", {"collaboration_operating_mode", "execution_context_lifecycle", "bounded_work_unit_lifecycle", "policy_record_lifecycle", "next_action"}.issubset(set(projection["lifecycle"])), projection))
         errors.extend(expect("single-next-action", isinstance(projection["next_action"], str) and projection["next_action"] == projection["lifecycle"]["next_action"], projection))
 
     routine = base_fixture()
@@ -77,7 +102,55 @@ def main() -> int:
     code, output = run_fixture(setup_intent)
     if code == 0:
         intent = output["conversation_projection"]["policy_setup_intent"]
-        errors.extend(expect("setup-intent-no-write", intent == {"requested": True, "apply_supported_now": False, "write_performed": False} and output["conversation_projection"]["next_action"].startswith("Set up collaboration policy"), output))
+        errors.extend(expect("setup-intent-no-write", intent["requested"] is True and intent["apply_supported_now"] is False and intent["write_performed"] is False and output["conversation_projection"]["next_action"].startswith("Set up collaboration policy"), output))
+
+    inspect_policy = base_fixture()
+    inspect_policy["policy_lifecycle"] = {"action": "inspect", "scope": "project"}
+    code, output, _ = run_fixture_with_tmp(inspect_policy)
+    if code == 0:
+        record = output["conversation_projection"]["policy_record"]
+        errors.extend(expect("policy-inspect-read-only", output["mutation_performed"] is False and output["policy_lifecycle"]["write_performed"] is False and record["readback"]["validity"] == "missing", output))
+
+    preview_policy = base_fixture()
+    preview_policy["policy_lifecycle"] = {"action": "preview", "scope": "project", "profile": "performance"}
+    code, output, _ = run_fixture_with_tmp(preview_policy)
+    if code == 0:
+        intent = output["conversation_projection"]["policy_setup_intent"]
+        errors.extend(expect("policy-preview-no-write", intent["requested"] is True and intent["write_performed"] is False and output["policy_lifecycle"]["diff"]["after"]["profile"] == "performance", output))
+
+    apply_policy = base_fixture()
+    apply_policy["policy_lifecycle"] = {"action": "apply", "scope": "project", "profile": "economy", "confirmed": True}
+    code, output, _ = run_fixture_with_tmp(apply_policy)
+    if code == 0:
+        lifecycle = output["policy_lifecycle"]
+        projection = output["conversation_projection"]
+        errors.extend(expect("policy-apply-one-write-readback", lifecycle["write_performed"] is True and lifecycle["readback"]["validity"] == "valid" and projection["effective_policy"]["source"] == "project" and projection["effective_policy"]["profile"] == "economy", output))
+        errors.extend(expect("policy-effective-next-dispatch-project-scoped", projection["role_task_dispatch_policy"]["new_role_task_preference"] == "project_scoped_codex_task" and projection["role_task_dispatch_policy"]["project_id"] == "local-eb6e22ec0d00ef785d687022be1b433d", projection))
+
+    unconfirmed_policy = base_fixture()
+    unconfirmed_policy["policy_lifecycle"] = {"action": "apply", "scope": "personal", "profile": "normal", "confirmed": False}
+    code, output, _ = run_fixture_with_tmp(unconfirmed_policy)
+    if code == 0:
+        errors.extend(expect("policy-apply-needs-one-confirmation", output["policy_lifecycle"]["write_performed"] is False and output["conversation_projection"]["policy_setup_intent"]["confirmation_required"] is True and output["conversation_projection"]["next_action"] == "Confirm once before writing the selected policy record.", output))
+
+    with tempfile.TemporaryDirectory(prefix="af18-policy-write-fail-") as raw:
+        root = Path(raw)
+        blocked_path = root / "project" / ".agent-foundry" / "collaboration-routing-policy.yaml"
+        blocked_path.mkdir(parents=True)
+        failed_write = base_fixture()
+        failed_write["policy_lifecycle"] = {
+            "action": "apply",
+            "scope": "project",
+            "profile": "performance",
+            "confirmed": True,
+            "paths": {"project": str(blocked_path), "project_root": str(root / "project")},
+        }
+        code, output = run_fixture_path(failed_write, root / "fixture.json")
+        if code == 0:
+            projection = output["conversation_projection"]
+            errors.extend(expect("policy-write-failure-preserves-prior", output["policy_lifecycle"]["write_performed"] is False and projection["effective_policy"]["source"] == "unsaved_normal_default" and "retry" in output["policy_lifecycle"]["next_action"], output))
+        else:
+            errors.append(f"policy-write-failure-preserves-prior: {output}")
 
     material = base_fixture()
     material["work_unit"].update({"task_class": "complex", "material_signals": ["cross_boundary", "contradictory_evidence"], "task_class_correction": {"task_class": "complex", "scope": "AF18-fixture", "expires_after_work_unit": True}})

--- a/scripts/test_collaboration_route_planner.py
+++ b/scripts/test_collaboration_route_planner.py
@@ -133,6 +133,38 @@ def main() -> int:
     if code == 0:
         errors.extend(expect("policy-apply-needs-one-confirmation", output["policy_lifecycle"]["write_performed"] is False and output["conversation_projection"]["policy_setup_intent"]["confirmation_required"] is True and output["conversation_projection"]["next_action"] == "Confirm once before writing the selected policy record.", output))
 
+    invalid_lifecycle_profile = base_fixture()
+    invalid_lifecycle_profile["policy_sources"] = {
+        "personal": {
+            "validity": "valid",
+            "profile": "economy",
+            "fingerprint": "sha256:prior-personal",
+            "policy_set": invalid_lifecycle_profile["policy_set"],
+        }
+    }
+    invalid_lifecycle_profile["policy_lifecycle"] = {"action": "apply", "scope": "project", "profile": "turbo", "confirmed": True}
+    code, output, _ = run_fixture_with_tmp(invalid_lifecycle_profile)
+    if code == 0:
+        lifecycle = output["policy_lifecycle"]
+        projection = output["conversation_projection"]
+        errors.extend(
+            expect(
+                "policy-invalid-profile-preserves-prior",
+                lifecycle["write_performed"] is False
+                and lifecycle["failure"] == "invalid policy_lifecycle.profile"
+                and lifecycle["invalid_input"]["field"] == "policy_lifecycle.profile"
+                and lifecycle["diff"]["after"]["profile"] == "turbo"
+                and lifecycle["diff"]["after"]["validity"] == "invalid"
+                and lifecycle["readback"]["validity"] in {"missing", "valid", "invalid"}
+                and projection["effective_policy"]["source"] == "personal"
+                and projection["effective_policy"]["fingerprint_or_unsaved_default"] == "sha256:prior-personal"
+                and projection["next_action"] == lifecycle["recovery_action"],
+                output,
+            )
+        )
+    else:
+        errors.append(f"policy-invalid-profile-preserves-prior: {output}")
+
     with tempfile.TemporaryDirectory(prefix="af18-policy-write-fail-") as raw:
         root = Path(raw)
         blocked_path = root / "project" / ".agent-foundry" / "collaboration-routing-policy.yaml"

--- a/workflows/github-collaboration-helper.md
+++ b/workflows/github-collaboration-helper.md
@@ -63,12 +63,13 @@ confidence, reset, and hold-for-decision conditions.
 
 The conversation-facing projection resolves policy deterministically: current
 work-unit Human grant, project record, personal record, then an explicitly
-labelled unsaved `normal` default. It exposes the selected profile, source,
-validity, and fingerprint or `unsaved-normal-default`; invalid or drifted
-sources remain visible. It also projects task class, bounded one-work-unit
-corrections, material signals, a compact recommendation, requested-versus-
-observable runtime state, attention, and exactly one next action. The portable
-mode is one of `economy`, `normal`, `performance`, or temporary `low_limit`.
+labelled unsaved `normal` default. It exposes the selected profile, Chinese
+profile label, source, validity, and fingerprint or `unsaved-normal-default`;
+invalid or drifted sources remain visible. It also projects task class, bounded
+one-work-unit corrections, material signals, a compact recommendation,
+requested-versus-observable runtime state, attention, and exactly one next
+action. The portable mode is one of `economy`, `normal`, `performance`, or
+temporary `low_limit`.
 The lifecycle section models three aligned levels: collaboration operating
 mode, execution-context lifecycle, and bounded work-unit lifecycle. It reports
 create/reuse/compact-rehydrate/callback/cooldown/archive eligibility as
@@ -82,13 +83,27 @@ specialization value, project continuity relevance, and independent-review
 value are explicit inputs; the planner must not infer them from role label or
 thread age alone.
 
-The planner is advisory only: it always reports `mutation_performed: false` and
-`dispatch_performed: false`. It does not create, fork, resume, or message a
-thread; it does not start subagents or automation; and it does not change
-runtime settings. Portable policy uses named capability/reasoning tiers rather
-than provider or model identifiers. Missing effective retained settings remain
-`unknown`; fork and heartbeat are non-enforcing; hook and custom-agent
-enforcement remain unsupported until a later Human-gated adapter scope.
+The named conversation action `set up collaboration policy` is distinct from
+V2 guided onboarding. It supports read-only inspection, dry-run preview, and an
+explicit setup flow: read preflight, select one of `节俭`, `正常`, or `高性能`,
+select `personal` or `project` scope, show a compact before/after diff, require
+one confirmation, write exactly one selected policy record, validate/read it
+back in the same conversation, and make it effective for the next eligible
+dispatch. The personal record path is
+`~/.agent-foundry/collaboration-routing-policy.yaml`; the project record path
+is `<repo>/.agent-foundry/collaboration-routing-policy.yaml`. Records are
+versioned, policy-data only, and fingerprinted. Invalid input, failed write,
+failed validation/readback, or fingerprint mismatch preserves the prior
+effective state and returns one recovery action.
+
+Outside a confirmed policy lifecycle apply action, the planner remains
+advisory: it reports `dispatch_performed: false`, does not create, fork,
+resume, or message a thread, does not start subagents or automation, and does
+not change runtime settings. Portable policy uses named capability/reasoning
+tiers rather than provider or model identifiers. Missing effective retained
+settings remain `unknown`; fork and heartbeat are non-enforcing; hook and
+custom-agent enforcement remain unsupported until a later Human-gated adapter
+scope.
 
 Example:
 
@@ -100,11 +115,11 @@ Treat `hold_for_decision` as a decision boundary, not a failed dispatch. A later
 runtime adapter may map an accepted advisory plan to supported tool calls; that
 adapter is outside this workflow slice.
 
-This planner does not set up, write, read back, or retain personal/project
-policy records. It does not create telemetry, a monitoring history, dashboard,
-or report product. The JSON result is secondary technical evidence; a later
-conversation surface owns compact Human-facing wording and a later lifecycle
-slice owns any approved policy-record write/readback path.
+This planner does not create telemetry, a monitoring history, dashboard, or
+report product. It must not write the user's live personal or repository policy
+record unless the conversation explicitly confirms the setup action and the
+caller selected that scope. Tests must use isolated temp roots or controlled
+fixtures for policy-record writes.
 
 ### Optional Codex Adapter Pilot
 
@@ -127,6 +142,14 @@ unsupported for envelope enforcement. Omitted, stale, unknown, or unsupported
 configuration produces one recovery action and never silently inherits a
 retained setting. Its lifecycle evidence is bounded to one work unit and states
 that close/archive/resume was not executed in dry-run mode.
+
+For Agent Foundry role dispatches that create a new Codex task, the adapter
+projection must prefer a project-scoped task under Codex project
+`local-eb6e22ec0d00ef785d687022be1b433d` for
+`/Users/jinghuliu/Desktop/Code/Personal Projects/agent-foundry`. Existing
+healthy Agent Foundry role tasks remain preferred when resumable. A projectless
+chat or subagent fallback is degraded, bounded to one work unit, and must be
+evidenced; it is not the default policy.
 
 It proposes no real tool call: all adapter output reports
 `mutation_performed: false` and `dispatch_performed: false`. User config,


### PR DESCRIPTION
## Summary

Implements #430 collaboration policy lifecycle and conversation setup on top of the AF18 lifecycle planner.

Changed surfaces:
- `scripts/plan_collaboration_routes.py`
- `scripts/test_collaboration_route_planner.py`
- `schemas/collaboration-routing-policy.schema.yaml`
- `workflows/github-collaboration-helper.md`
- `scripts/plan_codex_route_adapter.py`
- `scripts/test_codex_route_adapter.py`

## Scope

- Recognizes the named `set up collaboration policy` action separately from guided onboarding.
- Adds fixed setup profiles `节俭`, `正常`, and `高性能`, with profile labels, task-class rules, scope options, source/validity/fingerprint, and observable runtime projection.
- Resolves effective policy as current-work-unit grant > project record > personal record > labelled unsaved normal default.
- Supports read-only inspect, dry-run preview, one-confirmation apply, one selected policy-record write, same-conversation validation/readback, and next eligible dispatch effectiveness.
- Keeps policy records versioned, policy-data only, and fingerprint-checked.
- Preserves prior effective state on invalid/drifted sources and failed write/readback, with one recovery action.
- Adds Agent Foundry Codex role-task dispatch policy projection: existing healthy role task preferred; new task creation prefers project-scoped Codex task under `local-eb6e22ec0d00ef785d687022be1b433d`; projectless fallback is degraded, one-work-unit bounded, and evidenced.

## Boundaries

No runtime model/reasoning config mutation, hook/custom-agent/config mutation, actual thread/subagent dispatch as product behavior, Vault/generated mutation, GitHub Project mutation, telemetry store/dashboard/report product, automatic multi-machine sync, main merge, release/tag, V2.1 work, destructive action, or release of #435/#436/#426 Stage D/#427.

Policy-record writes in tests use isolated temp roots. No live personal policy record or live repo policy record was written.

## Verification

Passed:
- `python3 -m py_compile scripts/plan_collaboration_routes.py scripts/test_collaboration_route_planner.py scripts/plan_codex_route_adapter.py scripts/test_codex_route_adapter.py`
- `python3 scripts/test_collaboration_route_planner.py`
- `python3 scripts/test_codex_route_adapter.py`
- `git diff --check`
- `git diff --check origin/codex/af18-collaboration-cost-policy-integration...HEAD`

Known pre-existing/orthogonal blocker observed:
- `python3 scripts/check_consistency.py` fails operation-context/runtime-import fixtures. Observed failure: expected `foundry_core_maintenance` / `status: rejected`, but the current worktree path is classified as runtime import candidate for `workflows/import-external-skills.md`. This was not caused by #430 policy lifecycle assertions and remains recorded for Reviewer attention.

## Review Handoff

Issue: #430
Owner role: Implementer
Next owner: Reviewer
Reviewer target: separate reviewer role
Runtime envelope requested for downstream dispatch: model `gpt-5.5` or lower, thinking/reasoning `medium` or lower.
