### PR TITLE
Add AF18 MVP-1 control-plane proof

### DIFF
--- a/schemas/af18-control-plane.schema.yaml
+++ b/schemas/af18-control-plane.schema.yaml
@@ -119,6 +119,35 @@ properties:
         type: array
         items:
           type: object
+          additionalProperties: false
+          required:
+            - issue
+            - durable_anchor
+            - scope
+            - risk
+            - acceptance
+            - human_gates
+          properties:
+            issue:
+              type: integer
+              minimum: 1
+            durable_anchor:
+              type: string
+              minLength: 1
+            scope:
+              type: string
+              minLength: 1
+            risk:
+              type: string
+              minLength: 1
+            acceptance:
+              type: string
+              minLength: 1
+            human_gates:
+              type: array
+              items:
+                type: string
+                minLength: 1
   execution_run:
     type: object
     additionalProperties: false

--- a/schemas/af18-control-plane.schema.yaml
+++ b/schemas/af18-control-plane.schema.yaml
@@ -83,7 +83,7 @@ properties:
         required:
           - source_timestamp
           - threshold_band
-          - estimated_context_tokens
+          - resource_observations
         properties:
           source_timestamp:
             type: string
@@ -96,9 +96,43 @@ properties:
               - implementer_small_scoped_implementation
               - reviewer_exact_pr_review
               - tester_focused_validation
-          estimated_context_tokens:
-            type: integer
-            minimum: 0
+          resource_observations:
+            type: object
+            additionalProperties: false
+            required:
+              - context_tokens
+            properties:
+              context_tokens:
+                type: object
+                additionalProperties: false
+                required:
+                  - provenance
+                  - source
+                properties:
+                  provenance:
+                    enum:
+                      - observed
+                      - estimated
+                      - unavailable
+                  tokens:
+                    type: integer
+                    minimum: 0
+                  source:
+                    type: string
+                    minLength: 1
+                  lower_capability_policy:
+                    enum:
+                      - serial_execution_only
+                allOf:
+                  - if:
+                      properties:
+                        provenance:
+                          enum:
+                            - observed
+                            - estimated
+                    then:
+                      required:
+                        - tokens
           max_context_tokens:
             type: integer
             minimum: 1
@@ -185,6 +219,7 @@ properties:
       - work_id
       - role
       - decision_boundary
+      - transition_semantics
       - durable_anchor
     properties:
       idempotency_key:
@@ -199,15 +234,25 @@ properties:
       decision_boundary:
         type: string
         minLength: 1
+      transition_semantics:
+        type: string
+        minLength: 1
       durable_anchor:
         type: string
         minLength: 1
+      adapter_metadata:
+        type: object
+        additionalProperties: true
   requested_route:
     enum:
-      - bounded_subagent
-      - visible_interactive
-      - external_provider
-      - privileged_runtime
+      - isolated_execution
+      - interactive_execution
+      - serial_execution
+      - external_execution
+      - privileged_execution
+  adapter_metadata:
+    type: object
+    additionalProperties: true
   existing_dispatch_claims:
     type: array
     items:

--- a/schemas/af18-control-plane.schema.yaml
+++ b/schemas/af18-control-plane.schema.yaml
@@ -15,7 +15,10 @@ properties:
     required:
       - work_id
       - issue
+      - issue_anchor
       - role
+      - objective
+      - stage
       - phase
       - root_budget_tokens
       - remaining_budget_tokens
@@ -28,10 +31,50 @@ properties:
       issue:
         type: integer
         minimum: 1
+      issue_anchor:
+        type: object
+        additionalProperties: false
+        required:
+          - issue
+          - durable_anchor
+          - scope
+          - risk
+          - acceptance
+          - human_gates
+        properties:
+          issue:
+            type: integer
+            minimum: 1
+          durable_anchor:
+            type: string
+            minLength: 1
+          scope:
+            type: string
+            minLength: 1
+          risk:
+            type: string
+            minLength: 1
+          acceptance:
+            type: string
+            minLength: 1
+          human_gates:
+            type: array
+            items:
+              type: string
+              minLength: 1
       role:
         type: string
         minLength: 1
+      objective:
+        type: string
+        minLength: 1
+      stage:
+        type: string
+        minLength: 1
       phase:
+        type: string
+        minLength: 1
+      current_owner:
         type: string
         minLength: 1
       root_budget_tokens:
@@ -51,6 +94,31 @@ properties:
         items:
           type: string
           minLength: 1
+      material_decisions:
+        type: array
+        items:
+          type: string
+          minLength: 1
+      accepted_evidence_refs:
+        type: array
+        items:
+          type: string
+          minLength: 1
+      material_risk_or_blocker:
+        type:
+          - string
+          - "null"
+      next_action:
+        type: string
+        minLength: 1
+      cross_issue_work:
+        type: boolean
+      multiple_issue_work:
+        type: boolean
+      additional_issue_anchors:
+        type: array
+        items:
+          type: object
   execution_run:
     type: object
     additionalProperties: false
@@ -253,6 +321,38 @@ properties:
   adapter_metadata:
     type: object
     additionalProperties: true
+  attention_events:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - category
+      properties:
+        category:
+          enum:
+            - hdc_approval
+            - risk_change
+            - privacy_boundary
+            - external_side_effect
+            - model_escalation
+            - context_budget_strategy_change
+            - retry_claim_anomaly
+            - acceptance_evidence_conflict
+            - phase_completion
+            - stale_no_owner_work
+            - execution_run
+            - dispatch_claim
+            - transition_receipt
+            - resource_observation
+            - successor_retry_mechanic
+            - ordinary_receipt
+        reason:
+          type: string
+          minLength: 1
+        evidence_ref:
+          type: string
+          minLength: 1
   existing_dispatch_claims:
     type: array
     items:

--- a/schemas/af18-control-plane.schema.yaml
+++ b/schemas/af18-control-plane.schema.yaml
@@ -1,0 +1,218 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "https://agent-foundry.local/schemas/af18-control-plane.schema.yaml"
+title: AF18 MVP-1 Control-Plane Packet
+type: object
+additionalProperties: false
+required:
+  - work
+  - execution_run
+  - dispatch_claim
+  - requested_route
+properties:
+  work:
+    type: object
+    additionalProperties: false
+    required:
+      - work_id
+      - issue
+      - role
+      - phase
+      - root_budget_tokens
+      - remaining_budget_tokens
+      - durable_anchors
+      - stop_conditions
+    properties:
+      work_id:
+        type: string
+        minLength: 1
+      issue:
+        type: integer
+        minimum: 1
+      role:
+        type: string
+        minLength: 1
+      phase:
+        type: string
+        minLength: 1
+      root_budget_tokens:
+        type: integer
+        minimum: 1
+      remaining_budget_tokens:
+        type: integer
+        minimum: 0
+      durable_anchors:
+        type: array
+        minItems: 1
+        items:
+          type: string
+          minLength: 1
+      stop_conditions:
+        type: array
+        items:
+          type: string
+          minLength: 1
+  execution_run:
+    type: object
+    additionalProperties: false
+    required:
+      - run_id
+      - work_id
+      - role
+      - state
+      - context
+      - model
+    properties:
+      run_id:
+        type: string
+        minLength: 1
+      work_id:
+        type: string
+        minLength: 1
+      role:
+        type: string
+        minLength: 1
+      state:
+        enum:
+          - active
+          - successor_required
+          - hold_required
+          - completed
+      context:
+        type: object
+        additionalProperties: false
+        required:
+          - source_timestamp
+          - threshold_band
+          - estimated_context_tokens
+        properties:
+          source_timestamp:
+            type: string
+            format: date-time
+          threshold_band:
+            enum:
+              - generic_default
+              - coordinator_routing_status_readback
+              - architect_design_gate
+              - implementer_small_scoped_implementation
+              - reviewer_exact_pr_review
+              - tester_focused_validation
+          estimated_context_tokens:
+            type: integer
+            minimum: 0
+          max_context_tokens:
+            type: integer
+            minimum: 1
+            maximum: 12000
+          max_age_hours:
+            type: integer
+            minimum: 1
+          threshold_exception:
+            type: object
+            additionalProperties: false
+            required:
+              - issue
+              - role
+              - temporary_cap
+              - reason
+              - expiry
+            properties:
+              issue:
+                type: integer
+                minimum: 1
+              role:
+                type: string
+                minLength: 1
+              temporary_cap:
+                type: integer
+                minimum: 1
+                maximum: 12000
+              reason:
+                type: string
+                minLength: 1
+              expiry:
+                type: string
+                format: date-time
+      model:
+        type: object
+        additionalProperties: false
+        required:
+          - name
+          - reasoning
+        properties:
+          name:
+            type: string
+            minLength: 1
+          reasoning:
+            enum:
+              - minimal
+              - low
+              - medium
+              - high
+          human_escalation_approval:
+            type: object
+            additionalProperties: false
+            required:
+              - issue
+              - role
+              - model
+              - reasoning
+              - purpose
+              - budget
+            properties:
+              issue:
+                type: integer
+                minimum: 1
+              role:
+                type: string
+                minLength: 1
+              model:
+                type: string
+                minLength: 1
+              reasoning:
+                type: string
+                minLength: 1
+              purpose:
+                type: string
+                minLength: 1
+              budget:
+                type: string
+                minLength: 1
+  dispatch_claim:
+    type: object
+    additionalProperties: false
+    required:
+      - idempotency_key
+      - work_id
+      - role
+      - decision_boundary
+      - durable_anchor
+    properties:
+      idempotency_key:
+        type: string
+        minLength: 1
+      work_id:
+        type: string
+        minLength: 1
+      role:
+        type: string
+        minLength: 1
+      decision_boundary:
+        type: string
+        minLength: 1
+      durable_anchor:
+        type: string
+        minLength: 1
+  requested_route:
+    enum:
+      - bounded_subagent
+      - visible_interactive
+      - external_provider
+      - privileged_runtime
+  existing_dispatch_claims:
+    type: array
+    items:
+      type: object
+  active_runs:
+    type: array
+    items:
+      type: object

