### PR TITLE
Add runtime-owned capture evidence validation

### DIFF
--- a/schemas/runtime-owned-capture.schema.yaml
+++ b/schemas/runtime-owned-capture.schema.yaml
@@ -1,0 +1,168 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "https://agent-foundry.local/schemas/runtime-owned-capture.schema.yaml"
+title: Runtime-Owned Capability Capture Evidence
+type: object
+additionalProperties: false
+required:
+  - schema_version
+  - record_id
+  - captured_at
+  - producer
+  - runtime_attestation
+  - route
+  - evidence_metadata
+  - privacy
+  - stop_conditions
+properties:
+  schema_version:
+    const: 1
+  record_id:
+    type: string
+    minLength: 1
+  captured_at:
+    type: string
+    format: date-time
+  producer:
+    type: object
+    additionalProperties: false
+    required:
+      - producer_type
+      - producer_id
+      - runtime_id
+      - capture_session_id
+      - runtime_owned
+      - caller_supplied
+    properties:
+      producer_type:
+        enum:
+          - runtime_control_surface
+          - adapter_control_surface
+      producer_id:
+        type: string
+        minLength: 1
+      runtime_id:
+        type: string
+        minLength: 1
+      capture_session_id:
+        type: string
+        minLength: 1
+      runtime_owned:
+        const: true
+      caller_supplied:
+        const: false
+  runtime_attestation:
+    type: object
+    additionalProperties: false
+    required:
+      - producer_bound
+      - capture_nonce
+    properties:
+      producer_bound:
+        const: true
+      capture_nonce:
+        type: string
+        minLength: 1
+  route:
+    type: object
+    additionalProperties: false
+    required:
+      - category
+      - support_status
+      - requested_envelope
+      - effective_envelope
+    properties:
+      category:
+        enum:
+          - create
+          - send
+          - spawn
+          - fork
+          - automation
+          - future
+      support_status:
+        enum:
+          - supported
+          - degraded
+          - unsupported
+      requested_envelope:
+        type: object
+        additionalProperties: false
+        required:
+          - model
+          - reasoning
+        properties:
+          model:
+            type: string
+            minLength: 1
+          reasoning:
+            type: string
+            minLength: 1
+      effective_envelope:
+        type: object
+        additionalProperties: false
+        required:
+          - status
+        properties:
+          status:
+            enum:
+              - accepted
+              - downgraded
+              - unknown
+          model:
+            type: string
+            minLength: 1
+          reasoning:
+            type: string
+            minLength: 1
+      missing_observations:
+        type: array
+        items:
+          type: string
+          minLength: 1
+      unsupported_reason:
+        type: string
+        minLength: 1
+  evidence_metadata:
+    type: object
+    additionalProperties: false
+    properties:
+      route_id:
+        type: string
+      target_id:
+        type: string
+      cursor:
+        type: string
+      budget_anchor:
+        type: string
+      external_cost_possible:
+        type: boolean
+      duplicate_owner_detected:
+        type: boolean
+      evidence_ref:
+        type: string
+  privacy:
+    type: object
+    additionalProperties: false
+    required:
+      - contains_prompt_body
+      - redaction
+    properties:
+      contains_prompt_body:
+        const: false
+      redaction:
+        const: metadata_only
+  stop_conditions:
+    type: array
+    uniqueItems: true
+    items:
+      enum:
+        - missing_producer
+        - stale_evidence
+        - forged_evidence
+        - caller_only_evidence
+        - privacy_exposure
+        - duplicate_owner
+        - budget_breach
+        - external_cost_ambiguity
+        - missing_runtime_capture
+        - unsupported_runtime_capture

--- a/schemas/runtime-owned-capture.schema.yaml
+++ b/schemas/runtime-owned-capture.schema.yaml
@@ -122,6 +122,73 @@ properties:
       unsupported_reason:
         type: string
         minLength: 1
