### PR TITLE
Add AF18 low_limit threshold bands

### DIFF
--- a/schemas/collaboration-routing-policy.schema.yaml
+++ b/schemas/collaboration-routing-policy.schema.yaml
@@ -53,11 +53,20 @@ properties:
     additionalProperties: false
     required:
       - source_timestamp
-      - max_age_hours
+      - threshold_band
     properties:
       source_timestamp:
         type: string
         format: date-time
+      threshold_band:
+        type: string
+        enum:
+          - generic_default
+          - coordinator_routing_status_readback
+          - architect_design_gate
+          - implementer_small_scoped_implementation
+          - reviewer_exact_pr_review
+          - tester_focused_validation
       max_age_hours:
         type: integer
         minimum: 1
@@ -67,6 +76,33 @@ properties:
       max_context_tokens:
         type: integer
         minimum: 1
+        maximum: 12000
+      threshold_exception:
+        type: object
+        additionalProperties: false
+        required:
+          - issue
+          - role
+          - temporary_cap
+          - reason
+          - expiry
+        properties:
+          issue:
+            type: integer
+            minimum: 1
+          role:
+            type: string
+            minLength: 1
+          temporary_cap:
+            type: integer
+            minimum: 1
+            maximum: 12000
+          reason:
+            type: string
+            minLength: 1
+          expiry:
+            type: string
+            format: date-time
   readback:
     type: object
     additionalProperties: false

--- a/scripts/plan_collaboration_routes.py
+++ b/scripts/plan_collaboration_routes.py
@@ -102,11 +102,13 @@ def valid_escalation_approval(approval: Any) -> bool:
     return all(approval.get(field) not in (None, "", [], {}) for field in required)
 
 
-def valid_threshold_exception(exception: Any, now: dt.datetime) -> bool:
+def valid_threshold_exception(exception: Any, now: dt.datetime, issue: Any, role: Any) -> bool:
     if not isinstance(exception, dict):
         return False
     required = ("issue", "role", "temporary_cap", "reason", "expiry")
     if not all(exception.get(field) not in (None, "", [], {}) for field in required):
+        return False
+    if exception.get("issue") != issue or exception.get("role") != role:
         return False
     if not isinstance(exception.get("temporary_cap"), int) or exception["temporary_cap"] > GLOBAL_HARD_CONTEXT_CEILING:
         return False
@@ -117,7 +119,7 @@ def valid_threshold_exception(exception: Any, now: dt.datetime) -> bool:
     return expiry > now
 
 
-def resolve_threshold(context: dict[str, Any], now: dt.datetime, stops: list[str]) -> dict[str, Any]:
+def resolve_threshold(context: dict[str, Any], now: dt.datetime, stops: list[str], issue: Any, role: Any) -> dict[str, Any]:
     band = context.get("threshold_band")
     if not isinstance(band, str) or not band.strip():
         stops.append("missing_threshold_band")