--- a/scripts/plan_af18_mvp1_control.py
+++ b/scripts/plan_af18_mvp1_control.py
@@ -17,11 +17,13 @@ POLICY_SOURCE = "scripts/plan_collaboration_routes.py"
 POLICY_VERSION = "af18-cost-policy-440-442"
 CONTROL_VERSION = "af18-mvp1-control-plane-v1"
 ROUTE_PERMISSIONS = {
-    "bounded_subagent": "allow",
-    "visible_interactive": "successor_required",
-    "external_provider": "hold_required",
-    "privileged_runtime": "hold_required",
+    "isolated_execution": "allow",
+    "interactive_execution": "successor_required",
+    "serial_execution": "allow",
+    "external_execution": "hold_required",
+    "privileged_execution": "hold_required",
 }
+RESOURCE_PROVENANCE = {"observed", "estimated", "unavailable"}
 FORBIDDEN_PACKET_KEYS = {
     "prompt",
     "body",
@@ -112,8 +114,16 @@ def active_policy_readout() -> dict[str, Any]:
             "model_ceiling_breach",
             "duplicate_dispatch_claim",
             "duplicate_active_run",
+            "missing_resource_observation",
+            "missing_context_token_measurement",
+            "resource_measurement_unavailable",
             "privacy_exposure",
         ],
+        "resource_observation_policy": {
+            "accepted_provenance": sorted(RESOURCE_PROVENANCE),
+            "missing_or_unavailable": "hold_required_or_explicit_lower_capability_policy",
+            "missing_counts_as_zero": False,
+        },
         "mutation_performed": False,
         "dispatch_performed": False,
     }
