### PR TITLE
Add AF18 low limit collaboration route gate

### DIFF
--- a/schemas/collaboration-routing-policy.schema.yaml
+++ b/schemas/collaboration-routing-policy.schema.yaml
@@ -1,0 +1,168 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "https://agent-foundry.local/schemas/collaboration-routing-policy.schema.yaml"
+title: Collaboration Routing Policy
+type: object
+additionalProperties: false
+required:
+  - issue
+  - role
+  - token_budget
+  - context
+  - readback
+  - duplicate_dispatch
+  - hold_conditions
+  - model
+properties:
+  issue:
+    type: integer
+    minimum: 1
+  role:
+    type: string
+    minLength: 1
+  dispatch_id:
+    type: string
+    minLength: 1
+  durable_anchor:
+    type: string
+    minLength: 1
+  requested_route:
+    type: string
+    enum:
+      - serial_current_session
+      - fresh_bounded_thread
+      - bounded_subagent
+      - no_dispatch
+      - hold_for_decision
+  token_budget:
+    type: object
+    additionalProperties: false
+    required:
+      - first_active_turn_words
+      - total_role_thread_tokens
+    properties:
+      first_active_turn_words:
+        type: integer
+        minimum: 1
+        maximum: 1500
+      total_role_thread_tokens:
+        type: integer
+        minimum: 1
+        maximum: 25000
+  context:
+    type: object
+    additionalProperties: false
+    required:
+      - source_timestamp
+      - max_age_hours
+    properties:
+      source_timestamp:
+        type: string
+        format: date-time
+      max_age_hours:
+        type: integer
+        minimum: 1
+      estimated_context_tokens:
+        type: integer
+        minimum: 0
+      max_context_tokens:
+        type: integer
+        minimum: 1
+  readback:
+    type: object
+    additionalProperties: false
+    required:
+      - mode
+      - compact_readback_available
+    properties:
+      mode:
+        const: cursor_only_compact
+      compact_readback_available:
+        const: true
+  duplicate_dispatch:
+    type: object
+    additionalProperties: false
+    required:
+      - duplicate_owner_detected
+      - same_issue_role_boundary_seen
+    properties:
+      duplicate_owner_detected:
+        const: false
+      same_issue_role_boundary_seen:
+        const: false
+  hold_conditions:
+    type: array
+    uniqueItems: true
+    contains:
+      const: missing_required_fields
+    allOf:
+      - contains:
+          const: missing_budget
+      - contains:
+          const: budget_breach
+      - contains:
+          const: stale_context
+      - contains:
+          const: oversized_context
+      - contains:
+          const: duplicate_owner
+      - contains:
+          const: compact_readback_unavailable
+      - contains:
+          const: escalation_need
+    items:
+      type: string
+      enum:
+        - missing_budget
+        - budget_breach
+        - stale_context
+        - oversized_context
+        - duplicate_owner
+        - compact_readback_unavailable
+        - escalation_need
+        - missing_required_fields
+  model:
+    type: object
+    additionalProperties: false
+    required:
+      - name
+      - reasoning
+    properties:
+      name:
+        type: string
+      reasoning:
+        type: string
+        enum:
+          - minimal
+          - low
+          - medium
+          - high
+      human_escalation_approval:
+        type: object
+        additionalProperties: false
+        required:
+          - issue
+          - role
+          - model
+          - reasoning
+          - purpose
+          - budget
+        properties:
+          issue:
+            type: integer
+          role:
+            type: string
+          model:
+            type: string
+          reasoning:
+            type: string
+          purpose:
+            type: string
+            minLength: 1
+          budget:
+            type: string
+            minLength: 1
+anyOf:
+  - required:
+      - dispatch_id
+  - required:
+      - durable_anchor