@@ -145,7 +147,7 @@ def resolve_threshold(context: dict[str, Any], now: dt.datetime, stops: list[str
     if override_requested:
         exception = context.get("threshold_exception")
         if (
-            not valid_threshold_exception(exception, now)
+            not valid_threshold_exception(exception, now, issue, role)
             or age_override_requested
             or (max_override_requested and requested_max != exception.get("temporary_cap"))
         ):
@@ -191,7 +193,7 @@ def validate(packet: dict[str, Any], now: dt.datetime) -> dict[str, Any]:
     except (TypeError, ValueError):
         stops.append("missing_or_invalid_source_timestamp")
         source_ts = None
-    threshold = resolve_threshold(context, now, stops)
+    threshold = resolve_threshold(context, now, stops, issue, role)
     if source_ts is not None and now - source_ts > dt.timedelta(hours=threshold["max_age_hours"]):
         stops.append("stale_context")
 

--- a/scripts/plan_collaboration_routes.py
+++ b/scripts/plan_collaboration_routes.py
@@ -23,6 +23,15 @@ MODEL_ORDER = {
 REASONING_ORDER = {"minimal": 0, "low": 1, "medium": 2, "high": 3}
 DEFAULT_CEILING_MODEL = "gpt-5.5"
 DEFAULT_CEILING_REASONING = "medium"
+GLOBAL_HARD_CONTEXT_CEILING = 12000
+THRESHOLD_BANDS = {
+    "generic_default": {"max_context_tokens": 6000, "max_age_hours": 24},
+    "coordinator_routing_status_readback": {"max_context_tokens": 4000, "max_age_hours": 12},
+    "architect_design_gate": {"max_context_tokens": 6000, "max_age_hours": 24},
+    "implementer_small_scoped_implementation": {"max_context_tokens": 8000, "max_age_hours": 24},
+    "reviewer_exact_pr_review": {"max_context_tokens": 10000, "max_age_hours": 12},
+    "tester_focused_validation": {"max_context_tokens": 8000, "max_age_hours": 12},
+}
 
 
 def parse_args() -> argparse.Namespace:
@@ -93,6 +102,60 @@ def valid_escalation_approval(approval: Any) -> bool:
     return all(approval.get(field) not in (None, "", [], {}) for field in required)
 
 
+def valid_threshold_exception(exception: Any, now: dt.datetime) -> bool:
+    if not isinstance(exception, dict):
+        return False
+    required = ("issue", "role", "temporary_cap", "reason", "expiry")
+    if not all(exception.get(field) not in (None, "", [], {}) for field in required):
+        return False
+    if not isinstance(exception.get("temporary_cap"), int) or exception["temporary_cap"] > GLOBAL_HARD_CONTEXT_CEILING:
+        return False
+    try:
+        expiry = parse_timestamp(exception.get("expiry"), "threshold_exception.expiry")
+    except (TypeError, ValueError):
+        return False
+    return expiry > now
+
+
+def resolve_threshold(context: dict[str, Any], now: dt.datetime, stops: list[str]) -> dict[str, Any]:
+    band = context.get("threshold_band")
+    if not isinstance(band, str) or not band.strip():
+        stops.append("missing_threshold_band")
+        band = "unknown"
+    policy = THRESHOLD_BANDS.get(band)
+    if policy is None:
+        stops.append("unknown_threshold_band")
+        policy = THRESHOLD_BANDS["generic_default"]
+
+    effective = {
+        "band": band,
+        "max_context_tokens": policy["max_context_tokens"],
+        "max_age_hours": policy["max_age_hours"],
+        "global_hard_ceiling": GLOBAL_HARD_CONTEXT_CEILING,
+        "exception_applied": False,
+    }
+
+    requested_max = context.get("max_context_tokens")
+    requested_age = context.get("max_age_hours")
+    max_override_requested = requested_max not in (None, policy["max_context_tokens"])
+    age_override_requested = requested_age not in (None, policy["max_age_hours"])
+    override_requested = max_override_requested or age_override_requested or "threshold_exception" in context
+    if isinstance(requested_max, int) and requested_max > GLOBAL_HARD_CONTEXT_CEILING:
+        stops.append("context_exceeds_global_hard_ceiling")
+    if override_requested:
+        exception = context.get("threshold_exception")
+        if (
+            not valid_threshold_exception(exception, now)
+            or age_override_requested
+            or (max_override_requested and requested_max != exception.get("temporary_cap"))
+        ):
+            stops.append("malformed_threshold_override")
+        else:
+            effective["max_context_tokens"] = exception["temporary_cap"]
+            effective["exception_applied"] = True
+    return effective
+
+
 def validate(packet: dict[str, Any], now: dt.datetime) -> dict[str, Any]:
     stops: list[str] = []
     warnings: list[str] = []
@@ -128,10 +191,8 @@ def validate(packet: dict[str, Any], now: dt.datetime) -> dict[str, Any]:
     except (TypeError, ValueError):
         stops.append("missing_or_invalid_source_timestamp")
         source_ts = None
-    max_age_hours = context.get("max_age_hours")
-    if not isinstance(max_age_hours, int) or max_age_hours <= 0:
-        stops.append("missing_max_context_age_hours")
-    elif source_ts is not None and now - source_ts > dt.timedelta(hours=max_age_hours):
+    threshold = resolve_threshold(context, now, stops)
+    if source_ts is not None and now - source_ts > dt.timedelta(hours=threshold["max_age_hours"]):
         stops.append("stale_context")
 
     readback = packet.get("readback")
@@ -194,8 +255,7 @@ def validate(packet: dict[str, Any], now: dt.datetime) -> dict[str, Any]:
             stops.append("reasoning_escalation_requires_human_approval")
 
     context_size = context.get("estimated_context_tokens")
-    max_context_tokens = context.get("max_context_tokens")
-    if isinstance(context_size, int) and isinstance(max_context_tokens, int) and context_size > max_context_tokens:
+    if isinstance(context_size, int) and context_size > threshold["max_context_tokens"]:
         stops.append("oversized_context")
 
     decision = "hold_for_decision" if stops else packet.get("requested_route", "serial_current_session")
@@ -213,7 +273,9 @@ def validate(packet: dict[str, Any], now: dt.datetime) -> dict[str, Any]:
             "model_ceiling": DEFAULT_CEILING_MODEL,
             "reasoning_ceiling": DEFAULT_CEILING_REASONING,
             "readback_default": "cursor_only_compact",
+            "global_hard_context_ceiling": GLOBAL_HARD_CONTEXT_CEILING,
         },
+        "effective_threshold": threshold,
         "mutation_performed": False,
         "dispatch_performed": False,
     }

--- a/scripts/test_collaboration_route_planner.py
+++ b/scripts/test_collaboration_route_planner.py
@@ -187,7 +187,7 @@ def main() -> int:
                 **packet()["context"],
                 "max_age_hours": 48,
                 "threshold_exception": {
-                    "issue": 442,
+                    "issue": 440,
                     "role": "Implementer",
                     "temporary_cap": 8000,
                     "reason": "age overrides are not authorized",
@@ -204,7 +204,7 @@ def main() -> int:
                 **packet()["context"],
                 "max_context_tokens": 9000,
                 "threshold_exception": {
-                    "issue": 442,
+                    "issue": 440,
                     "role": "Implementer",
                     "temporary_cap": 8500,
                     "reason": "mismatched cap",
@@ -215,13 +215,47 @@ def main() -> int:
     )
     expect("mismatched-cap-exception-holds", "malformed_threshold_override" in mismatched_cap_exception["stop_conditions"], mismatched_cap_exception)
 
-    valid_exception = validate(
+    mismatched_issue_exception = validate(
         packet(
             context={
                 **packet()["context"],
                 "max_context_tokens": 9000,
                 "threshold_exception": {
                     "issue": 442,
+                    "role": "Implementer",
+                    "temporary_cap": 9000,
+                    "reason": "wrong issue",
+                    "expiry": "2026-07-25T00:00:00Z",
+                },
+            }
+        )
+    )
+    expect("mismatched-issue-exception-holds", "malformed_threshold_override" in mismatched_issue_exception["stop_conditions"], mismatched_issue_exception)
+
+    mismatched_role_exception = validate(
+        packet(
+            context={
+                **packet()["context"],
+                "max_context_tokens": 9000,
+                "threshold_exception": {
+                    "issue": 440,
+                    "role": "Reviewer",
+                    "temporary_cap": 9000,
+                    "reason": "wrong role",
+                    "expiry": "2026-07-25T00:00:00Z",
+                },
+            }
+        )
+    )
+    expect("mismatched-role-exception-holds", "malformed_threshold_override" in mismatched_role_exception["stop_conditions"], mismatched_role_exception)
+
+    valid_exception = validate(
+        packet(
+            context={
+                **packet()["context"],
+                "max_context_tokens": 9000,
+                "threshold_exception": {
+                    "issue": 440,
                     "role": "Implementer",
                     "temporary_cap": 9000,
                     "reason": "bounded temporary exception",

--- a/scripts/test_collaboration_route_planner.py
+++ b/scripts/test_collaboration_route_planner.py
@@ -29,9 +29,8 @@ def packet(**overrides):
         },
         "context": {
             "source_timestamp": "2026-07-24T01:33:07Z",
-            "max_age_hours": 24,
+            "threshold_band": "implementer_small_scoped_implementation",
             "estimated_context_tokens": 1000,
-            "max_context_tokens": 4000,
         },
         "readback": {
             "mode": "cursor_only_compact",
@@ -74,6 +73,8 @@ def main() -> int:
     ok = validate(packet())
     expect("valid-packet-routes", ok["route_decision"] == "fresh_bounded_thread", ok)
     expect("valid-packet-does-not-mutate", ok["mutation_performed"] is False and ok["dispatch_performed"] is False, ok)
+    expect("valid-band-max", ok["effective_threshold"]["max_context_tokens"] == 8000, ok)
+    expect("valid-band-age", ok["effective_threshold"]["max_age_hours"] == 24, ok)
 
     missing_budget = validate(packet(token_budget={}))
     expect("missing-budget-holds", missing_budget["route_decision"] == "hold_for_decision", missing_budget)
@@ -146,13 +147,91 @@ def main() -> int:
     expect("complete-approval-does-not-hold", complete_approval_result["route_decision"] == "fresh_bounded_thread", complete_approval_result)
 
     oversized = packet()
-    oversized["context"] = {**oversized["context"], "estimated_context_tokens": 5000, "max_context_tokens": 4000}
+    oversized["context"] = {**oversized["context"], "estimated_context_tokens": 9000}
     oversized_result = validate(oversized)
     expect("oversized-context-holds", "oversized_context" in oversized_result["stop_conditions"], oversized_result)
 
     missing_anchor = packet(dispatch_id="", durable_anchor="")
     missing_anchor_result = validate(missing_anchor)
     expect("missing-anchor-holds", "missing_duplicate_dispatch_anchor" in missing_anchor_result["stop_conditions"], missing_anchor_result)
+
+    generic = validate(packet(context={**packet()["context"], "threshold_band": "generic_default"}))
+    expect("generic-band-max", generic["effective_threshold"]["max_context_tokens"] == 6000, generic)
+    expect("generic-band-age", generic["effective_threshold"]["max_age_hours"] == 24, generic)
+
+    coordinator = validate(packet(context={**packet()["context"], "threshold_band": "coordinator_routing_status_readback"}))
+    expect("coordinator-band-max", coordinator["effective_threshold"]["max_context_tokens"] == 4000, coordinator)
+    expect("coordinator-band-age", coordinator["effective_threshold"]["max_age_hours"] == 12, coordinator)
+
+    reviewer = validate(packet(context={**packet()["context"], "threshold_band": "reviewer_exact_pr_review"}))
+    expect("reviewer-band-max", reviewer["effective_threshold"]["max_context_tokens"] == 10000, reviewer)
+    expect("reviewer-band-age", reviewer["effective_threshold"]["max_age_hours"] == 12, reviewer)
+
+    missing_threshold = packet()
+    missing_threshold["context"] = {key: value for key, value in missing_threshold["context"].items() if key != "threshold_band"}
+    missing_threshold_result = validate(missing_threshold)
+    expect("missing-threshold-holds", "missing_threshold_band" in missing_threshold_result["stop_conditions"], missing_threshold_result)
+
+    unknown_threshold = validate(packet(context={**packet()["context"], "threshold_band": "wide_open"}))
+    expect("unknown-threshold-holds", "unknown_threshold_band" in unknown_threshold["stop_conditions"], unknown_threshold)
+
+    global_breach = validate(packet(context={**packet()["context"], "max_context_tokens": 12001}))
+    expect("global-ceiling-holds", "context_exceeds_global_hard_ceiling" in global_breach["stop_conditions"], global_breach)
+
+    malformed_override = validate(packet(context={**packet()["context"], "max_context_tokens": 9000}))
+    expect("malformed-override-holds", "malformed_threshold_override" in malformed_override["stop_conditions"], malformed_override)
+
+    malformed_age_override = validate(
+        packet(
+            context={
+                **packet()["context"],
+                "max_age_hours": 48,
+                "threshold_exception": {
+                    "issue": 442,
+                    "role": "Implementer",
+                    "temporary_cap": 8000,
+                    "reason": "age overrides are not authorized",
+                    "expiry": "2026-07-25T00:00:00Z",
+                },
+            }
+        )
+    )
+    expect("malformed-age-override-holds", "malformed_threshold_override" in malformed_age_override["stop_conditions"], malformed_age_override)
+
+    mismatched_cap_exception = validate(
+        packet(
+            context={
+                **packet()["context"],
+                "max_context_tokens": 9000,
+                "threshold_exception": {
+                    "issue": 442,
+                    "role": "Implementer",
+                    "temporary_cap": 8500,
+                    "reason": "mismatched cap",
+                    "expiry": "2026-07-25T00:00:00Z",
+                },
+            }
+        )
+    )
+    expect("mismatched-cap-exception-holds", "malformed_threshold_override" in mismatched_cap_exception["stop_conditions"], mismatched_cap_exception)
+
+    valid_exception = validate(
+        packet(
+            context={
+                **packet()["context"],
+                "max_context_tokens": 9000,
+                "threshold_exception": {
+                    "issue": 442,
+                    "role": "Implementer",
+                    "temporary_cap": 9000,
+                    "reason": "bounded temporary exception",
+                    "expiry": "2026-07-25T00:00:00Z",
+                },
+            }
+        )
+    )
+    expect("valid-threshold-exception-routes", valid_exception["route_decision"] == "fresh_bounded_thread", valid_exception)
+    expect("valid-threshold-exception-visible", valid_exception["effective_threshold"]["exception_applied"] is True, valid_exception)
 
     print("collaboration route planner tests passed")
     return 0


### PR DESCRIPTION
## Summary
- Implements AF18 hybrid low_limit threshold bands in the advisory collaboration route planner.
- Resolves supported role/task bands to effective max context tokens and max age, with visible planner output for effective threshold and global hard ceiling.
- Fails closed on missing/unknown threshold band, oversized context, global hard ceiling breach, malformed override, age override, and mismatched Human exception cap.
- Adds schema fields and focused regressions for the approved #442 threshold policy while preserving advisory-only mutation/dispatch output.

## Verification
- python3 scripts/test_collaboration_route_planner.py
- python3 scripts/plan_collaboration_routes.py --help
- git diff --check
- git diff --cached --check

Closes #442 after review/merge. Do not merge from this Implementer role.