+      category_evidence:
+        type: object
+        additionalProperties: false
+        properties:
+          new_thread_id:
+            type: string
+            minLength: 1
+          capability_source:
+            type: string
+            minLength: 1
+          capture_timestamp:
+            type: string
+            format: date-time
+          target_id:
+            type: string
+            minLength: 1
+          cursor_behavior:
+            type: string
+            minLength: 1
+          delivery_status:
+            type: string
+            minLength: 1
+          result_status:
+            type: string
+            minLength: 1
+          child_owner:
+            type: string
+            minLength: 1
+          isolation_boundary:
+            type: string
+            minLength: 1
+          inherited_context_policy:
+            type: string
+            minLength: 1
+          budget_anchor:
+            type: string
+            minLength: 1
+          source_id:
+            type: string
+            minLength: 1
+          fork_boundary:
+            type: string
+            minLength: 1
+          inherited_packet_ref:
+            type: string
+            minLength: 1
+          materialized_packet_ref:
+            type: string
+            minLength: 1
+          rollback_delete_constraints:
+            type: string
+            minLength: 1
+          schedule_id:
+            type: string
+            minLength: 1
+          trigger:
+            type: string
+            minLength: 1
+          dispatch_target:
+            type: string
+            minLength: 1
+          stop_expiry:
+            type: string
+            format: date-time
+          user_approval_scope:
+            type: string
+            minLength: 1
   evidence_metadata:
     type: object
     additionalProperties: false

--- a/schemas/runtime-owned-capture.schema.yaml
+++ b/schemas/runtime-owned-capture.schema.yaml
@@ -233,3 +233,4 @@ properties:
         - external_cost_ambiguity
         - missing_runtime_capture
         - unsupported_runtime_capture
+        - unsupported_future_route

--- a/scripts/test_runtime_owned_capture.py
+++ b/scripts/test_runtime_owned_capture.py
@@ -109,6 +109,19 @@ def main() -> int:
     expect("unsupported-runtime-owned-record-valid", unsupported_result["valid"] is True, unsupported_result)
     expect("unsupported-status-visible", unsupported_result["support_status"] == "unsupported", unsupported_result)
 