@@ -124,6 +134,8 @@ def effective_snapshot(packet: dict[str, Any], now: dt.datetime, stops: list[str
     run = packet.get("execution_run") if isinstance(packet.get("execution_run"), dict) else {}
     context = run.get("context") if isinstance(run.get("context"), dict) else {}
     model = run.get("model") if isinstance(run.get("model"), dict) else {}
+    observations = context.get("resource_observations") if isinstance(context.get("resource_observations"), dict) else {}
+    context_tokens = observations.get("context_tokens") if isinstance(observations.get("context_tokens"), dict) else {}
     issue = work.get("issue")
     role = work.get("role")
     threshold = cost_policy.resolve_threshold(context, now, stops, issue, role)
@@ -136,6 +148,14 @@ def effective_snapshot(packet: dict[str, Any], now: dt.datetime, stops: list[str
         "reasoning_ceiling": cost_policy.DEFAULT_CEILING_REASONING,
         "requested_model": model.get("name"),
         "requested_reasoning": model.get("reasoning"),
+        "resource_observation": {
+            "context_tokens": {
+                "provenance": context_tokens.get("provenance"),
+                "tokens": context_tokens.get("tokens") if isinstance(context_tokens.get("tokens"), int) else None,
+                "source": context_tokens.get("source"),
+                "lower_capability_policy": context_tokens.get("lower_capability_policy"),
+            }
+        },
         "route_permissions": ROUTE_PERMISSIONS,
     }
 
@@ -147,7 +167,7 @@ def validate_required(work: dict[str, Any], run: dict[str, Any], claim: dict[str
     for field in ("run_id", "work_id", "role", "state", "context", "model"):
         if missing(run.get(field)):
             stops.append(f"missing_execution_run_{field}")
-    for field in ("idempotency_key", "work_id", "role", "decision_boundary", "durable_anchor"):
+    for field in ("idempotency_key", "work_id", "role", "decision_boundary", "transition_semantics", "durable_anchor"):
         if missing(claim.get(field)):
             stops.append(f"missing_dispatch_claim_{field}")
 
@@ -164,6 +184,32 @@ def validate_required(work: dict[str, Any], run: dict[str, Any], claim: dict[str
         stops.append("claim_work_role_mismatch")
 
 
+def context_token_count(context: dict[str, Any], stops: list[str]) -> int | None:
+    observations = context.get("resource_observations")
+    if not isinstance(observations, dict):
+        stops.append("missing_resource_observation")
+        return None
+    context_tokens = observations.get("context_tokens")
+    if not isinstance(context_tokens, dict):
+        stops.append("missing_resource_observation")
+        return None
+    provenance = context_tokens.get("provenance")
+    if provenance not in RESOURCE_PROVENANCE:
+        stops.append("unknown_resource_observation_provenance")
+        return None
+    if provenance == "unavailable":
+        if context_tokens.get("lower_capability_policy") == "serial_execution_only":
+            stops.append("resource_measurement_lower_capability_required")
+        else:
+            stops.append("resource_measurement_unavailable")
+        return None
+    tokens = context_tokens.get("tokens")
+    if not isinstance(tokens, int) or tokens < 0:
+        stops.append("missing_context_token_measurement")
+        return None
+    return tokens
+
+
 def validate_context(run: dict[str, Any], snapshot: dict[str, Any], now: dt.datetime, stops: list[str]) -> None:
     context = run.get("context") if isinstance(run.get("context"), dict) else {}
     try:
@@ -173,10 +219,8 @@ def validate_context(run: dict[str, Any], snapshot: dict[str, Any], now: dt.date
         source_ts = None
     if source_ts is not None and now - source_ts > dt.timedelta(hours=snapshot["threshold"]["max_age_hours"]):
         stops.append("stale_context")
-    context_size = context.get("estimated_context_tokens")
-    if not isinstance(context_size, int):
-        stops.append("missing_estimated_context_tokens")
-    elif context_size > snapshot["threshold"]["max_context_tokens"]:
+    context_size = context_token_count(context, stops)
+    if isinstance(context_size, int) and context_size > snapshot["threshold"]["max_context_tokens"]:
         stops.append("oversized_context")
 
 
@@ -199,9 +243,12 @@ def validate_model(run: dict[str, Any], stops: list[str]) -> None:
 def duplicate_claim_seen(claim: dict[str, Any], existing: Any) -> bool:
     if not isinstance(existing, list):
         return False
-    keys = ("idempotency_key", "work_id", "role", "decision_boundary")
     for item in existing:
-        if isinstance(item, dict) and all(item.get(key) == claim.get(key) for key in keys):
+        if not isinstance(item, dict):
+            continue
+        same_boundary = all(item.get(key) == claim.get(key) for key in ("work_id", "role", "decision_boundary"))
+        same_transition = item.get("transition_semantics") in (None, claim.get("transition_semantics"))
+        if same_boundary and same_transition:
             return True
     return False
 

--- a/scripts/plan_af18_mvp1_control.py
+++ b/scripts/plan_af18_mvp1_control.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Plan AF18 MVP-1 lifecycle control-plane decisions without dispatch."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import plan_collaboration_routes as cost_policy
+
+
+POLICY_SOURCE = "scripts/plan_collaboration_routes.py"
+POLICY_VERSION = "af18-cost-policy-440-442"
+CONTROL_VERSION = "af18-mvp1-control-plane-v1"
+ROUTE_PERMISSIONS = {
+    "bounded_subagent": "allow",
+    "visible_interactive": "successor_required",
+    "external_provider": "hold_required",
+    "privileged_runtime": "hold_required",
+}
+FORBIDDEN_PACKET_KEYS = {
+    "prompt",
+    "body",
+    "message",
+    "messages",
+    "content",
+    "tool_history",
+    "raw_tool_history",
+    "raw_large_diff",
+    "large_diff",
+    "raw_log",
+    "log",
+    "full_history",
+    "transcript",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Plan AF18 MVP-1 lifecycle control-plane readouts and preflights.")
+    parser.add_argument("--input", help="Control-plane packet JSON path. Defaults to stdin when provided.")
+    parser.add_argument("--mode", choices=("preflight", "readout", "explain"), default="preflight")
+    parser.add_argument("--now", help="Current UTC timestamp for deterministic tests.")
+    return parser.parse_args()
+
+
+def read_packet(path: str | None) -> dict[str, Any]:
+    if path:
+        text = Path(path).read_text(encoding="utf-8")
+    elif not sys.stdin.isatty():
+        text = sys.stdin.read()
+    else:
+        return {}
+    if not text.strip():
+        return {}
+    value = json.loads(text)
+    if not isinstance(value, dict):
+        raise SystemExit("control-plane packet must be a JSON object")
+    return value
+
+
+def utc_now(raw: str | None) -> dt.datetime:
+    if raw:
+        return cost_policy.parse_timestamp(raw, "now")
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def missing(value: Any) -> bool:
+    return value in (None, "", [], {})
+
+
+def find_forbidden(value: Any, path: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, item in value.items():
+            child = f"{path}.{key}"
+            if key in FORBIDDEN_PACKET_KEYS:
+                found.append(child)
+            found.extend(find_forbidden(item, child))
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            found.extend(find_forbidden(item, f"{path}[{index}]"))
+    return found
+
+
+def active_policy_readout() -> dict[str, Any]:
+    return {
+        "control_version": CONTROL_VERSION,
+        "policy_source": POLICY_SOURCE,
+        "policy_version": POLICY_VERSION,
+        "read_only": True,
+        "readback_default": "cursor_only_compact",
+        "threshold_bands": cost_policy.THRESHOLD_BANDS,
+        "global_hard_context_ceiling": cost_policy.GLOBAL_HARD_CONTEXT_CEILING,
+        "effective_context_ceiling_rule": "min(threshold_band.max_context_tokens, global_hard_context_ceiling)",
+        "model_ceiling": cost_policy.DEFAULT_CEILING_MODEL,
+        "reasoning_ceiling": cost_policy.DEFAULT_CEILING_REASONING,
+        "route_permissions": ROUTE_PERMISSIONS,
+        "override_requirements": {
+            "threshold_exception": ["issue", "role", "temporary_cap", "reason", "expiry"],
+            "model_escalation": ["issue", "role", "model", "reasoning", "purpose", "budget"],
+        },
+        "fail_closed_on": [
+            "missing_policy",
+            "unknown_classification",
+            "missing_budget",
+            "stale_context",
+            "oversized_context",
+            "model_ceiling_breach",
+            "duplicate_dispatch_claim",
+            "duplicate_active_run",
+            "privacy_exposure",
+        ],
+        "mutation_performed": False,
+        "dispatch_performed": False,
+    }
+
+
+def effective_snapshot(packet: dict[str, Any], now: dt.datetime, stops: list[str]) -> dict[str, Any]:
+    work = packet.get("work") if isinstance(packet.get("work"), dict) else {}
+    run = packet.get("execution_run") if isinstance(packet.get("execution_run"), dict) else {}
+    context = run.get("context") if isinstance(run.get("context"), dict) else {}
+    model = run.get("model") if isinstance(run.get("model"), dict) else {}
+    issue = work.get("issue")
+    role = work.get("role")
+    threshold = cost_policy.resolve_threshold(context, now, stops, issue, role)
+    return {
+        "policy_source": POLICY_SOURCE,
+        "policy_version": POLICY_VERSION,
+        "threshold": threshold,
+        "effective_context_ceiling_rule": "min(threshold_band.max_context_tokens, global_hard_context_ceiling)",
+        "model_ceiling": cost_policy.DEFAULT_CEILING_MODEL,
+        "reasoning_ceiling": cost_policy.DEFAULT_CEILING_REASONING,
+        "requested_model": model.get("name"),
+        "requested_reasoning": model.get("reasoning"),
+        "route_permissions": ROUTE_PERMISSIONS,
+    }
+
+
+def validate_required(work: dict[str, Any], run: dict[str, Any], claim: dict[str, Any], stops: list[str]) -> None:
+    for field in ("work_id", "issue", "role", "phase", "root_budget_tokens", "remaining_budget_tokens", "durable_anchors", "stop_conditions"):
+        if missing(work.get(field)):
+            stops.append(f"missing_work_{field}")
+    for field in ("run_id", "work_id", "role", "state", "context", "model"):
+        if missing(run.get(field)):
+            stops.append(f"missing_execution_run_{field}")
+    for field in ("idempotency_key", "work_id", "role", "decision_boundary", "durable_anchor"):
+        if missing(claim.get(field)):
+            stops.append(f"missing_dispatch_claim_{field}")
+
+    if not isinstance(work.get("root_budget_tokens"), int) or work.get("root_budget_tokens", 0) <= 0:
+        stops.append("missing_budget")
+    if not isinstance(work.get("remaining_budget_tokens"), int) or work.get("remaining_budget_tokens", 0) < 0:
+        stops.append("missing_budget")
+    if isinstance(work.get("remaining_budget_tokens"), int) and isinstance(work.get("root_budget_tokens"), int):
+        if work["remaining_budget_tokens"] > work["root_budget_tokens"]:
+            stops.append("budget_breach")
+    if run.get("work_id") not in (None, work.get("work_id")) or run.get("role") not in (None, work.get("role")):
+        stops.append("run_work_role_mismatch")
+    if claim.get("work_id") not in (None, work.get("work_id")) or claim.get("role") not in (None, work.get("role")):
+        stops.append("claim_work_role_mismatch")
+
+
+def validate_context(run: dict[str, Any], snapshot: dict[str, Any], now: dt.datetime, stops: list[str]) -> None:
+    context = run.get("context") if isinstance(run.get("context"), dict) else {}
+    try:
+        source_ts = cost_policy.parse_timestamp(context.get("source_timestamp"), "execution_run.context.source_timestamp")
+    except (TypeError, ValueError):
+        stops.append("missing_or_invalid_source_timestamp")
+        source_ts = None
+    if source_ts is not None and now - source_ts > dt.timedelta(hours=snapshot["threshold"]["max_age_hours"]):
+        stops.append("stale_context")
+    context_size = context.get("estimated_context_tokens")
+    if not isinstance(context_size, int):
+        stops.append("missing_estimated_context_tokens")
+    elif context_size > snapshot["threshold"]["max_context_tokens"]:
+        stops.append("oversized_context")
+
+
+def validate_model(run: dict[str, Any], stops: list[str]) -> None:
+    model = run.get("model") if isinstance(run.get("model"), dict) else {}
+    requested_model = model.get("name")
+    requested_reasoning = model.get("reasoning")
+    if cost_policy.model_rank(requested_model) is None:
+        stops.append("missing_or_unknown_model")
+    elif cost_policy.model_rank(requested_model) > cost_policy.model_rank(cost_policy.DEFAULT_CEILING_MODEL):
+        if not cost_policy.valid_escalation_approval(model.get("human_escalation_approval")):
+            stops.append("model_escalation_requires_human_approval")
+    if cost_policy.reasoning_rank(requested_reasoning) is None:
+        stops.append("missing_or_unknown_reasoning")
+    elif cost_policy.reasoning_rank(requested_reasoning) > cost_policy.reasoning_rank(cost_policy.DEFAULT_CEILING_REASONING):
+        if not cost_policy.valid_escalation_approval(model.get("human_escalation_approval")):
+            stops.append("reasoning_escalation_requires_human_approval")
+
+
+def duplicate_claim_seen(claim: dict[str, Any], existing: Any) -> bool:
+    if not isinstance(existing, list):
+        return False
+    keys = ("idempotency_key", "work_id", "role", "decision_boundary")
+    for item in existing:
+        if isinstance(item, dict) and all(item.get(key) == claim.get(key) for key in keys):
+            return True
+    return False
+
+
+def duplicate_active_run(work: dict[str, Any], run: dict[str, Any], active_runs: Any) -> bool:
+    if not isinstance(active_runs, list):
+        return False
+    for item in active_runs:
+        if not isinstance(item, dict):
+            continue
+        if item.get("state") == "active" and item.get("work_id") == work.get("work_id") and item.get("role") == work.get("role"):
+            if item.get("run_id") != run.get("run_id"):
+                return True
+    return False
+
+
+def successor_packet(work: dict[str, Any], run: dict[str, Any], route: str, now: dt.datetime) -> dict[str, Any]:
+    return {
+        "packet_type": "SuccessorPacket",
+        "created_at": now.isoformat().replace("+00:00", "Z"),
+        "work_id": work.get("work_id"),
+        "role": work.get("role"),
+        "phase": work.get("phase"),
+        "root_budget_tokens": work.get("root_budget_tokens"),
+        "remaining_budget_tokens": work.get("remaining_budget_tokens"),
+        "durable_anchors": work.get("durable_anchors", []),
+        "stop_conditions": work.get("stop_conditions", []),
+        "predecessor_run_id": run.get("run_id"),
+        "requested_route": route,
+        "context_policy": "cursor_only_compact_no_prompt_body_no_full_history",
+        "exclusions": sorted(FORBIDDEN_PACKET_KEYS),
+    }
+
+
+def plan_preflight(packet: dict[str, Any], now: dt.datetime) -> dict[str, Any]:
+    stops: list[str] = []
+    warnings: list[str] = []
+    work = packet.get("work") if isinstance(packet.get("work"), dict) else {}
+    run = packet.get("execution_run") if isinstance(packet.get("execution_run"), dict) else {}
+    claim = packet.get("dispatch_claim") if isinstance(packet.get("dispatch_claim"), dict) else {}
+    route = packet.get("requested_route")
+    validate_required(work, run, claim, stops)
+    if route not in ROUTE_PERMISSIONS:
+        stops.append("unknown_route_classification")
+        route = "unknown"
+    snapshot = effective_snapshot(packet, now, stops)
+    validate_context(run, snapshot, now, stops)
+    validate_model(run, stops)
+    if duplicate_claim_seen(claim, packet.get("existing_dispatch_claims")):
+        stops.append("duplicate_dispatch_claim")
+    if duplicate_active_run(work, run, packet.get("active_runs")):
+        stops.append("duplicate_active_run")
+    forbidden = find_forbidden(packet)
+    if forbidden:
+        stops.append("privacy_exposure")
+        warnings.append("forbidden_content_paths:" + ",".join(forbidden))
+
+    permission = ROUTE_PERMISSIONS.get(route, "hold_required")
+    if stops:
+        decision = "hold_required"
+    elif permission == "allow":
+        decision = "allow"
+    elif permission == "successor_required":
+        decision = "successor_required"
+    else:
+        decision = "hold_required"
+        stops.append(f"route_not_permitted:{route}")
+
+    result = {
+        "control_version": CONTROL_VERSION,
+        "decision": decision,
+        "classification": route,
+        "matched_routing_rule": permission,
+        "selected_route": route if decision in {"allow", "successor_required"} else None,
+        "held_route": route if decision == "hold_required" else None,
+        "work_id": work.get("work_id"),
+        "role": work.get("role"),
+        "root_budget_tokens": work.get("root_budget_tokens"),
+        "remaining_budget_tokens": work.get("remaining_budget_tokens"),
+        "effective_control_snapshot": snapshot,
+        "stop_conditions": sorted(set(stops)),
+        "warnings": warnings,
+        "reason": "preflight passed" if decision == "allow" else "successor context required" if decision == "successor_required" else "fail-closed hold required",
+        "one_recovery_action": None if decision != "hold_required" else "ask Coordinator for a compact issue-specific packet or Human approval",
+        "mutation_performed": False,
+        "dispatch_performed": False,
+    }
+    if decision == "successor_required":
+        result["successor_packet"] = successor_packet(work, run, route, now)
+        result["transition_receipt"] = {
+            "receipt_type": "TransitionReceipt",
+            "from_run_id": run.get("run_id"),
+            "work_id": work.get("work_id"),
+            "role": work.get("role"),
+            "decision": decision,
+            "root_budget_tokens": work.get("root_budget_tokens"),
+            "remaining_budget_tokens": work.get("remaining_budget_tokens"),
+            "mutation_performed": False,
+            "dispatch_performed": False,
+        }
+    return result
+
+
+def explain_work_policy(packet: dict[str, Any], now: dt.datetime) -> dict[str, Any]:
+    preflight = plan_preflight(packet, now)
+    return {
+        "control_version": CONTROL_VERSION,
+        "classification": preflight["classification"],
+        "matched_routing_rule": preflight["matched_routing_rule"],
+        "effective_control_snapshot": preflight["effective_control_snapshot"],
+        "selected_route": preflight["selected_route"],
+        "held_route": preflight["held_route"],
+        "work_id": preflight["work_id"],
+        "role": preflight["role"],
+        "root_budget_tokens": preflight["root_budget_tokens"],
+        "remaining_budget_tokens": preflight["remaining_budget_tokens"],
+        "decision": preflight["decision"],
+        "reason": preflight["reason"],
+        "stop_conditions": preflight["stop_conditions"],
+        "one_recovery_action": preflight["one_recovery_action"],
+        "read_only": True,
+        "mutation_performed": False,
+        "dispatch_performed": False,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    packet = read_packet(args.input)
+    now = utc_now(args.now)
+    if args.mode == "readout":
+        result = active_policy_readout()
+    elif args.mode == "explain":
+        result = explain_work_policy(packet, now)
+    else:
+        result = plan_preflight(packet, now)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/plan_af18_mvp1_control.py
+++ b/scripts/plan_af18_mvp1_control.py
@@ -234,13 +234,25 @@ def validate_issue_work_anchor(work: dict[str, Any], stops: list[str]) -> None:
         return
     if issue_anchor.get("issue") != work.get("issue"):
         stops.append("work_issue_anchor_mismatch")
-    for field in ("durable_anchor", "scope", "risk", "acceptance", "human_gates"):
-        if missing(issue_anchor.get(field)):
-            stops.append(f"missing_issue_anchor_{field}")
+    validate_durable_issue_anchor(issue_anchor, "issue_anchor", stops)
     if work.get("cross_issue_work") is True or work.get("multiple_issue_work") is True:
         anchors = work.get("additional_issue_anchors")
         if not isinstance(anchors, list) or not anchors:
             stops.append("missing_cross_issue_durable_anchors")
+        else:
+            for index, anchor in enumerate(anchors):
+                if not isinstance(anchor, dict) or not anchor:
+                    stops.append("malformed_additional_issue_anchor")
+                    continue
+                validate_durable_issue_anchor(anchor, f"additional_issue_anchor_{index}", stops)
+
+
+def validate_durable_issue_anchor(anchor: dict[str, Any], prefix: str, stops: list[str]) -> None:
+    if not isinstance(anchor.get("issue"), int) or anchor.get("issue", 0) <= 0:
+        stops.append(f"missing_{prefix}_issue")
+    for field in ("durable_anchor", "scope", "risk", "acceptance", "human_gates"):
+        if missing(anchor.get(field)):
+            stops.append(f"missing_{prefix}_{field}")
 
 
 def context_token_count(context: dict[str, Any], stops: list[str]) -> int | None:
@@ -350,6 +362,12 @@ def compact_reason(raw: Any, fallback: str) -> str:
     return fallback
 
 
+def corrective_reason(stops: list[str]) -> str:
+    if not stops:
+        return "No policy-material attention event."
+    return f"Invalid summary input: {sorted(set(stops))[0]}. Provide compact corrected evidence."
+
+
 def attention_summary_projection(packet: dict[str, Any], now: dt.datetime) -> dict[str, Any]:
     del now
     stops: list[str] = []
@@ -440,7 +458,7 @@ def work_summary_projection(packet: dict[str, Any], now: dt.datetime) -> dict[st
         "material_risk_or_blocker": work.get("material_risk_or_blocker"),
         "next_action": work.get("next_action"),
         "human_attention_required": attention["human_attention_required"] or bool(stops),
-        "human_attention_reason": attention["reason"] if attention["human_attention_required"] else "No policy-material attention event.",
+        "human_attention_reason": attention["reason"] if attention["human_attention_required"] else corrective_reason(stops),
         "default_human_ux_excludes": [
             "ExecutionRun",
             "DispatchClaim",

--- a/scripts/plan_af18_mvp1_control.py
+++ b/scripts/plan_af18_mvp1_control.py
@@ -24,6 +24,26 @@ ROUTE_PERMISSIONS = {
     "privileged_execution": "hold_required",
 }
 RESOURCE_PROVENANCE = {"observed", "estimated", "unavailable"}
+ATTENTION_CATEGORIES = {
+    "hdc_approval": "Human decision or approval is required.",
+    "risk_change": "Material risk changed or needs explicit owner attention.",
+    "privacy_boundary": "Privacy boundary is affected or needs review.",
+    "external_side_effect": "External side effect is possible or requested.",
+    "model_escalation": "Model or reasoning escalation needs Human approval.",
+    "context_budget_strategy_change": "Context or budget strategy changed materially.",
+    "retry_claim_anomaly": "Retry or claim anomaly is beyond policy.",
+    "acceptance_evidence_conflict": "Acceptance and evidence conflict.",
+    "phase_completion": "Phase completed and needs next-owner acknowledgement.",
+    "stale_no_owner_work": "Work is stale or lacks a current owner.",
+}
+SUPPRESSED_EVENT_CATEGORIES = {
+    "execution_run",
+    "dispatch_claim",
+    "transition_receipt",
+    "resource_observation",
+    "successor_retry_mechanic",
+    "ordinary_receipt",
+}
 FORBIDDEN_PACKET_KEYS = {
     "prompt",
     "body",
@@ -44,7 +64,11 @@ FORBIDDEN_PACKET_KEYS = {
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Plan AF18 MVP-1 lifecycle control-plane readouts and preflights.")
     parser.add_argument("--input", help="Control-plane packet JSON path. Defaults to stdin when provided.")
-    parser.add_argument("--mode", choices=("preflight", "readout", "explain"), default="preflight")
+    parser.add_argument(
+        "--mode",
+        choices=("preflight", "readout", "explain", "work-summary", "attention-summary"),
+        default="preflight",
+    )
     parser.add_argument("--now", help="Current UTC timestamp for deterministic tests.")
     return parser.parse_args()
 
@@ -101,6 +125,12 @@ def active_policy_readout() -> dict[str, Any]:
         "model_ceiling": cost_policy.DEFAULT_CEILING_MODEL,
         "reasoning_ceiling": cost_policy.DEFAULT_CEILING_REASONING,
         "route_permissions": ROUTE_PERMISSIONS,
+        "human_facing_views": ["active_policy", "work_explain", "work_summary", "attention_summary"],
+        "human_attention_policy": {
+            "attention_categories": ATTENTION_CATEGORIES,
+            "suppressed_default_event_categories": sorted(SUPPRESSED_EVENT_CATEGORIES),
+            "ordinary_control_plane_receipts_default_human_attention": False,
+        },
         "override_requirements": {
             "threshold_exception": ["issue", "role", "temporary_cap", "reason", "expiry"],
             "model_escalation": ["issue", "role", "model", "reasoning", "purpose", "budget"],
@@ -161,7 +191,19 @@ def effective_snapshot(packet: dict[str, Any], now: dt.datetime, stops: list[str
 
 
 def validate_required(work: dict[str, Any], run: dict[str, Any], claim: dict[str, Any], stops: list[str]) -> None:
-    for field in ("work_id", "issue", "role", "phase", "root_budget_tokens", "remaining_budget_tokens", "durable_anchors", "stop_conditions"):
+    for field in (
+        "work_id",
+        "issue",
+        "issue_anchor",
+        "role",
+        "objective",
+        "stage",
+        "phase",
+        "root_budget_tokens",
+        "remaining_budget_tokens",
+        "durable_anchors",
+        "stop_conditions",
+    ):
         if missing(work.get(field)):
             stops.append(f"missing_work_{field}")
     for field in ("run_id", "work_id", "role", "state", "context", "model"):
@@ -182,6 +224,23 @@ def validate_required(work: dict[str, Any], run: dict[str, Any], claim: dict[str
         stops.append("run_work_role_mismatch")
     if claim.get("work_id") not in (None, work.get("work_id")) or claim.get("role") not in (None, work.get("role")):
         stops.append("claim_work_role_mismatch")
+    validate_issue_work_anchor(work, stops)
+
+
+def validate_issue_work_anchor(work: dict[str, Any], stops: list[str]) -> None:
+    issue_anchor = work.get("issue_anchor") if isinstance(work.get("issue_anchor"), dict) else {}
+    if not issue_anchor:
+        stops.append("missing_issue_anchor")
+        return
+    if issue_anchor.get("issue") != work.get("issue"):
+        stops.append("work_issue_anchor_mismatch")
+    for field in ("durable_anchor", "scope", "risk", "acceptance", "human_gates"):
+        if missing(issue_anchor.get(field)):
+            stops.append(f"missing_issue_anchor_{field}")
+    if work.get("cross_issue_work") is True or work.get("multiple_issue_work") is True:
+        anchors = work.get("additional_issue_anchors")
+        if not isinstance(anchors, list) or not anchors:
+            stops.append("missing_cross_issue_durable_anchors")
 
 
 def context_token_count(context: dict[str, Any], stops: list[str]) -> int | None:
@@ -270,6 +329,7 @@ def successor_packet(work: dict[str, Any], run: dict[str, Any], route: str, now:
         "packet_type": "SuccessorPacket",
         "created_at": now.isoformat().replace("+00:00", "Z"),
         "work_id": work.get("work_id"),
+        "issue_anchor": work.get("issue_anchor"),
         "role": work.get("role"),
         "phase": work.get("phase"),
         "root_budget_tokens": work.get("root_budget_tokens"),
@@ -280,6 +340,119 @@ def successor_packet(work: dict[str, Any], run: dict[str, Any], route: str, now:
         "requested_route": route,
         "context_policy": "cursor_only_compact_no_prompt_body_no_full_history",
         "exclusions": sorted(FORBIDDEN_PACKET_KEYS),
+    }
+
+
+def compact_reason(raw: Any, fallback: str) -> str:
+    if isinstance(raw, str) and raw.strip():
+        words = raw.strip().split()
+        return " ".join(words[:16])
+    return fallback
+
+
+def attention_summary_projection(packet: dict[str, Any], now: dt.datetime) -> dict[str, Any]:
+    del now
+    stops: list[str] = []
+    warnings: list[str] = []
+    events = packet.get("attention_events")
+    if events is None:
+        events = []
+    if not isinstance(events, list):
+        stops.append("invalid_attention_events")
+        events = []
+    items: list[dict[str, Any]] = []
+    suppressed: list[str] = []
+    for index, event in enumerate(events):
+        if not isinstance(event, dict):
+            stops.append("invalid_attention_event")
+            continue
+        category = event.get("category")
+        if category in SUPPRESSED_EVENT_CATEGORIES:
+            suppressed.append(str(category))
+            continue
+        if category not in ATTENTION_CATEGORIES:
+            stops.append("unknown_attention_category")
+            continue
+        reason = compact_reason(event.get("reason"), ATTENTION_CATEGORIES[category])
+        items.append(
+            {
+                "category": category,
+                "reason": reason,
+                "evidence_ref": event.get("evidence_ref"),
+                "requires_human": True,
+                "index": index,
+            }
+        )
+    forbidden = find_forbidden(packet.get("attention_events", []))
+    if forbidden:
+        stops.append("privacy_exposure")
+        warnings.append("forbidden_attention_paths:" + ",".join(forbidden))
+    if stops:
+        items.append(
+            {
+                "category": "invalid_attention_input",
+                "reason": "Attention input is invalid; hold for compact corrected evidence.",
+                "requires_human": True,
+            }
+        )
+    return {
+        "projection_type": "AttentionSummary",
+        "control_version": CONTROL_VERSION,
+        "valid": not stops,
+        "human_attention_required": bool(items),
+        "reason": compact_reason(items[0]["reason"], "Human attention is required.") if items else "No policy-material attention event.",
+        "items": items,
+        "suppressed_event_categories": sorted(set(suppressed)),
+        "stop_conditions": sorted(set(stops)),
+        "warnings": warnings,
+        "read_only": True,
+        "mutation_performed": False,
+        "dispatch_performed": False,
+    }
+
+
+def work_summary_projection(packet: dict[str, Any], now: dt.datetime) -> dict[str, Any]:
+    work = packet.get("work") if isinstance(packet.get("work"), dict) else {}
+    stops: list[str] = []
+    validate_issue_work_anchor(work, stops)
+    for field in ("work_id", "objective", "stage", "role"):
+        if missing(work.get(field)):
+            stops.append(f"missing_work_summary_{field}")
+    attention = attention_summary_projection(packet, now)
+    if not attention["valid"]:
+        stops.append("invalid_attention_summary")
+    forbidden = find_forbidden(work)
+    warnings: list[str] = []
+    if forbidden:
+        stops.append("privacy_exposure")
+        warnings.append("forbidden_work_summary_paths:" + ",".join(forbidden))
+    return {
+        "projection_type": "WorkSummary",
+        "control_version": CONTROL_VERSION,
+        "valid": not stops,
+        "issue_anchor": work.get("issue_anchor"),
+        "work_id": work.get("work_id"),
+        "objective": work.get("objective"),
+        "stage": work.get("stage"),
+        "current_owner": work.get("current_owner", work.get("role")),
+        "material_decisions": work.get("material_decisions", []),
+        "accepted_evidence_refs": work.get("accepted_evidence_refs", []),
+        "material_risk_or_blocker": work.get("material_risk_or_blocker"),
+        "next_action": work.get("next_action"),
+        "human_attention_required": attention["human_attention_required"] or bool(stops),
+        "human_attention_reason": attention["reason"] if attention["human_attention_required"] else "No policy-material attention event.",
+        "default_human_ux_excludes": [
+            "ExecutionRun",
+            "DispatchClaim",
+            "TransitionReceipt",
+            "raw_token_context_observations",
+            "successor_retry_mechanics",
+        ],
+        "stop_conditions": sorted(set(stops)),
+        "warnings": warnings,
+        "read_only": True,
+        "mutation_performed": False,
+        "dispatch_performed": False,
     }
 
 
@@ -333,6 +506,8 @@ def plan_preflight(packet: dict[str, Any], now: dt.datetime) -> dict[str, Any]:
         "warnings": warnings,
         "reason": "preflight passed" if decision == "allow" else "successor context required" if decision == "successor_required" else "fail-closed hold required",
         "one_recovery_action": None if decision != "hold_required" else "ask Coordinator for a compact issue-specific packet or Human approval",
+        "human_attention_required": decision == "hold_required",
+        "human_attention_reason": "Hold requires Human or Coordinator attention." if decision == "hold_required" else "No policy-material attention event.",
         "mutation_performed": False,
         "dispatch_performed": False,
     }
@@ -354,6 +529,7 @@ def plan_preflight(packet: dict[str, Any], now: dt.datetime) -> dict[str, Any]:
 
 def explain_work_policy(packet: dict[str, Any], now: dt.datetime) -> dict[str, Any]:
     preflight = plan_preflight(packet, now)
+    attention = attention_summary_projection(packet, now)
     return {
         "control_version": CONTROL_VERSION,
         "classification": preflight["classification"],
@@ -369,6 +545,10 @@ def explain_work_policy(packet: dict[str, Any], now: dt.datetime) -> dict[str, A
         "reason": preflight["reason"],
         "stop_conditions": preflight["stop_conditions"],
         "one_recovery_action": preflight["one_recovery_action"],
+        "human_attention_required": preflight["human_attention_required"] or attention["human_attention_required"],
+        "human_attention_reason": preflight["human_attention_reason"]
+        if preflight["human_attention_required"]
+        else attention["reason"],
         "read_only": True,
         "mutation_performed": False,
         "dispatch_performed": False,
@@ -383,6 +563,10 @@ def main() -> int:
         result = active_policy_readout()
     elif args.mode == "explain":
         result = explain_work_policy(packet, now)
+    elif args.mode == "work-summary":
+        result = work_summary_projection(packet, now)
+    elif args.mode == "attention-summary":
+        result = attention_summary_projection(packet, now)
     else:
         result = plan_preflight(packet, now)
     print(json.dumps(result, indent=2, sort_keys=True))

--- a/scripts/test_af18_mvp1_control.py
+++ b/scripts/test_af18_mvp1_control.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Focused tests for AF18 MVP-1 lifecycle control-plane planning."""
+
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PLANNER = ROOT / "scripts" / "plan_af18_mvp1_control.py"
+spec = importlib.util.spec_from_file_location("plan_af18_mvp1_control", PLANNER)
+planner = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(planner)
+
+NOW = dt.datetime(2026, 7, 29, 4, 0, tzinfo=dt.timezone.utc)
+
+
+def packet(**overrides):
+    base = {
+        "work": {
+            "work_id": "af18-450",
+            "issue": 450,
+            "role": "Implementer",
+            "phase": "mvp1-control-plane",
+            "root_budget_tokens": 7000,
+            "remaining_budget_tokens": 6200,
+            "durable_anchors": ["https://github.com/farmerhunter/agent-foundry/issues/450"],
+            "stop_conditions": ["hold_on_missing_budget", "hold_on_stale_context", "hold_on_duplicate_dispatch"],
+        },
+        "execution_run": {
+            "run_id": "run-450-a",
+            "work_id": "af18-450",
+            "role": "Implementer",
+            "state": "active",
+            "context": {
+                "source_timestamp": "2026-07-29T03:30:00Z",
+                "threshold_band": "implementer_small_scoped_implementation",
+                "estimated_context_tokens": 5500,
+            },
+            "model": {"name": "gpt-5.5", "reasoning": "medium"},
+        },
+        "dispatch_claim": {
+            "idempotency_key": "issue-450-implementer-mvp1-control-v1",
+            "work_id": "af18-450",
+            "role": "Implementer",
+            "decision_boundary": "issue-450-mvp1",
+            "durable_anchor": "https://github.com/farmerhunter/agent-foundry/issues/450",
+        },
+        "existing_dispatch_claims": [],
+        "active_runs": [],
+        "requested_route": "bounded_subagent",
+    }
+    base.update(overrides)
+    return base
+
+
+def plan(value):
+    return planner.plan_preflight(value, NOW)
+
+
+def expect(name, condition, detail):
+    if not condition:
+        raise AssertionError(f"{name} failed: {detail}")
+
+
+def forbidden_paths(value):
+    return planner.find_forbidden(value)
+
+
+def main() -> int:
+    allowed = plan(packet())
+    expect("allow-route", allowed["decision"] == "allow", allowed)
+    expect("allow-policy-source", allowed["effective_control_snapshot"]["policy_source"] == "scripts/plan_collaboration_routes.py", allowed)
+    expect("allow-no-mutation", allowed["mutation_performed"] is False and allowed["dispatch_performed"] is False, allowed)
+
+    missing_budget = packet(work={**packet()["work"], "root_budget_tokens": None})
+    missing_budget_result = plan(missing_budget)
+    expect("missing-budget-holds", missing_budget_result["decision"] == "hold_required", missing_budget_result)
+    expect("missing-budget-stop", "missing_budget" in missing_budget_result["stop_conditions"], missing_budget_result)
+
+    stale = packet()
+    stale["execution_run"] = {
+        **stale["execution_run"],
+        "context": {**stale["execution_run"]["context"], "source_timestamp": "2026-07-26T00:00:00Z"},
+    }
+    stale_result = plan(stale)
+    expect("stale-context-holds", "stale_context" in stale_result["stop_conditions"], stale_result)
+
+    oversized = packet()
+    oversized["execution_run"] = {
+        **oversized["execution_run"],
+        "context": {**oversized["execution_run"]["context"], "estimated_context_tokens": 9000},
+    }
+    oversized_result = plan(oversized)
+    expect("oversized-context-holds", "oversized_context" in oversized_result["stop_conditions"], oversized_result)
+
+    escalation = packet()
+    escalation["execution_run"] = {**escalation["execution_run"], "model": {"name": "gpt-5.6", "reasoning": "high"}}
+    escalation_result = plan(escalation)
+    expect("model-ceiling-holds", "model_escalation_requires_human_approval" in escalation_result["stop_conditions"], escalation_result)
+    expect("reasoning-ceiling-holds", "reasoning_escalation_requires_human_approval" in escalation_result["stop_conditions"], escalation_result)
+
+    duplicate_claim = packet(
+        existing_dispatch_claims=[
+            {
+                "idempotency_key": "issue-450-implementer-mvp1-control-v1",
+                "work_id": "af18-450",
+                "role": "Implementer",
+                "decision_boundary": "issue-450-mvp1",
+            }
+        ]
+    )
+    duplicate_claim_result = plan(duplicate_claim)
+    expect("duplicate-claim-holds", "duplicate_dispatch_claim" in duplicate_claim_result["stop_conditions"], duplicate_claim_result)
+
+    active_run = packet(active_runs=[{"run_id": "run-450-other", "work_id": "af18-450", "role": "Implementer", "state": "active"}])
+    active_run_result = plan(active_run)
+    expect("one-active-run-holds", "duplicate_active_run" in active_run_result["stop_conditions"], active_run_result)
+
+    visible = plan(packet(requested_route="visible_interactive"))
+    expect("visible-successor-required", visible["decision"] == "successor_required", visible)
+    expect("successor-keeps-work-id", visible["successor_packet"]["work_id"] == "af18-450", visible)
+    expect("successor-keeps-root-budget", visible["successor_packet"]["root_budget_tokens"] == 7000, visible)
+    expect("successor-keeps-remaining-budget", visible["successor_packet"]["remaining_budget_tokens"] == 6200, visible)
+    expect("successor-privacy-safe", forbidden_paths(visible["successor_packet"]) == [], visible)
+
+    external = plan(packet(requested_route="external_provider"))
+    expect("external-holds", external["decision"] == "hold_required", external)
+    expect("external-held-route-visible", external["held_route"] == "external_provider", external)
+
+    readout = planner.active_policy_readout()
+    expect("readout-source-visible", readout["policy_source"] == "scripts/plan_collaboration_routes.py", readout)
+    expect("readout-global-ceiling", readout["global_hard_context_ceiling"] == 12000, readout)
+    expect("readout-effective-rule-visible", "effective_context_ceiling_rule" in readout, readout)
+    expect("readout-band-visible", readout["threshold_bands"]["implementer_small_scoped_implementation"]["max_context_tokens"] == 8000, readout)
+    expect("readout-no-dispatch", readout["mutation_performed"] is False and readout["dispatch_performed"] is False, readout)
+    expect("readout-privacy-safe", forbidden_paths(readout) == [], readout)
+
+    explanation = planner.explain_work_policy(packet(), NOW)
+    expect("explain-allow", explanation["decision"] == "allow", explanation)
+    expect("explain-budget-visible", explanation["root_budget_tokens"] == 7000 and explanation["remaining_budget_tokens"] == 6200, explanation)
+
+    visible_explanation = planner.explain_work_policy(packet(requested_route="visible_interactive"), NOW)
+    expect("explain-visible-successor", visible_explanation["decision"] == "successor_required", visible_explanation)
+    expect("explain-visible-route", visible_explanation["selected_route"] == "visible_interactive", visible_explanation)
+
+    hold_explanation = planner.explain_work_policy(oversized, NOW)
+    expect("explain-hold", hold_explanation["decision"] == "hold_required", hold_explanation)
+    expect("explain-recovery-action", hold_explanation["one_recovery_action"] is not None, hold_explanation)
+
+    unknown = plan(packet(requested_route="unclassified_route"))
+    expect("unknown-classification-holds", unknown["decision"] == "hold_required", unknown)
+    expect("unknown-classification-stop", "unknown_route_classification" in unknown["stop_conditions"], unknown)
+
+    prompt_body = packet(prompt="private prompt body")
+    prompt_body_result = plan(prompt_body)
+    expect("prompt-body-holds", "privacy_exposure" in prompt_body_result["stop_conditions"], prompt_body_result)
+
+    print("af18 mvp1 control-plane tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_af18_mvp1_control.py
+++ b/scripts/test_af18_mvp1_control.py
@@ -23,12 +23,27 @@ def packet(**overrides):
         "work": {
             "work_id": "af18-450",
             "issue": 450,
+            "issue_anchor": {
+                "issue": 450,
+                "durable_anchor": "https://github.com/farmerhunter/agent-foundry/issues/450",
+                "scope": "mvp1-control-plane",
+                "risk": "high",
+                "acceptance": "portable read-only control-plane proof",
+                "human_gates": ["model_escalation", "external_side_effect"],
+            },
             "role": "Implementer",
+            "objective": "Implement AF18 MVP-1 control-plane contract",
+            "stage": "needs:reviewer",
             "phase": "mvp1-control-plane",
+            "current_owner": "Implementer",
             "root_budget_tokens": 7000,
             "remaining_budget_tokens": 6200,
             "durable_anchors": ["https://github.com/farmerhunter/agent-foundry/issues/450"],
             "stop_conditions": ["hold_on_missing_budget", "hold_on_stale_context", "hold_on_duplicate_dispatch"],
+            "material_decisions": ["Option A approved for bounded MVP"],
+            "accepted_evidence_refs": ["https://github.com/farmerhunter/agent-foundry/pull/453"],
+            "material_risk_or_blocker": None,
+            "next_action": "review PR #453",
         },
         "execution_run": {
             "run_id": "run-450-a",
@@ -59,6 +74,7 @@ def packet(**overrides):
         },
         "existing_dispatch_claims": [],
         "active_runs": [],
+        "attention_events": [],
         "requested_route": "isolated_execution",
         "adapter_metadata": {"runtime_binding": "codex"},
     }
@@ -89,6 +105,15 @@ def main() -> int:
         allowed,
     )
     expect("allow-no-mutation", allowed["mutation_performed"] is False and allowed["dispatch_performed"] is False, allowed)
+    expect("allow-no-human-attention", allowed["human_attention_required"] is False, allowed)
+
+    issue_anchor_mismatch = packet(work={**packet()["work"], "issue_anchor": {**packet()["work"]["issue_anchor"], "issue": 449}})
+    issue_anchor_mismatch_result = plan(issue_anchor_mismatch)
+    expect("issue-anchor-mismatch-holds", "work_issue_anchor_mismatch" in issue_anchor_mismatch_result["stop_conditions"], issue_anchor_mismatch_result)
+
+    cross_issue_without_anchor = packet(work={**packet()["work"], "cross_issue_work": True})
+    cross_issue_result = plan(cross_issue_without_anchor)
+    expect("cross-issue-requires-anchor", "missing_cross_issue_durable_anchors" in cross_issue_result["stop_conditions"], cross_issue_result)
 
     missing_budget = packet(work={**packet()["work"], "root_budget_tokens": None})
     missing_budget_result = plan(missing_budget)
@@ -240,6 +265,7 @@ def main() -> int:
     interactive = plan(packet(requested_route="interactive_execution"))
     expect("interactive-successor-required", interactive["decision"] == "successor_required", interactive)
     expect("successor-keeps-work-id", interactive["successor_packet"]["work_id"] == "af18-450", interactive)
+    expect("successor-keeps-issue-anchor", interactive["successor_packet"]["issue_anchor"]["issue"] == 450, interactive)
     expect("successor-keeps-root-budget", interactive["successor_packet"]["root_budget_tokens"] == 7000, interactive)
     expect("successor-keeps-remaining-budget", interactive["successor_packet"]["remaining_budget_tokens"] == 6200, interactive)
     expect("successor-privacy-safe", forbidden_paths(interactive["successor_packet"]) == [], interactive)
@@ -260,11 +286,18 @@ def main() -> int:
     expect("readout-effective-rule-visible", "effective_context_ceiling_rule" in readout, readout)
     expect("readout-band-visible", readout["threshold_bands"]["implementer_small_scoped_implementation"]["max_context_tokens"] == 8000, readout)
     expect("readout-no-dispatch", readout["mutation_performed"] is False and readout["dispatch_performed"] is False, readout)
+    expect("readout-human-views-visible", "attention_summary" in readout["human_facing_views"], readout)
+    expect(
+        "ordinary-receipts-not-default-attention",
+        readout["human_attention_policy"]["ordinary_control_plane_receipts_default_human_attention"] is False,
+        readout,
+    )
     expect("readout-privacy-safe", forbidden_paths(readout) == [], readout)
 
     explanation = planner.explain_work_policy(packet(), NOW)
     expect("explain-allow", explanation["decision"] == "allow", explanation)
     expect("explain-budget-visible", explanation["root_budget_tokens"] == 7000 and explanation["remaining_budget_tokens"] == 6200, explanation)
+    expect("explain-attention-reason", explanation["human_attention_reason"] == "No policy-material attention event.", explanation)
 
     interactive_explanation = planner.explain_work_policy(packet(requested_route="interactive_execution"), NOW)
     expect("explain-interactive-successor", interactive_explanation["decision"] == "successor_required", interactive_explanation)
@@ -281,6 +314,60 @@ def main() -> int:
     prompt_body = packet(prompt="private prompt body")
     prompt_body_result = plan(prompt_body)
     expect("prompt-body-holds", "privacy_exposure" in prompt_body_result["stop_conditions"], prompt_body_result)
+
+    ordinary_receipt = planner.attention_summary_projection(
+        packet(attention_events=[{"category": "transition_receipt", "reason": "ordinary run receipt"}]),
+        NOW,
+    )
+    expect("ordinary-receipt-suppressed", ordinary_receipt["human_attention_required"] is False, ordinary_receipt)
+    expect("ordinary-receipt-category-suppressed", "transition_receipt" in ordinary_receipt["suppressed_event_categories"], ordinary_receipt)
+
+    attention_categories = {
+        "hdc_approval": "Human approval needed",
+        "risk_change": "Risk changed",
+        "privacy_boundary": "Privacy boundary",
+        "external_side_effect": "External side effect",
+        "model_escalation": "Model escalation",
+        "context_budget_strategy_change": "Budget strategy changed",
+        "retry_claim_anomaly": "Claim anomaly",
+        "acceptance_evidence_conflict": "Evidence conflict",
+        "phase_completion": "Phase complete",
+        "stale_no_owner_work": "No owner",
+    }
+    for category, reason in attention_categories.items():
+        attention = planner.attention_summary_projection(
+            packet(attention_events=[{"category": category, "reason": reason, "evidence_ref": "issue-450"}]),
+            NOW,
+        )
+        expect(f"attention-{category}-required", attention["human_attention_required"] is True, attention)
+        expect(f"attention-{category}-reason", attention["items"][0]["reason"] == reason, attention)
+
+    work_summary = planner.work_summary_projection(packet(), NOW)
+    expect("work-summary-valid", work_summary["valid"] is True, work_summary)
+    expect("work-summary-fields", work_summary["objective"] == "Implement AF18 MVP-1 control-plane contract", work_summary)
+    expect("work-summary-no-attention", work_summary["human_attention_required"] is False, work_summary)
+    expect("work-summary-default-excludes-runs", "ExecutionRun" in work_summary["default_human_ux_excludes"], work_summary)
+
+    work_summary_attention = planner.work_summary_projection(
+        packet(attention_events=[{"category": "phase_completion", "reason": "Phase complete"}]),
+        NOW,
+    )
+    expect("work-summary-attention-required", work_summary_attention["human_attention_required"] is True, work_summary_attention)
+    expect("work-summary-attention-reason", work_summary_attention["human_attention_reason"] == "Phase complete", work_summary_attention)
+
+    private_work_summary = planner.work_summary_projection(
+        packet(work={**packet()["work"], "prompt": "private prompt body"}),
+        NOW,
+    )
+    expect("work-summary-privacy-fail-closed", "privacy_exposure" in private_work_summary["stop_conditions"], private_work_summary)
+
+    invalid_attention = planner.attention_summary_projection(packet(attention_events=[{"category": "unknown_policy_event"}]), NOW)
+    expect("unknown-attention-fails-closed", invalid_attention["valid"] is False, invalid_attention)
+    expect("unknown-attention-stop", "unknown_attention_category" in invalid_attention["stop_conditions"], invalid_attention)
+
+    invalid_summary = planner.work_summary_projection(packet(work={**packet()["work"], "objective": ""}), NOW)
+    expect("invalid-summary-fails-closed", invalid_summary["valid"] is False, invalid_summary)
+    expect("invalid-summary-stop", "missing_work_summary_objective" in invalid_summary["stop_conditions"], invalid_summary)
 
     print("af18 mvp1 control-plane tests passed")
     return 0

--- a/scripts/test_af18_mvp1_control.py
+++ b/scripts/test_af18_mvp1_control.py
@@ -38,7 +38,13 @@ def packet(**overrides):
             "context": {
                 "source_timestamp": "2026-07-29T03:30:00Z",
                 "threshold_band": "implementer_small_scoped_implementation",
-                "estimated_context_tokens": 5500,
+                "resource_observations": {
+                    "context_tokens": {
+                        "provenance": "estimated",
+                        "tokens": 5500,
+                        "source": "compact_coordinator_packet",
+                    }
+                },
             },
             "model": {"name": "gpt-5.5", "reasoning": "medium"},
         },
@@ -47,11 +53,14 @@ def packet(**overrides):
             "work_id": "af18-450",
             "role": "Implementer",
             "decision_boundary": "issue-450-mvp1",
+            "transition_semantics": "initial_control_plane_preflight",
             "durable_anchor": "https://github.com/farmerhunter/agent-foundry/issues/450",
+            "adapter_metadata": {"native_binding": "codex"},
         },
         "existing_dispatch_claims": [],
         "active_runs": [],
-        "requested_route": "bounded_subagent",
+        "requested_route": "isolated_execution",
+        "adapter_metadata": {"runtime_binding": "codex"},
     }
     base.update(overrides)
     return base
@@ -74,6 +83,11 @@ def main() -> int:
     allowed = plan(packet())
     expect("allow-route", allowed["decision"] == "allow", allowed)
     expect("allow-policy-source", allowed["effective_control_snapshot"]["policy_source"] == "scripts/plan_collaboration_routes.py", allowed)
+    expect(
+        "allow-resource-provenance-visible",
+        allowed["effective_control_snapshot"]["resource_observation"]["context_tokens"]["provenance"] == "estimated",
+        allowed,
+    )
     expect("allow-no-mutation", allowed["mutation_performed"] is False and allowed["dispatch_performed"] is False, allowed)
 
     missing_budget = packet(work={**packet()["work"], "root_budget_tokens": None})
@@ -92,10 +106,83 @@ def main() -> int:
     oversized = packet()
     oversized["execution_run"] = {
         **oversized["execution_run"],
-        "context": {**oversized["execution_run"]["context"], "estimated_context_tokens": 9000},
+        "context": {
+            **oversized["execution_run"]["context"],
+            "resource_observations": {
+                "context_tokens": {
+                    "provenance": "observed",
+                    "tokens": 9000,
+                    "source": "runtime_control_surface",
+                }
+            },
+        },
     }
     oversized_result = plan(oversized)
     expect("oversized-context-holds", "oversized_context" in oversized_result["stop_conditions"], oversized_result)
+
+    missing_resource_observation = packet()
+    missing_resource_observation["execution_run"] = {
+        **missing_resource_observation["execution_run"],
+        "context": {
+            key: value
+            for key, value in missing_resource_observation["execution_run"]["context"].items()
+            if key != "resource_observations"
+        },
+    }
+    missing_resource_result = plan(missing_resource_observation)
+    expect("missing-resource-holds", "missing_resource_observation" in missing_resource_result["stop_conditions"], missing_resource_result)
+
+    unavailable_resource = packet()
+    unavailable_resource["execution_run"] = {
+        **unavailable_resource["execution_run"],
+        "context": {
+            **unavailable_resource["execution_run"]["context"],
+            "resource_observations": {"context_tokens": {"provenance": "unavailable", "source": "adapter_not_supported"}},
+        },
+    }
+    unavailable_result = plan(unavailable_resource)
+    expect("unavailable-resource-holds", "resource_measurement_unavailable" in unavailable_result["stop_conditions"], unavailable_result)
+
+    missing_token_measurement = packet()
+    missing_token_measurement["execution_run"] = {
+        **missing_token_measurement["execution_run"],
+        "context": {
+            **missing_token_measurement["execution_run"]["context"],
+            "resource_observations": {
+                "context_tokens": {
+                    "provenance": "observed",
+                    "source": "runtime_control_surface",
+                }
+            },
+        },
+    }
+    missing_token_result = plan(missing_token_measurement)
+    expect(
+        "missing-token-measurement-not-zero",
+        "missing_context_token_measurement" in missing_token_result["stop_conditions"],
+        missing_token_result,
+    )
+
+    unavailable_lower_capability = packet()
+    unavailable_lower_capability["execution_run"] = {
+        **unavailable_lower_capability["execution_run"],
+        "context": {
+            **unavailable_lower_capability["execution_run"]["context"],
+            "resource_observations": {
+                "context_tokens": {
+                    "provenance": "unavailable",
+                    "source": "adapter_not_supported",
+                    "lower_capability_policy": "serial_execution_only",
+                }
+            },
+        },
+    }
+    lower_capability_result = plan(unavailable_lower_capability)
+    expect(
+        "unavailable-lower-capability-not-zero",
+        "resource_measurement_lower_capability_required" in lower_capability_result["stop_conditions"],
+        lower_capability_result,
+    )
 
     escalation = packet()
     escalation["execution_run"] = {**escalation["execution_run"], "model": {"name": "gpt-5.6", "reasoning": "high"}}
@@ -110,29 +197,65 @@ def main() -> int:
                 "work_id": "af18-450",
                 "role": "Implementer",
                 "decision_boundary": "issue-450-mvp1",
+                "transition_semantics": "initial_control_plane_preflight",
             }
         ]
     )
     duplicate_claim_result = plan(duplicate_claim)
     expect("duplicate-claim-holds", "duplicate_dispatch_claim" in duplicate_claim_result["stop_conditions"], duplicate_claim_result)
 
+    semantic_duplicate = packet(
+        dispatch_claim={**packet()["dispatch_claim"], "idempotency_key": "changed-idempotency-key"},
+        existing_dispatch_claims=[
+            {
+                "idempotency_key": "original-idempotency-key",
+                "work_id": "af18-450",
+                "role": "Implementer",
+                "decision_boundary": "issue-450-mvp1",
+                "transition_semantics": "initial_control_plane_preflight",
+            }
+        ],
+    )
+    semantic_duplicate_result = plan(semantic_duplicate)
+    expect("semantic-duplicate-claim-holds", "duplicate_dispatch_claim" in semantic_duplicate_result["stop_conditions"], semantic_duplicate_result)
+
+    boundary_duplicate_without_transition = packet(
+        dispatch_claim={**packet()["dispatch_claim"], "idempotency_key": "changed-idempotency-key"},
+        existing_dispatch_claims=[
+            {
+                "idempotency_key": "legacy-idempotency-key",
+                "work_id": "af18-450",
+                "role": "Implementer",
+                "decision_boundary": "issue-450-mvp1",
+            }
+        ],
+    )
+    boundary_duplicate_result = plan(boundary_duplicate_without_transition)
+    expect("boundary-duplicate-without-transition-holds", "duplicate_dispatch_claim" in boundary_duplicate_result["stop_conditions"], boundary_duplicate_result)
+
     active_run = packet(active_runs=[{"run_id": "run-450-other", "work_id": "af18-450", "role": "Implementer", "state": "active"}])
     active_run_result = plan(active_run)
     expect("one-active-run-holds", "duplicate_active_run" in active_run_result["stop_conditions"], active_run_result)
 
-    visible = plan(packet(requested_route="visible_interactive"))
-    expect("visible-successor-required", visible["decision"] == "successor_required", visible)
-    expect("successor-keeps-work-id", visible["successor_packet"]["work_id"] == "af18-450", visible)
-    expect("successor-keeps-root-budget", visible["successor_packet"]["root_budget_tokens"] == 7000, visible)
-    expect("successor-keeps-remaining-budget", visible["successor_packet"]["remaining_budget_tokens"] == 6200, visible)
-    expect("successor-privacy-safe", forbidden_paths(visible["successor_packet"]) == [], visible)
+    interactive = plan(packet(requested_route="interactive_execution"))
+    expect("interactive-successor-required", interactive["decision"] == "successor_required", interactive)
+    expect("successor-keeps-work-id", interactive["successor_packet"]["work_id"] == "af18-450", interactive)
+    expect("successor-keeps-root-budget", interactive["successor_packet"]["root_budget_tokens"] == 7000, interactive)
+    expect("successor-keeps-remaining-budget", interactive["successor_packet"]["remaining_budget_tokens"] == 6200, interactive)
+    expect("successor-privacy-safe", forbidden_paths(interactive["successor_packet"]) == [], interactive)
 
-    external = plan(packet(requested_route="external_provider"))
+    serial = plan(packet(requested_route="serial_execution"))
+    expect("serial-route-allowed", serial["decision"] == "allow", serial)
+
+    external = plan(packet(requested_route="external_execution"))
     expect("external-holds", external["decision"] == "hold_required", external)
-    expect("external-held-route-visible", external["held_route"] == "external_provider", external)
+    expect("external-held-route-visible", external["held_route"] == "external_execution", external)
 
     readout = planner.active_policy_readout()
+    expect("codex-route-not-core-canonical", "bounded_subagent" not in readout["route_permissions"], readout)
+    expect("codex-visible-route-not-core-canonical", "visible_interactive" not in readout["route_permissions"], readout)
     expect("readout-source-visible", readout["policy_source"] == "scripts/plan_collaboration_routes.py", readout)
+    expect("readout-resource-policy-visible", readout["resource_observation_policy"]["missing_counts_as_zero"] is False, readout)
     expect("readout-global-ceiling", readout["global_hard_context_ceiling"] == 12000, readout)
     expect("readout-effective-rule-visible", "effective_context_ceiling_rule" in readout, readout)
     expect("readout-band-visible", readout["threshold_bands"]["implementer_small_scoped_implementation"]["max_context_tokens"] == 8000, readout)
@@ -143,9 +266,9 @@ def main() -> int:
     expect("explain-allow", explanation["decision"] == "allow", explanation)
     expect("explain-budget-visible", explanation["root_budget_tokens"] == 7000 and explanation["remaining_budget_tokens"] == 6200, explanation)
 
-    visible_explanation = planner.explain_work_policy(packet(requested_route="visible_interactive"), NOW)
-    expect("explain-visible-successor", visible_explanation["decision"] == "successor_required", visible_explanation)
-    expect("explain-visible-route", visible_explanation["selected_route"] == "visible_interactive", visible_explanation)
+    interactive_explanation = planner.explain_work_policy(packet(requested_route="interactive_execution"), NOW)
+    expect("explain-interactive-successor", interactive_explanation["decision"] == "successor_required", interactive_explanation)
+    expect("explain-interactive-route", interactive_explanation["selected_route"] == "interactive_execution", interactive_explanation)
 
     hold_explanation = planner.explain_work_policy(oversized, NOW)
     expect("explain-hold", hold_explanation["decision"] == "hold_required", hold_explanation)

--- a/scripts/test_af18_mvp1_control.py
+++ b/scripts/test_af18_mvp1_control.py
@@ -115,6 +115,14 @@ def main() -> int:
     cross_issue_result = plan(cross_issue_without_anchor)
     expect("cross-issue-requires-anchor", "missing_cross_issue_durable_anchors" in cross_issue_result["stop_conditions"], cross_issue_result)
 
+    cross_issue_malformed_anchor = packet(work={**packet()["work"], "cross_issue_work": True, "additional_issue_anchors": [{}]})
+    cross_issue_malformed_result = plan(cross_issue_malformed_anchor)
+    expect(
+        "cross-issue-malformed-anchor-holds",
+        "malformed_additional_issue_anchor" in cross_issue_malformed_result["stop_conditions"],
+        cross_issue_malformed_result,
+    )
+
     missing_budget = packet(work={**packet()["work"], "root_budget_tokens": None})
     missing_budget_result = plan(missing_budget)
     expect("missing-budget-holds", missing_budget_result["decision"] == "hold_required", missing_budget_result)
@@ -368,6 +376,12 @@ def main() -> int:
     invalid_summary = planner.work_summary_projection(packet(work={**packet()["work"], "objective": ""}), NOW)
     expect("invalid-summary-fails-closed", invalid_summary["valid"] is False, invalid_summary)
     expect("invalid-summary-stop", "missing_work_summary_objective" in invalid_summary["stop_conditions"], invalid_summary)
+    expect(
+        "invalid-summary-corrective-reason",
+        invalid_summary["human_attention_reason"] != "No policy-material attention event."
+        and invalid_summary["human_attention_reason"].startswith("Invalid summary input:"),
+        invalid_summary,
+    )
 
     print("af18 mvp1 control-plane tests passed")
     return 0


### PR DESCRIPTION
## Summary
- add AF18 MVP-1 lifecycle control-plane planner for Work, ExecutionRun, DispatchClaim, SuccessorPacket, TransitionReceipt, preflight, readout, and explain outputs
- reuse scripts/plan_collaboration_routes.py as the authoritative #440/#442 policy source for bands, global ceiling, and model/reasoning ceiling
- add JSON schema and focused regressions for allow/hold/successor paths, duplicate claim, one-active-run invariant, budget inheritance, and privacy-safe compact output

## Verification
- python3 scripts/test_af18_mvp1_control.py
- python3 scripts/test_collaboration_route_planner.py
- python3 scripts/test_runtime_owned_capture.py
- python3 scripts/plan_af18_mvp1_control.py --help
- python3 scripts/plan_collaboration_routes.py --help
- python3 scripts/validate_runtime_owned_capture.py --help
- git diff --check
- git diff --cached --check

## Residual risks
- This is a static/read-only control-plane proof surface only; it does not implement live runtime dispatch, runtime/config/hook mutation, local ledger behavior, auto-archive/delete, thread migration, or final AF18 activation.