--- a/scripts/plan_collaboration_routes.py
+++ b/scripts/plan_collaboration_routes.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Plan advisory collaboration routes with a hard low_limit gate."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+MODEL_ORDER = {
+    "gpt-5": 50,
+    "gpt-5.1": 51,
+    "gpt-5.2": 52,
+    "gpt-5.3": 53,
+    "gpt-5.4": 54,
+    "gpt-5.5": 55,
+    "gpt-5.6": 56,
+}
+REASONING_ORDER = {"minimal": 0, "low": 1, "medium": 2, "high": 3}
+DEFAULT_CEILING_MODEL = "gpt-5.5"
+DEFAULT_CEILING_REASONING = "medium"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate an advisory collaboration route packet and fail closed on low_limit breaches.",
+    )
+    parser.add_argument("--input", help="JSON packet path. Defaults to stdin when provided.")
+    parser.add_argument("--now", help="Current UTC timestamp for deterministic tests.")
+    return parser.parse_args()
+
+
+def read_packet(path: str | None) -> dict[str, Any]:
+    if path:
+        text = Path(path).read_text(encoding="utf-8")
+    elif not sys.stdin.isatty():
+        text = sys.stdin.read()
+    else:
+        return {}
+    if not text.strip():
+        return {}
+    value = json.loads(text)
+    if not isinstance(value, dict):
+        raise SystemExit("input packet must be a JSON object")
+    return value
+
+
+def utc_now(raw: str | None) -> dt.datetime:
+    if raw:
+        return parse_timestamp(raw, "now")
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def parse_timestamp(raw: Any, field: str) -> dt.datetime:
+    if not isinstance(raw, str) or not raw.strip():
+        raise ValueError(f"{field} missing")
+    value = raw.strip().replace("Z", "+00:00")
+    parsed = dt.datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def model_rank(model: Any) -> int | None:
+    if not isinstance(model, str):
+        return None
+    if model in MODEL_ORDER:
+        return MODEL_ORDER[model]
+    return None
+
+
+def reasoning_rank(reasoning: Any) -> int | None:
+    if not isinstance(reasoning, str):
+        return None
+    return REASONING_ORDER.get(reasoning)
+
+
+def add_missing(stops: list[str], packet: dict[str, Any], field: str) -> Any:
+    value = packet.get(field)
+    if value in (None, "", [], {}):
+        stops.append(f"missing_{field}")
+    return value
+
+
+def validate(packet: dict[str, Any], now: dt.datetime) -> dict[str, Any]:
+    stops: list[str] = []
+    warnings: list[str] = []
+
+    issue = add_missing(stops, packet, "issue")
+    role = add_missing(stops, packet, "role")
+    dispatch_id = packet.get("dispatch_id")
+    durable_anchor = packet.get("durable_anchor")
+    if not dispatch_id and not durable_anchor:
+        stops.append("missing_duplicate_dispatch_anchor")
+
+    token_budget = packet.get("token_budget")
+    if not isinstance(token_budget, dict):
+        stops.append("missing_token_budget")
+        token_budget = {}
+    first_turn_words = token_budget.get("first_active_turn_words")
+    total_tokens = token_budget.get("total_role_thread_tokens")
+    if not isinstance(first_turn_words, int) or first_turn_words <= 0:
+        stops.append("missing_first_active_turn_word_budget")
+    elif first_turn_words > 1500:
+        stops.append("first_active_turn_word_budget_exceeds_low_limit")
+    if not isinstance(total_tokens, int) or total_tokens <= 0:
+        stops.append("missing_total_role_thread_token_budget")
+    elif total_tokens > 25000:
+        stops.append("total_role_thread_token_budget_exceeds_low_limit")
+
+    context = packet.get("context")
+    if not isinstance(context, dict):
+        stops.append("missing_context")
+        context = {}
+    try:
+        source_ts = parse_timestamp(context.get("source_timestamp"), "context.source_timestamp")
+    except (TypeError, ValueError):
+        stops.append("missing_or_invalid_source_timestamp")
+        source_ts = None
+    max_age_hours = context.get("max_age_hours")
+    if not isinstance(max_age_hours, int) or max_age_hours <= 0:
+        stops.append("missing_max_context_age_hours")
+    elif source_ts is not None and now - source_ts > dt.timedelta(hours=max_age_hours):
+        stops.append("stale_context")
+
+    readback = packet.get("readback")
+    if not isinstance(readback, dict):
+        stops.append("missing_readback")
+        readback = {}
+    if readback.get("mode") != "cursor_only_compact":
+        stops.append("readback_not_cursor_only_compact")
+    if readback.get("compact_readback_available") is not True:
+        stops.append("compact_readback_unavailable")
+
+    duplicate = packet.get("duplicate_dispatch")
+    if not isinstance(duplicate, dict):
+        stops.append("missing_duplicate_dispatch")
+        duplicate = {}
+    if duplicate.get("duplicate_owner_detected") is True:
+        stops.append("duplicate_owner")
+    if duplicate.get("same_issue_role_boundary_seen") is True:
+        stops.append("duplicate_issue_role_boundary")
+
+    hold_conditions = packet.get("hold_conditions")
+    required_holds = {
+        "missing_budget",
+        "budget_breach",
+        "stale_context",
+        "oversized_context",
+        "duplicate_owner",
+        "compact_readback_unavailable",
+        "escalation_need",
+        "missing_required_fields",
+    }
+    if not isinstance(hold_conditions, list):
+        stops.append("missing_hold_conditions")
+    else:
+        missing_holds = sorted(required_holds - {str(item) for item in hold_conditions})
+        if missing_holds:
+            stops.append("incomplete_hold_conditions")
+            warnings.append(f"missing_hold_conditions:{','.join(missing_holds)}")
+
+    model = packet.get("model", {})
+    if not isinstance(model, dict):
+        stops.append("missing_model")
+        model = {}
+    requested_model = model.get("name")
+    requested_reasoning = model.get("reasoning")
+    if model_rank(requested_model) is None:
+        stops.append("missing_or_unknown_model")
+    if reasoning_rank(requested_reasoning) is None:
+        stops.append("missing_or_unknown_reasoning")
+    if model_rank(requested_model) is not None and model_rank(requested_model) > model_rank(DEFAULT_CEILING_MODEL):
+        if not model.get("human_escalation_approval"):
+            stops.append("model_escalation_requires_human_approval")
+    if reasoning_rank(requested_reasoning) is not None and reasoning_rank(requested_reasoning) > reasoning_rank(DEFAULT_CEILING_REASONING):
+        if not model.get("human_escalation_approval"):
+            stops.append("reasoning_escalation_requires_human_approval")
+
+    context_size = context.get("estimated_context_tokens")
+    max_context_tokens = context.get("max_context_tokens")
+    if isinstance(context_size, int) and isinstance(max_context_tokens, int) and context_size > max_context_tokens:
+        stops.append("oversized_context")
+
+    decision = "hold_for_decision" if stops else packet.get("requested_route", "serial_current_session")
+    return {
+        "issue": issue,
+        "role": role,
+        "dispatch_id": dispatch_id,
+        "durable_anchor": durable_anchor,
+        "route_decision": decision,
+        "stop_conditions": sorted(set(stops)),
+        "warnings": warnings,
+        "low_limit": {
+            "first_active_turn_words": 1500,
+            "total_role_thread_tokens": 25000,
+            "model_ceiling": DEFAULT_CEILING_MODEL,
+            "reasoning_ceiling": DEFAULT_CEILING_REASONING,
+            "readback_default": "cursor_only_compact",
+        },
+        "mutation_performed": False,
+        "dispatch_performed": False,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    packet = read_packet(args.input)
+    result = validate(packet, utc_now(args.now))
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/plan_collaboration_routes.py
+++ b/scripts/plan_collaboration_routes.py
@@ -86,6 +86,13 @@ def add_missing(stops: list[str], packet: dict[str, Any], field: str) -> Any:
     return value
 
 
+def valid_escalation_approval(approval: Any) -> bool:
+    if not isinstance(approval, dict):
+        return False
+    required = ("issue", "role", "model", "reasoning", "purpose", "budget")
+    return all(approval.get(field) not in (None, "", [], {}) for field in required)
+
+
 def validate(packet: dict[str, Any], now: dt.datetime) -> dict[str, Any]:
     stops: list[str] = []
     warnings: list[str] = []
@@ -140,6 +147,10 @@ def validate(packet: dict[str, Any], now: dt.datetime) -> dict[str, Any]:
     if not isinstance(duplicate, dict):
         stops.append("missing_duplicate_dispatch")
         duplicate = {}
+    if "duplicate_owner_detected" not in duplicate:
+        stops.append("missing_duplicate_owner_detected")
+    if "same_issue_role_boundary_seen" not in duplicate:
+        stops.append("missing_same_issue_role_boundary_seen")
     if duplicate.get("duplicate_owner_detected") is True:
         stops.append("duplicate_owner")
     if duplicate.get("same_issue_role_boundary_seen") is True:
@@ -174,11 +185,12 @@ def validate(packet: dict[str, Any], now: dt.datetime) -> dict[str, Any]:
         stops.append("missing_or_unknown_model")
     if reasoning_rank(requested_reasoning) is None:
         stops.append("missing_or_unknown_reasoning")
+    approval = model.get("human_escalation_approval")
     if model_rank(requested_model) is not None and model_rank(requested_model) > model_rank(DEFAULT_CEILING_MODEL):
-        if not model.get("human_escalation_approval"):
+        if not valid_escalation_approval(approval):
             stops.append("model_escalation_requires_human_approval")
     if reasoning_rank(requested_reasoning) is not None and reasoning_rank(requested_reasoning) > reasoning_rank(DEFAULT_CEILING_REASONING):
-        if not model.get("human_escalation_approval"):
+        if not valid_escalation_approval(approval):
             stops.append("reasoning_escalation_requires_human_approval")
 
     context_size = context.get("estimated_context_tokens")

--- a/scripts/test_collaboration_route_planner.py
+++ b/scripts/test_collaboration_route_planner.py
@@ -91,11 +91,59 @@ def main() -> int:
     duplicate = packet(duplicate_dispatch={"duplicate_owner_detected": True})
     duplicate_result = validate(duplicate)
     expect("duplicate-owner-holds", "duplicate_owner" in duplicate_result["stop_conditions"], duplicate_result)
+    expect(
+        "duplicate-boundary-subfield-required",
+        "missing_same_issue_role_boundary_seen" in duplicate_result["stop_conditions"],
+        duplicate_result,
+    )
+
+    missing_duplicate_subfield = packet(duplicate_dispatch={"duplicate_owner_detected": False})
+    missing_duplicate_subfield_result = validate(missing_duplicate_subfield)
+    expect(
+        "missing-duplicate-subfield-holds",
+        missing_duplicate_subfield_result["route_decision"] == "hold_for_decision",
+        missing_duplicate_subfield_result,
+    )
+    expect(
+        "missing-duplicate-subfield-visible",
+        "missing_same_issue_role_boundary_seen" in missing_duplicate_subfield_result["stop_conditions"],
+        missing_duplicate_subfield_result,
+    )
 
     escalation = packet(model={"name": "gpt-5.6", "reasoning": "high"})
     escalation_result = validate(escalation)
     expect("model-escalation-holds", "model_escalation_requires_human_approval" in escalation_result["stop_conditions"], escalation_result)
     expect("reasoning-escalation-holds", "reasoning_escalation_requires_human_approval" in escalation_result["stop_conditions"], escalation_result)
+
+    incomplete_approval = packet(model={"name": "gpt-5.6", "reasoning": "high", "human_escalation_approval": {"purpose": "x"}})
+    incomplete_approval_result = validate(incomplete_approval)
+    expect(
+        "incomplete-approval-model-holds",
+        "model_escalation_requires_human_approval" in incomplete_approval_result["stop_conditions"],
+        incomplete_approval_result,
+    )
+    expect(
+        "incomplete-approval-reasoning-holds",
+        "reasoning_escalation_requires_human_approval" in incomplete_approval_result["stop_conditions"],
+        incomplete_approval_result,
+    )
+
+    complete_approval = packet(
+        model={
+            "name": "gpt-5.6",
+            "reasoning": "high",
+            "human_escalation_approval": {
+                "issue": 440,
+                "role": "Implementer",
+                "model": "gpt-5.6",
+                "reasoning": "high",
+                "purpose": "bounded review fix",
+                "budget": "25000 tokens",
+            },
+        }
+    )
+    complete_approval_result = validate(complete_approval)
+    expect("complete-approval-does-not-hold", complete_approval_result["route_decision"] == "fresh_bounded_thread", complete_approval_result)
 
     oversized = packet()
     oversized["context"] = {**oversized["context"], "estimated_context_tokens": 5000, "max_context_tokens": 4000}

--- a/scripts/test_collaboration_route_planner.py
+++ b/scripts/test_collaboration_route_planner.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Focused regression tests for the collaboration route planner."""
+
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PLANNER = ROOT / "scripts" / "plan_collaboration_routes.py"
+spec = importlib.util.spec_from_file_location("plan_collaboration_routes", PLANNER)
+planner = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(planner)
+
+
+def packet(**overrides):
+    base = {
+        "issue": 440,
+        "role": "Implementer",
+        "dispatch_id": "issue-440-implementer-low-limit-v1",
+        "durable_anchor": "https://github.com/farmerhunter/agent-foundry/issues/440#issuecomment-5065248122",
+        "requested_route": "fresh_bounded_thread",
+        "token_budget": {
+            "first_active_turn_words": 1500,
+            "total_role_thread_tokens": 25000,
+        },
+        "context": {
+            "source_timestamp": "2026-07-24T01:33:07Z",
+            "max_age_hours": 24,
+            "estimated_context_tokens": 1000,
+            "max_context_tokens": 4000,
+        },
+        "readback": {
+            "mode": "cursor_only_compact",
+            "compact_readback_available": True,
+        },
+        "duplicate_dispatch": {
+            "duplicate_owner_detected": False,
+            "same_issue_role_boundary_seen": False,
+        },
+        "hold_conditions": [
+            "missing_budget",
+            "budget_breach",
+            "stale_context",
+            "oversized_context",
+            "duplicate_owner",
+            "compact_readback_unavailable",
+            "escalation_need",
+            "missing_required_fields",
+        ],
+        "model": {
+            "name": "gpt-5.5",
+            "reasoning": "medium",
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def validate(value):
+    now = dt.datetime(2026, 7, 24, 2, 0, tzinfo=dt.timezone.utc)
+    return planner.validate(value, now)
+
+
+def expect(name, condition, detail):
+    if not condition:
+        raise AssertionError(f"{name} failed: {detail}")
+
+
+def main() -> int:
+    ok = validate(packet())
+    expect("valid-packet-routes", ok["route_decision"] == "fresh_bounded_thread", ok)
+    expect("valid-packet-does-not-mutate", ok["mutation_performed"] is False and ok["dispatch_performed"] is False, ok)
+
+    missing_budget = validate(packet(token_budget={}))
+    expect("missing-budget-holds", missing_budget["route_decision"] == "hold_for_decision", missing_budget)
+    expect("missing-budget-stop-visible", "missing_first_active_turn_word_budget" in missing_budget["stop_conditions"], missing_budget)
+
+    stale = packet()
+    stale["context"] = {**stale["context"], "source_timestamp": "2026-07-20T01:33:07Z"}
+    stale_result = validate(stale)
+    expect("stale-context-holds", "stale_context" in stale_result["stop_conditions"], stale_result)
+
+    readback = packet(readback={"mode": "full_rehydrate", "compact_readback_available": True})
+    readback_result = validate(readback)
+    expect("non-compact-readback-holds", "readback_not_cursor_only_compact" in readback_result["stop_conditions"], readback_result)
+
+    duplicate = packet(duplicate_dispatch={"duplicate_owner_detected": True})
+    duplicate_result = validate(duplicate)
+    expect("duplicate-owner-holds", "duplicate_owner" in duplicate_result["stop_conditions"], duplicate_result)
+
+    escalation = packet(model={"name": "gpt-5.6", "reasoning": "high"})
+    escalation_result = validate(escalation)
+    expect("model-escalation-holds", "model_escalation_requires_human_approval" in escalation_result["stop_conditions"], escalation_result)
+    expect("reasoning-escalation-holds", "reasoning_escalation_requires_human_approval" in escalation_result["stop_conditions"], escalation_result)
+
+    oversized = packet()
+    oversized["context"] = {**oversized["context"], "estimated_context_tokens": 5000, "max_context_tokens": 4000}
+    oversized_result = validate(oversized)
+    expect("oversized-context-holds", "oversized_context" in oversized_result["stop_conditions"], oversized_result)
+
+    missing_anchor = packet(dispatch_id="", durable_anchor="")
+    missing_anchor_result = validate(missing_anchor)
+    expect("missing-anchor-holds", "missing_duplicate_dispatch_anchor" in missing_anchor_result["stop_conditions"], missing_anchor_result)
+
+    print("collaboration route planner tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds an advisory collaboration route planner that fails closed to hold_for_decision when AF18 low_limit packet fields are missing or breached.
- Adds schema coverage for token budgets, source timestamp/context age, cursor-only compact readback, duplicate-dispatch anchors, hold conditions, and model/reasoning escalation approval.
- Adds focused planner regression tests for missing budget, stale context, non-compact readback, duplicate owner, oversized context, missing anchor, and escalation above gpt-5.5 medium.

## Verification
- python3 scripts/test_collaboration_route_planner.py
- python3 scripts/plan_collaboration_routes.py --help
- git diff --check
- git diff --cached --check

Closes #440 after review/merge. Do not merge from this Implementer role.