+    future_supported = validate(
+        record(
+            route={
+                "category": "future",
+                "support_status": "supported",
+                "requested_envelope": {"model": "gpt-5.5", "reasoning": "medium"},
+                "effective_envelope": {"status": "accepted", "model": "gpt-5.5", "reasoning": "medium"},
+            }
+        )
+    )
+    expect("future-supported-invalid", future_supported["valid"] is False, future_supported)
+    expect("future-supported-error", "unsupported_future_route" in future_supported["errors"], future_supported)
+
     supported_routes = {
         "create": {
             "new_thread_id": "thread-446",

--- a/scripts/test_runtime_owned_capture.py
+++ b/scripts/test_runtime_owned_capture.py
@@ -41,6 +41,11 @@ def record(**overrides):
             "support_status": "supported",
             "requested_envelope": {"model": "gpt-5.5", "reasoning": "medium"},
             "effective_envelope": {"status": "accepted", "model": "gpt-5.5", "reasoning": "medium"},
+            "category_evidence": {
+                "new_thread_id": "thread-446",
+                "capability_source": "codex-control-surface",
+                "capture_timestamp": "2026-07-24T03:55:00Z",
+            },
         },
         "evidence_metadata": {
             "route_id": "route-446",
@@ -103,6 +108,70 @@ def main() -> int:
     unsupported_result = validate(unsupported)
     expect("unsupported-runtime-owned-record-valid", unsupported_result["valid"] is True, unsupported_result)
     expect("unsupported-status-visible", unsupported_result["support_status"] == "unsupported", unsupported_result)
+
+    supported_routes = {
+        "create": {
+            "new_thread_id": "thread-446",
+            "capability_source": "codex-control-surface",
+            "capture_timestamp": "2026-07-24T03:55:00Z",
+        },
+        "send": {
+            "target_id": "thread-446",
+            "cursor_behavior": "after_cursor",
+            "delivery_status": "delivered",
+            "result_status": "accepted",
+        },
+        "spawn": {
+            "child_owner": "Implementer",
+            "isolation_boundary": "bounded_child_session",
+            "inherited_context_policy": "compact_issue_packet",
+            "budget_anchor": "issue-446",
+        },
+        "fork": {
+            "source_id": "thread-446",
+            "fork_boundary": "fresh_task_branch",
+            "materialized_packet_ref": "issue-446-packet",
+            "rollback_delete_constraints": "no_delete_without_human_approval",
+        },
+        "automation": {
+            "schedule_id": "schedule-446",
+            "trigger": "manual_human_approved",
+            "dispatch_target": "reviewer",
+            "stop_expiry": "2026-07-25T00:00:00Z",
+            "user_approval_scope": "issue-446-only",
+        },
+    }
+    for category, category_evidence in supported_routes.items():
+        supported_category = validate(
+            record(
+                route={
+                    "category": category,
+                    "support_status": "supported",
+                    "requested_envelope": {"model": "gpt-5.5", "reasoning": "medium"},
+                    "effective_envelope": {"status": "accepted", "model": "gpt-5.5", "reasoning": "medium"},
+                    "category_evidence": category_evidence,
+                }
+            )
+        )
+        expect(f"supported-{category}-category-valid", supported_category["valid"] is True, supported_category)
+
+        missing_category = validate(
+            record(
+                route={
+                    "category": category,
+                    "support_status": "supported",
+                    "requested_envelope": {"model": "gpt-5.5", "reasoning": "medium"},
+                    "effective_envelope": {"status": "accepted", "model": "gpt-5.5", "reasoning": "medium"},
+                    "category_evidence": {},
+                }
+            )
+        )
+        expect(f"supported-{category}-missing-category-evidence-invalid", missing_category["valid"] is False, missing_category)
+        expect(
+            f"supported-{category}-missing-category-evidence-error",
+            "missing_route_category_evidence" in missing_category["errors"],
+            missing_category,
+        )
 
     caller_supplied = record(producer={**record()["producer"], "runtime_owned": False, "caller_supplied": True})
     caller_result = validate(caller_supplied)

--- a/scripts/test_runtime_owned_capture.py
+++ b/scripts/test_runtime_owned_capture.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Focused tests for runtime-owned capability capture evidence."""
+
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = ROOT / "scripts" / "validate_runtime_owned_capture.py"
+spec = importlib.util.spec_from_file_location("validate_runtime_owned_capture", VALIDATOR)
+validator = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(validator)
+
+
+NOW = dt.datetime(2026, 7, 24, 4, 0, tzinfo=dt.timezone.utc)
+
+
+def record(**overrides):
+    base = {
+        "schema_version": 1,
+        "record_id": "capture-446-supported-create",
+        "captured_at": "2026-07-24T03:55:00Z",
+        "producer": {
+            "producer_type": "runtime_control_surface",
+            "producer_id": "codex-control-surface",
+            "runtime_id": "codex",
+            "capture_session_id": "capture-session-446",
+            "runtime_owned": True,
+            "caller_supplied": False,
+        },
+        "runtime_attestation": {
+            "producer_bound": True,
+            "capture_nonce": "nonce-446",
+        },
+        "route": {
+            "category": "create",
+            "support_status": "supported",
+            "requested_envelope": {"model": "gpt-5.5", "reasoning": "medium"},
+            "effective_envelope": {"status": "accepted", "model": "gpt-5.5", "reasoning": "medium"},
+        },
+        "evidence_metadata": {
+            "route_id": "route-446",
+            "target_id": "thread-446",
+            "cursor": "cursor-446",
+            "budget_anchor": "issue-446",
+            "external_cost_possible": False,
+            "duplicate_owner_detected": False,
+            "evidence_ref": "https://github.com/farmerhunter/agent-foundry/issues/446#runtime-capture",
+        },
+        "privacy": {
+            "contains_prompt_body": False,
+            "redaction": "metadata_only",
+        },
+        "stop_conditions": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def validate(value):
+    return validator.validate(value, NOW)
+
+
+def expect(name, condition, detail):
+    if not condition:
+        raise AssertionError(f"{name} failed: {detail}")
+
+
+def main() -> int:
+    supported = validate(record())
+    expect("supported-runtime-owned-record-valid", supported["valid"] is True, supported)
+    expect("supported-route-visible", supported["support_status"] == "supported", supported)
+    expect("supported-no-content", supported["content_redacted"] is True, supported)
+    expect("supported-advisory-only", supported["mutation_performed"] is False and supported["dispatch_performed"] is False, supported)
+
+    degraded = record(
+        route={
+            "category": "send",
+            "support_status": "degraded",
+            "requested_envelope": {"model": "gpt-5.5", "reasoning": "medium"},
+            "effective_envelope": {"status": "unknown"},
+            "missing_observations": ["effective_model"],
+        }
+    )
+    degraded_result = validate(degraded)
+    expect("degraded-runtime-owned-record-valid", degraded_result["valid"] is True, degraded_result)
+    expect("degraded-status-visible", degraded_result["support_status"] == "degraded", degraded_result)
+
+    unsupported = record(
+        route={
+            "category": "future",
+            "support_status": "unsupported",
+            "requested_envelope": {"model": "gpt-5.5", "reasoning": "medium"},
+            "effective_envelope": {"status": "unknown"},
+            "unsupported_reason": "future route has no runtime-owned capture contract",
+        },
+        stop_conditions=["unsupported_runtime_capture"],
+    )
+    unsupported_result = validate(unsupported)
+    expect("unsupported-runtime-owned-record-valid", unsupported_result["valid"] is True, unsupported_result)
+    expect("unsupported-status-visible", unsupported_result["support_status"] == "unsupported", unsupported_result)
+
+    caller_supplied = record(producer={**record()["producer"], "runtime_owned": False, "caller_supplied": True})
+    caller_result = validate(caller_supplied)
+    expect("caller-supplied-invalid", caller_result["valid"] is False, caller_result)
+    expect("caller-supplied-error", "caller_only_evidence" in caller_result["errors"], caller_result)
+
+    forged = record(runtime_attestation={"producer_bound": False, "capture_nonce": "nonce-446"})
+    forged_result = validate(forged)
+    expect("forged-invalid", forged_result["valid"] is False, forged_result)
+    expect("forged-error", "forged_evidence" in forged_result["errors"], forged_result)
+
+    stale = record(captured_at="2026-07-20T03:55:00Z")
+    stale_result = validate(stale)
+    expect("stale-invalid", stale_result["valid"] is False, stale_result)
+    expect("stale-error", "stale_evidence" in stale_result["errors"], stale_result)
+
+    missing_producer = record(producer={})
+    missing_producer_result = validate(missing_producer)
+    expect("missing-producer-invalid", missing_producer_result["valid"] is False, missing_producer_result)
+    expect("missing-producer-error", "missing_producer" in missing_producer_result["errors"], missing_producer_result)
+
+    prompt_body = record(evidence_metadata={**record()["evidence_metadata"], "prompt": "private task body"})
+    prompt_body_result = validate(prompt_body)
+    expect("prompt-body-invalid", prompt_body_result["valid"] is False, prompt_body_result)
+    expect("prompt-body-error", "prompt_body_content_present" in prompt_body_result["errors"], prompt_body_result)
+
+    print("runtime-owned capture tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_runtime_owned_capture.py
+++ b/scripts/validate_runtime_owned_capture.py
@@ -14,6 +14,13 @@ from typing import Any
 ROUTE_CATEGORIES = {"create", "send", "spawn", "fork", "automation", "future"}
 SUPPORT_STATUSES = {"supported", "degraded", "unsupported"}
 PRODUCER_TYPES = {"runtime_control_surface", "adapter_control_surface"}
+ROUTE_CATEGORY_REQUIRED_EVIDENCE = {
+    "create": ("new_thread_id", "capability_source", "capture_timestamp"),
+    "send": ("target_id", "cursor_behavior", "delivery_status", "result_status"),
+    "spawn": ("child_owner", "isolation_boundary", "inherited_context_policy", "budget_anchor"),
+    "fork": ("source_id", "fork_boundary", "rollback_delete_constraints"),
+    "automation": ("schedule_id", "trigger", "dispatch_target", "stop_expiry", "user_approval_scope"),
+}
 FORBIDDEN_CONTENT_KEYS = {
     "prompt",
     "body",
@@ -103,6 +110,21 @@ def find_forbidden_content(value: Any, path: str = "$") -> list[str]:
     return found
 
 
+def missing_route_category_evidence(category: Any, evidence: Any) -> list[str]:
+    if category not in ROUTE_CATEGORY_REQUIRED_EVIDENCE:
+        return []
+    if not isinstance(evidence, dict):
+        return ["route_category_evidence"]
+    missing_fields = [
+        field
+        for field in ROUTE_CATEGORY_REQUIRED_EVIDENCE[category]
+        if missing(evidence.get(field))
+    ]
+    if category == "fork" and missing(evidence.get("inherited_packet_ref")) and missing(evidence.get("materialized_packet_ref")):
+        missing_fields.append("inherited_or_materialized_packet_ref")
+    return missing_fields
+
+
 def validate(record: dict[str, Any], now: dt.datetime, max_age_hours: int = 24) -> dict[str, Any]:
     errors: list[str] = []
     warnings: list[str] = []
@@ -150,6 +172,10 @@ def validate(record: dict[str, Any], now: dt.datetime, max_age_hours: int = 24) 
     if support_status == "supported":
         if effective.get("status") != "accepted" or missing(effective.get("model")) or missing(effective.get("reasoning")):
             errors.append("missing_effective_envelope")
+        missing_category_fields = missing_route_category_evidence(category, route.get("category_evidence"))
+        if missing_category_fields:
+            errors.append("missing_route_category_evidence")
+            warnings.append("missing_route_category_fields:" + ",".join(missing_category_fields))
     elif support_status == "degraded":
         if not isinstance(route.get("missing_observations"), list) or not route.get("missing_observations"):
             errors.append("missing_degraded_observations")

--- a/scripts/validate_runtime_owned_capture.py
+++ b/scripts/validate_runtime_owned_capture.py
@@ -45,6 +45,7 @@ STOP_CONDITIONS = {
     "external_cost_ambiguity",
     "missing_runtime_capture",
     "unsupported_runtime_capture",
+    "unsupported_future_route",
 }
 
 
@@ -170,6 +171,8 @@ def validate(record: dict[str, Any], now: dt.datetime, max_age_hours: int = 24) 
     if missing(requested.get("model")) or missing(requested.get("reasoning")):
         errors.append("missing_requested_envelope")
     if support_status == "supported":
+        if category == "future":
+            errors.append("unsupported_future_route")
         if effective.get("status") != "accepted" or missing(effective.get("model")) or missing(effective.get("reasoning")):
             errors.append("missing_effective_envelope")
         missing_category_fields = missing_route_category_evidence(category, route.get("category_evidence"))

--- a/scripts/validate_runtime_owned_capture.py
+++ b/scripts/validate_runtime_owned_capture.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Validate runtime-owned collaboration capability capture evidence."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROUTE_CATEGORIES = {"create", "send", "spawn", "fork", "automation", "future"}
+SUPPORT_STATUSES = {"supported", "degraded", "unsupported"}
+PRODUCER_TYPES = {"runtime_control_surface", "adapter_control_surface"}
+FORBIDDEN_CONTENT_KEYS = {
+    "prompt",
+    "body",
+    "message",
+    "messages",
+    "content",
+    "raw_prompt",
+    "raw_body",
+    "raw_transcript",
+    "transcript",
+    "conversation",
+    "payload_body",
+}
+STOP_CONDITIONS = {
+    "missing_producer",
+    "stale_evidence",
+    "forged_evidence",
+    "caller_only_evidence",
+    "privacy_exposure",
+    "duplicate_owner",
+    "budget_breach",
+    "external_cost_ambiguity",
+    "missing_runtime_capture",
+    "unsupported_runtime_capture",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate runtime-owned capture evidence JSON.")
+    parser.add_argument("--input", help="Evidence JSON path. Defaults to stdin when provided.")
+    parser.add_argument("--now", help="Current UTC timestamp for deterministic tests.")
+    parser.add_argument("--max-age-hours", type=int, default=24)
+    return parser.parse_args()
+
+
+def read_record(path: str | None) -> dict[str, Any]:
+    if path:
+        text = Path(path).read_text(encoding="utf-8")
+    elif not sys.stdin.isatty():
+        text = sys.stdin.read()
+    else:
+        return {}
+    if not text.strip():
+        return {}
+    value = json.loads(text)
+    if not isinstance(value, dict):
+        raise SystemExit("runtime capture evidence must be a JSON object")
+    return value
+
+
+def parse_timestamp(raw: Any) -> dt.datetime | None:
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    try:
+        parsed = dt.datetime.fromisoformat(raw.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def utc_now(raw: str | None) -> dt.datetime:
+    if raw:
+        parsed = parse_timestamp(raw)
+        if parsed is None:
+            raise SystemExit("--now must be an ISO timestamp")
+        return parsed
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def missing(value: Any) -> bool:
+    return value in (None, "", [], {})
+
+
+def find_forbidden_content(value: Any, path: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, item in value.items():
+            child = f"{path}.{key}"
+            if key in FORBIDDEN_CONTENT_KEYS:
+                found.append(child)
+            found.extend(find_forbidden_content(item, child))
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            found.extend(find_forbidden_content(item, f"{path}[{index}]"))
+    return found
+
+
+def validate(record: dict[str, Any], now: dt.datetime, max_age_hours: int = 24) -> dict[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if record.get("schema_version") != 1:
+        errors.append("unsupported_schema_version")
+    for field in ("record_id", "captured_at", "producer", "route", "evidence_metadata", "privacy"):
+        if missing(record.get(field)):
+            errors.append(f"missing_{field}")
+
+    producer = record.get("producer") if isinstance(record.get("producer"), dict) else {}
+    if not producer:
+        errors.append("missing_producer")
+    if producer.get("producer_type") not in PRODUCER_TYPES:
+        errors.append("missing_runtime_owned_producer")
+    if producer.get("runtime_owned") is not True:
+        errors.append("caller_only_evidence")
+    if producer.get("caller_supplied") is not False:
+        errors.append("caller_only_evidence")
+    for field in ("producer_id", "runtime_id", "capture_session_id"):
+        if missing(producer.get(field)):
+            errors.append(f"missing_producer_{field}")
+
+    attestation = record.get("runtime_attestation") if isinstance(record.get("runtime_attestation"), dict) else {}
+    if attestation.get("producer_bound") is not True or missing(attestation.get("capture_nonce")):
+        errors.append("forged_evidence")
+
+    captured_at = parse_timestamp(record.get("captured_at"))
+    if captured_at is None:
+        errors.append("missing_capture_timestamp")
+    elif now - captured_at > dt.timedelta(hours=max_age_hours):
+        errors.append("stale_evidence")
+
+    route = record.get("route") if isinstance(record.get("route"), dict) else {}
+    category = route.get("category")
+    support_status = route.get("support_status")
+    if category not in ROUTE_CATEGORIES:
+        errors.append("unknown_route_category")
+    if support_status not in SUPPORT_STATUSES:
+        errors.append("unknown_support_status")
+    requested = route.get("requested_envelope") if isinstance(route.get("requested_envelope"), dict) else {}
+    effective = route.get("effective_envelope") if isinstance(route.get("effective_envelope"), dict) else {}
+    if missing(requested.get("model")) or missing(requested.get("reasoning")):
+        errors.append("missing_requested_envelope")
+    if support_status == "supported":
+        if effective.get("status") != "accepted" or missing(effective.get("model")) or missing(effective.get("reasoning")):
+            errors.append("missing_effective_envelope")
+    elif support_status == "degraded":
+        if not isinstance(route.get("missing_observations"), list) or not route.get("missing_observations"):
+            errors.append("missing_degraded_observations")
+    elif support_status == "unsupported":
+        if missing(route.get("unsupported_reason")):
+            errors.append("missing_unsupported_reason")
+
+    metadata = record.get("evidence_metadata") if isinstance(record.get("evidence_metadata"), dict) else {}
+    if metadata.get("external_cost_possible") is True and missing(metadata.get("budget_anchor")):
+        errors.append("external_cost_ambiguity")
+    if metadata.get("duplicate_owner_detected") is True:
+        errors.append("duplicate_owner")
+
+    privacy = record.get("privacy") if isinstance(record.get("privacy"), dict) else {}
+    if privacy.get("contains_prompt_body") is not False or privacy.get("redaction") != "metadata_only":
+        errors.append("privacy_exposure")
+    forbidden_paths = find_forbidden_content(record)
+    if forbidden_paths:
+        errors.append("prompt_body_content_present")
+        warnings.append("forbidden_content_paths:" + ",".join(forbidden_paths))
+
+    declared_stops = record.get("stop_conditions", [])
+    if not isinstance(declared_stops, list):
+        errors.append("missing_stop_conditions")
+        declared_stops = []
+    unknown_stops = sorted({str(item) for item in declared_stops} - STOP_CONDITIONS)
+    if unknown_stops:
+        errors.append("unknown_stop_conditions")
+        warnings.append("unknown_stop_conditions:" + ",".join(unknown_stops))
+
+    status = support_status if support_status in SUPPORT_STATUSES else "invalid"
+    return {
+        "valid": not errors,
+        "support_status": status,
+        "route_category": category,
+        "errors": sorted(set(errors)),
+        "warnings": warnings,
+        "runtime_owned": producer.get("runtime_owned") is True and producer.get("caller_supplied") is False,
+        "content_redacted": not forbidden_paths and privacy.get("contains_prompt_body") is False,
+        "mutation_performed": False,
+        "dispatch_performed": False,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    result = validate(read_record(args.input), utc_now(args.now), args.max_age_hours)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["valid"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds a Core-side runtime-owned capability capture evidence schema for AF18.
- Adds a local validator for supported, degraded, and unsupported route evidence without executing dispatch or mutating runtime state.
- Adds focused tests for positive runtime-owned supported/degraded/unsupported records and negative caller-supplied, forged, stale, missing-producer, and prompt/body content records.
- Preserves existing #440/#442 advisory route planner behavior via focused regression checks.

## Verification
- python3 scripts/test_runtime_owned_capture.py
- python3 scripts/validate_runtime_owned_capture.py --help
- python3 scripts/test_collaboration_route_planner.py
- python3 scripts/plan_collaboration_routes.py --help
- git diff --check
- git diff --cached --check

## Boundary
This PR adds Core schema/validation/evidence format only. It does not run external-cost dispatch, mutate runtime/config/hooks/custom agents, publish adapters, or claim runtime enforcement is complete.

Closes #446 after review/merge. Do not merge from this Implementer role.