### PR TITLE
[AF18-MVP-2] Runtime-owned observation bridge

### DIFF
--- a/scripts/plan_af18_mvp2_observation_bridge.py
+++ b/scripts/plan_af18_mvp2_observation_bridge.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Plan AF18 MVP-2 runtime-owned controlled observation bridge decisions."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import plan_af18_mvp1_control as control
+import validate_runtime_owned_capture as capture_validator
+
+
+BRIDGE_VERSION = "af18-mvp2-observation-bridge-v1"
+SNAPSHOT_SOURCE = "#442 low_limit containment"
+SNAPSHOT_VERSION = "af18-451-option-a-literal-v1"
+SNAPSHOT_BAND = "low_limit_experiment"
+COORDINATOR_EVENT_TYPES = {
+    "before_new_issue_work",
+    "after_compact_durable_readback",
+    "after_material_input_or_tool_output_increase",
+    "before_role_dispatch",
+    "after_role_dispatch",
+    "before_callback",
+    "after_callback",
+    "before_human_hdc_output",
+    "after_human_hdc_output",
+    "policy_anomaly",
+    "evidence_anomaly",
+    "budget_anomaly",
+}
+TOKEN_FIELDS = ("input_tokens", "cached_input_tokens", "output_tokens", "reasoning_tokens")
+TELEMETRY_FIELDS = TOKEN_FIELDS + ("tool_output_bytes",)
+AVAILABILITY = {"observed", "estimated", "unavailable"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Plan AF18 MVP-2 runtime-owned observation bridge decisions.")
+    parser.add_argument("--input", help="Bridge packet JSON path. Defaults to stdin when provided.")
+    parser.add_argument("--now", help="Current UTC timestamp for deterministic tests.")
+    parser.add_argument("--max-capture-age-hours", type=int, default=12)
+    return parser.parse_args()
+
+
+def read_packet(path: str | None) -> dict[str, Any]:
+    if path:
+        text = Path(path).read_text(encoding="utf-8")
+    elif not sys.stdin.isatty():
+        text = sys.stdin.read()
+    else:
+        return {}
+    if not text.strip():
+        return {}
+    value = json.loads(text)
+    if not isinstance(value, dict):
+        raise SystemExit("bridge packet must be a JSON object")
+    return value
+
+
+def utc_now(raw: str | None) -> dt.datetime:
+    if raw:
+        return control.cost_policy.parse_timestamp(raw, "now")
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def missing(value: Any) -> bool:
+    return value in (None, "", [], {})
+
+
+def literal_snapshot(packet: dict[str, Any], stops: list[str]) -> dict[str, Any]:
+    snapshot = packet.get("effective_control_snapshot")
+    if not isinstance(snapshot, dict):
+        stops.append("missing_literal_effective_control_snapshot")
+        return {}
+    required = {
+        "source": SNAPSHOT_SOURCE,
+        "version": SNAPSHOT_VERSION,
+        "band": SNAPSHOT_BAND,
+        "label": SNAPSHOT_BAND,
+        "coordinator_lifecycle_model": "CoordinatorSession -> CoordinationWindow -> coordination operation",
+        "threshold_band": "coordinator_routing_status_readback",
+        "max_context_tokens": 4000,
+        "max_age_hours": 12,
+        "measurement_unavailable_policy": "hold_required",
+        "normal_threshold_breach": "successor_required",
+    }
+    for key, expected in required.items():
+        if snapshot.get(key) != expected:
+            stops.append(f"literal_snapshot_{key}_mismatch")
+    for field in ("root_budget_tokens", "window_id", "stop_conditions", "allowed_route"):
+        if missing(snapshot.get(field)):
+            stops.append(f"missing_literal_snapshot_{field}")
+    if snapshot.get("allowed_route") != "isolated_execution":
+        stops.append("literal_snapshot_allowed_route_mismatch")
+    return snapshot
+
+
+def validate_event(packet: dict[str, Any], stops: list[str]) -> str:
+    event_type = packet.get("coordinator_event_type")
+    if event_type not in COORDINATOR_EVENT_TYPES:
+        stops.append("unbounded_or_unknown_lifecycle_event")
+        return "unknown"
+    return str(event_type)
+
+
+def telemetry_projection(packet: dict[str, Any], stops: list[str]) -> dict[str, Any]:
+    telemetry = packet.get("runtime_telemetry")
+    if not isinstance(telemetry, dict):
+        stops.append("missing_runtime_telemetry")
+        telemetry = {}
+    projection: dict[str, Any] = {}
+    total_context_tokens = 0
+    total_context_available = True
+    for field in TELEMETRY_FIELDS:
+        item = telemetry.get(field)
+        if not isinstance(item, dict):
+            stops.append(f"missing_{field}")
+            projection[field] = {"availability": "unavailable", "value": None}
+            total_context_available = False
+            continue
+        availability = item.get("availability")
+        if availability not in AVAILABILITY:
+            stops.append(f"unknown_{field}_availability")
+            availability = "unavailable"
+        value = item.get("value")
+        if availability == "unavailable":
+            stops.append(f"{field}_unavailable")
+            total_context_available = False
+            value = None
+        elif not isinstance(value, int) or value < 0:
+            stops.append(f"missing_{field}_value")
+            total_context_available = False
+            value = None
+        projection[field] = {
+            "availability": availability,
+            "value": value,
+            "source": item.get("source"),
+        }
+        if field in TOKEN_FIELDS and isinstance(value, int):
+            total_context_tokens += value
+    projection["total_context_tokens"] = {
+        "availability": "observed" if total_context_available else "unavailable",
+        "value": total_context_tokens if total_context_available else None,
+        "missing_counts_as_zero": False,
+    }
+    for field in ("route", "transition_reason"):
+        if missing(telemetry.get(field)):
+            stops.append(f"missing_runtime_telemetry_{field}")
+        projection[field] = telemetry.get(field)
+    cumulative = telemetry.get("cumulative_work_totals")
+    if not isinstance(cumulative, dict):
+        stops.append("missing_cumulative_work_totals")
+        cumulative = {}
+    projection["cumulative_work_totals"] = cumulative
+    return projection
+
+
+def validate_runtime_capture(packet: dict[str, Any], now: dt.datetime, max_age_hours: int, stops: list[str]) -> dict[str, Any]:
+    record = packet.get("runtime_capture")
+    if not isinstance(record, dict) or not record:
+        stops.append("missing_runtime_capture")
+        return {"valid": False, "errors": ["missing_runtime_capture"]}
+    result = capture_validator.validate(record, now, max_age_hours)
+    if result["valid"] is not True:
+        for error in result.get("errors", []):
+            if error in {"caller_only_evidence", "forged_evidence", "stale_evidence", "missing_producer"}:
+                stops.append(error)
+            else:
+                stops.append(f"runtime_capture_{error}")
+    if result.get("runtime_owned") is not True:
+        stops.append("caller_only_evidence")
+    return result
+
+
+def threshold_breached(snapshot: dict[str, Any], telemetry: dict[str, Any]) -> bool:
+    value = telemetry.get("total_context_tokens", {}).get("value")
+    limit = snapshot.get("max_context_tokens")
+    return isinstance(value, int) and isinstance(limit, int) and value > limit
+
+
+def control_plane_packet(packet: dict[str, Any], snapshot: dict[str, Any], telemetry: dict[str, Any]) -> dict[str, Any]:
+    work = dict(packet.get("work") if isinstance(packet.get("work"), dict) else {})
+    run = dict(packet.get("execution_run") if isinstance(packet.get("execution_run"), dict) else {})
+    context = dict(run.get("context") if isinstance(run.get("context"), dict) else {})
+    model = dict(run.get("model") if isinstance(run.get("model"), dict) else {})
+    work.setdefault("role", "Coordinator")
+    work.setdefault("phase", "mvp2-observation-bridge")
+    run["work_id"] = work.get("work_id")
+    run["role"] = work.get("role")
+    total_context_value = telemetry["total_context_tokens"]["value"]
+    context_tokens_value = total_context_value
+    if threshold_breached(snapshot, telemetry):
+        context_tokens_value = snapshot["max_context_tokens"]
+    context.update(
+        {
+            "threshold_band": "coordinator_routing_status_readback",
+            "resource_observations": {
+                "context_tokens": {
+                    "provenance": telemetry["total_context_tokens"]["availability"],
+                    "tokens": context_tokens_value,
+                    "source": "runtime_owned_observation_bridge",
+                }
+            },
+        }
+    )
+    if "source_timestamp" not in context:
+        context["source_timestamp"] = packet.get("observed_at")
+    run["context"] = context
+    run["model"] = model or {"name": "gpt-5.5", "reasoning": "medium"}
+    return {
+        "work": work,
+        "execution_run": run,
+        "dispatch_claim": packet.get("dispatch_claim", {}),
+        "existing_dispatch_claims": packet.get("existing_dispatch_claims", []),
+        "active_runs": packet.get("active_runs", []),
+        "requested_route": "interactive_execution" if threshold_breached(snapshot, telemetry) else snapshot.get("allowed_route", "isolated_execution"),
+        "attention_events": packet.get("attention_events", []),
+        "adapter_metadata": {
+            "runtime_binding": "codex",
+            "native_ids_are_adapter_metadata": True,
+            "native_session_id": packet.get("native_session_id"),
+            "coordination_window_id": snapshot.get("window_id"),
+        },
+    }
+
+
+def bridge_decision(packet: dict[str, Any], now: dt.datetime, max_age_hours: int = 12) -> dict[str, Any]:
+    stops: list[str] = []
+    warnings: list[str] = []
+    event_type = validate_event(packet, stops)
+    snapshot = literal_snapshot(packet, stops)
+    capture_result = validate_runtime_capture(packet, now, max_age_hours, stops)
+    telemetry = telemetry_projection(packet, stops)
+    forbidden = control.find_forbidden(packet)
+    if forbidden:
+        stops.append("privacy_exposure")
+        warnings.append("forbidden_content_paths:" + ",".join(forbidden))
+
+    planner_packet = control_plane_packet(packet, snapshot, telemetry)
+    lifecycle = control.plan_preflight(planner_packet, now)
+    if lifecycle["decision"] == "hold_required":
+        stops.extend(lifecycle["stop_conditions"])
+    elif stops:
+        lifecycle["decision"] = "hold_required"
+        lifecycle["selected_route"] = None
+        lifecycle["held_route"] = planner_packet["requested_route"]
+        lifecycle["reason"] = "fail-closed hold required"
+    elif threshold_breached(snapshot, telemetry) and lifecycle["decision"] == "successor_required":
+        lifecycle["reason"] = "low_limit_experiment threshold breach requires automatic successor"
+
+    effective_stops = sorted(set(stops))
+    if effective_stops:
+        decision = "hold_required"
+    else:
+        decision = lifecycle["decision"]
+
+    policy_material_events = list(packet.get("attention_events", [])) if isinstance(packet.get("attention_events"), list) else []
+    if decision == "successor_required":
+        policy_material_events.append(
+            {
+                "category": "context_budget_strategy_change",
+                "reason": "low_limit_experiment successor_required with inherited root budget",
+                "evidence_ref": packet.get("evidence_ref"),
+            }
+        )
+    elif decision == "hold_required":
+        policy_material_events.append(
+            {
+                "category": "acceptance_evidence_conflict",
+                "reason": "runtime observation bridge failed closed",
+                "evidence_ref": packet.get("evidence_ref"),
+            }
+        )
+    summary_packet = {**planner_packet, "attention_events": policy_material_events}
+    work_summary = control.work_summary_projection(summary_packet, now)
+    attention_summary = control.attention_summary_projection(summary_packet, now)
+
+    result = {
+        "bridge_version": BRIDGE_VERSION,
+        "decision": decision,
+        "experiment_label": SNAPSHOT_BAND,
+        "coordinator_lifecycle_model": snapshot.get("coordinator_lifecycle_model"),
+        "coordinator_event_type": event_type,
+        "bounded_meaningful_event": event_type in COORDINATOR_EVENT_TYPES,
+        "effective_control_snapshot": snapshot,
+        "runtime_capture_validation": capture_result,
+        "runtime_owned_observation": capture_result.get("runtime_owned") is True and not effective_stops,
+        "telemetry": telemetry,
+        "lifecycle_evaluator": lifecycle,
+        "work_summary": work_summary,
+        "attention_summary": attention_summary,
+        "raw_receipt_default_suppressed": "TransitionReceipt" in work_summary["default_human_ux_excludes"],
+        "stop_conditions": effective_stops,
+        "warnings": warnings,
+        "mutation_performed": False,
+        "dispatch_performed": False,
+        "external_action_performed": False,
+        "runtime_config_hook_mutation_performed": False,
+    }
+    if decision == "successor_required":
+        result["successor_packet"] = lifecycle.get("successor_packet")
+        result["transition_receipt"] = lifecycle.get("transition_receipt")
+    return result
+
+
+def main() -> int:
+    args = parse_args()
+    result = bridge_decision(read_packet(args.input), utc_now(args.now), args.max_capture_age_hours)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/plan_af18_mvp2_observation_bridge.py
+++ b/scripts/plan_af18_mvp2_observation_bridge.py
@@ -185,11 +185,7 @@ def control_plane_packet(packet: dict[str, Any], snapshot: dict[str, Any], telem
     work = dict(packet.get("work") if isinstance(packet.get("work"), dict) else {})
     run = dict(packet.get("execution_run") if isinstance(packet.get("execution_run"), dict) else {})
     context = dict(run.get("context") if isinstance(run.get("context"), dict) else {})
-    model = dict(run.get("model") if isinstance(run.get("model"), dict) else {})
-    work.setdefault("role", "Coordinator")
     work.setdefault("phase", "mvp2-observation-bridge")
-    run["work_id"] = work.get("work_id")
-    run["role"] = work.get("role")
     total_context_value = telemetry["total_context_tokens"]["value"]
     context_tokens_value = total_context_value
     if threshold_breached(snapshot, telemetry):
@@ -209,7 +205,6 @@ def control_plane_packet(packet: dict[str, Any], snapshot: dict[str, Any], telem
     if "source_timestamp" not in context:
         context["source_timestamp"] = packet.get("observed_at")
     run["context"] = context
-    run["model"] = model or {"name": "gpt-5.5", "reasoning": "medium"}
     return {
         "work": work,
         "execution_run": run,

--- a/scripts/test_af18_mvp2_observation_bridge.py
+++ b/scripts/test_af18_mvp2_observation_bridge.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Focused tests for AF18 MVP-2 runtime-owned observation bridge."""
+
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BRIDGE = ROOT / "scripts" / "plan_af18_mvp2_observation_bridge.py"
+spec = importlib.util.spec_from_file_location("plan_af18_mvp2_observation_bridge", BRIDGE)
+bridge = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(bridge)
+
+NOW = dt.datetime(2026, 7, 29, 8, 30, tzinfo=dt.timezone.utc)
+
+
+def capture(**overrides):
+    base = {
+        "schema_version": 1,
+        "record_id": "capture-451",
+        "captured_at": "2026-07-29T08:20:00Z",
+        "producer": {
+            "producer_type": "runtime_control_surface",
+            "producer_id": "codex-control-surface",
+            "runtime_id": "codex",
+            "capture_session_id": "coord-session-451",
+            "runtime_owned": True,
+            "caller_supplied": False,
+        },
+        "runtime_attestation": {"producer_bound": True, "capture_nonce": "nonce-451"},
+        "route": {
+            "category": "spawn",
+            "support_status": "supported",
+            "requested_envelope": {"model": "gpt-5.5", "reasoning": "medium"},
+            "effective_envelope": {"status": "accepted", "model": "gpt-5.5", "reasoning": "medium"},
+            "category_evidence": {
+                "child_owner": "Coordinator",
+                "isolation_boundary": "coordination_window",
+                "inherited_context_policy": "compact_issue_packet",
+                "budget_anchor": "issue-451",
+            },
+        },
+        "evidence_metadata": {
+            "route_id": "coordinator_internal_route",
+            "target_id": "coord-window-451-a",
+            "cursor": "cursor-451",
+            "budget_anchor": "issue-451",
+            "external_cost_possible": False,
+            "duplicate_owner_detected": False,
+            "evidence_ref": "https://github.com/farmerhunter/agent-foundry/issues/451#runtime-owned-observation",
+        },
+        "privacy": {"contains_prompt_body": False, "redaction": "metadata_only"},
+        "stop_conditions": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def telemetry(total=3200, tool_bytes=300):
+    return {
+        "input_tokens": {"availability": "observed", "value": total, "source": "runtime_usage"},
+        "cached_input_tokens": {"availability": "observed", "value": 0, "source": "runtime_usage"},
+        "output_tokens": {"availability": "observed", "value": 0, "source": "runtime_usage"},
+        "reasoning_tokens": {"availability": "observed", "value": 0, "source": "runtime_usage"},
+        "tool_output_bytes": {"availability": "observed", "value": tool_bytes, "source": "runtime_usage"},
+        "route": "interactive_execution",
+        "transition_reason": "after compact durable readback",
+        "cumulative_work_totals": {
+            "input_tokens": total,
+            "cached_input_tokens": 0,
+            "output_tokens": 0,
+            "reasoning_tokens": 0,
+            "tool_output_bytes": tool_bytes,
+        },
+    }
+
+
+def snapshot(**overrides):
+    base = {
+        "source": "#442 low_limit containment",
+        "version": "af18-451-option-a-literal-v1",
+        "band": "low_limit_experiment",
+        "label": "low_limit_experiment",
+        "coordinator_lifecycle_model": "CoordinatorSession -> CoordinationWindow -> coordination operation",
+        "threshold_band": "coordinator_routing_status_readback",
+        "max_context_tokens": 4000,
+        "max_age_hours": 12,
+        "root_budget_tokens": 7000,
+        "window_id": "coord-window-451-a",
+        "measurement_unavailable_policy": "hold_required",
+        "normal_threshold_breach": "successor_required",
+        "allowed_route": "isolated_execution",
+        "stop_conditions": ["hold_on_missing_observation", "hold_on_external_route", "hold_on_privilege_escalation"],
+    }
+    base.update(overrides)
+    return base
+
+
+def packet(**overrides):
+    base = {
+        "effective_control_snapshot": snapshot(),
+        "coordinator_event_type": "after_compact_durable_readback",
+        "observed_at": "2026-07-29T08:20:00Z",
+        "evidence_ref": "https://github.com/farmerhunter/agent-foundry/issues/451#runtime-owned-observation",
+        "runtime_capture": capture(),
+        "runtime_telemetry": telemetry(),
+        "work": {
+            "work_id": "af18-451",
+            "issue": 451,
+            "issue_anchor": {
+                "issue": 451,
+                "durable_anchor": "https://github.com/farmerhunter/agent-foundry/issues/451",
+                "scope": "mvp2-runtime-owned-observation-bridge",
+                "risk": "high",
+                "acceptance": "runtime-owned low_limit_experiment observation bridge",
+                "human_gates": ["external_side_effect", "runtime_config_mutation", "model_escalation"],
+            },
+            "role": "Coordinator",
+            "objective": "Implement AF18 MVP-2 runtime-owned observation bridge",
+            "stage": "needs:reviewer",
+            "phase": "mvp2-observation-bridge",
+            "current_owner": "Implementer",
+            "root_budget_tokens": 7000,
+            "remaining_budget_tokens": 6600,
+            "durable_anchors": ["https://github.com/farmerhunter/agent-foundry/issues/451"],
+            "stop_conditions": ["hold_on_missing_observation", "hold_on_privacy_boundary"],
+            "material_decisions": ["#451 Option A approved"],
+            "accepted_evidence_refs": [],
+            "material_risk_or_blocker": None,
+            "next_action": "review MVP-2 bridge PR",
+        },
+        "execution_run": {
+            "run_id": "run-451-a",
+            "work_id": "af18-451",
+            "role": "Coordinator",
+            "state": "active",
+            "context": {"source_timestamp": "2026-07-29T08:20:00Z"},
+            "model": {"name": "gpt-5.5", "reasoning": "medium"},
+        },
+        "dispatch_claim": {
+            "idempotency_key": "issue-451-coordinator-mvp2-bridge-v1",
+            "work_id": "af18-451",
+            "role": "Coordinator",
+            "decision_boundary": "issue-451-mvp2",
+            "transition_semantics": "runtime_owned_observation_bridge",
+            "durable_anchor": "https://github.com/farmerhunter/agent-foundry/issues/451",
+            "adapter_metadata": {"native_binding": "codex"},
+        },
+        "existing_dispatch_claims": [],
+        "active_runs": [],
+        "attention_events": [],
+        "native_session_id": "codex-session-metadata-only",
+    }
+    base.update(overrides)
+    return base
+
+
+def decide(value):
+    return bridge.bridge_decision(value, NOW)
+
+
+def expect(name, condition, detail):
+    if not condition:
+        raise AssertionError(f"{name} failed: {detail}")
+
+
+def main() -> int:
+    allowed = decide(packet())
+    expect("literal-low-limit-label", allowed["experiment_label"] == "low_limit_experiment", allowed)
+    expect("runtime-owned-observation", allowed["runtime_owned_observation"] is True, allowed)
+    expect("no-external-action", allowed["external_action_performed"] is False, allowed)
+    expect("no-runtime-config-mutation", allowed["runtime_config_hook_mutation_performed"] is False, allowed)
+    expect("bounded-event", allowed["bounded_meaningful_event"] is True, allowed)
+    expect("raw-receipts-suppressed", allowed["raw_receipt_default_suppressed"] is True, allowed)
+    expect("ordinary-attention-suppressed", allowed["attention_summary"]["human_attention_required"] is False, allowed)
+    expect("work-summary-emitted", allowed["work_summary"]["projection_type"] == "WorkSummary", allowed)
+    expect("attention-summary-emitted", allowed["attention_summary"]["projection_type"] == "AttentionSummary", allowed)
+    expect("native-id-adapter-metadata", allowed["lifecycle_evaluator"]["effective_control_snapshot"]["threshold"]["band"] == "coordinator_routing_status_readback", allowed)
+    expect("within-limit-continues", allowed["decision"] == "allow", allowed)
+
+    breached = decide(packet(runtime_telemetry=telemetry(total=4100)))
+    expect("threshold-breach-successor", breached["decision"] == "successor_required", breached)
+    expect("successor-root-budget-preserved", breached["successor_packet"]["root_budget_tokens"] == 7000, breached)
+    expect("successor-remaining-budget-preserved", breached["successor_packet"]["remaining_budget_tokens"] == 6600, breached)
+    expect("successor-labelled", breached["experiment_label"] == "low_limit_experiment", breached)
+    expect("attention-material-successor", breached["attention_summary"]["human_attention_required"] is True, breached)
+
+    caller_only = decide(packet(runtime_capture=capture(producer={**capture()["producer"], "runtime_owned": False, "caller_supplied": True})))
+    expect("caller-only-fails-closed", caller_only["decision"] == "hold_required", caller_only)
+    expect("caller-only-stop", "caller_only_evidence" in caller_only["stop_conditions"], caller_only)
+
+    forged = decide(packet(runtime_capture=capture(runtime_attestation={"producer_bound": False, "capture_nonce": "nonce-451"})))
+    expect("forged-fails-closed", forged["decision"] == "hold_required", forged)
+    expect("forged-stop", "forged_evidence" in forged["stop_conditions"], forged)
+
+    stale = decide(packet(runtime_capture=capture(captured_at="2026-07-28T08:00:00Z")))
+    expect("stale-fails-closed", stale["decision"] == "hold_required", stale)
+    expect("stale-stop", "stale_evidence" in stale["stop_conditions"], stale)
+
+    missing_capture = decide(packet(runtime_capture={}))
+    expect("missing-capture-fails-closed", missing_capture["decision"] == "hold_required", missing_capture)
+    expect("missing-capture-stop", "missing_runtime_capture" in missing_capture["stop_conditions"], missing_capture)
+
+    unavailable = telemetry()
+    unavailable["input_tokens"] = {"availability": "unavailable", "source": "runtime_usage_unavailable"}
+    unavailable_result = decide(packet(runtime_telemetry=unavailable))
+    expect("unavailable-fails-closed", unavailable_result["decision"] == "hold_required", unavailable_result)
+    expect("unavailable-not-zero", unavailable_result["telemetry"]["total_context_tokens"]["value"] is None, unavailable_result)
+    expect("unavailable-stop", "input_tokens_unavailable" in unavailable_result["stop_conditions"], unavailable_result)
+
+    privacy = decide(packet(prompt="private prompt body"))
+    expect("privacy-fails-closed", privacy["decision"] == "hold_required", privacy)
+    expect("privacy-stop", "privacy_exposure" in privacy["stop_conditions"], privacy)
+
+    unbounded_event = decide(packet(coordinator_event_type="continuous_polling_probe"))
+    expect("unbounded-event-holds", unbounded_event["decision"] == "hold_required", unbounded_event)
+    expect("unbounded-event-stop", "unbounded_or_unknown_lifecycle_event" in unbounded_event["stop_conditions"], unbounded_event)
+
+    bad_snapshot = decide(packet(effective_control_snapshot=snapshot(band="normal", label="normal")))
+    expect("normal-policy-not-invented", bad_snapshot["decision"] == "hold_required", bad_snapshot)
+    expect("literal-snapshot-stop", "literal_snapshot_band_mismatch" in bad_snapshot["stop_conditions"], bad_snapshot)
+
+    material = decide(packet(attention_events=[{"category": "privacy_boundary", "reason": "Privacy boundary", "evidence_ref": "issue-451"}]))
+    expect("material-category-attention", material["attention_summary"]["human_attention_required"] is True, material)
+    expect("material-category-reason", material["attention_summary"]["items"][0]["category"] == "privacy_boundary", material)
+
+    print("af18 mvp2 observation bridge tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_af18_mvp2_observation_bridge.py
+++ b/scripts/test_af18_mvp2_observation_bridge.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import copy
 import datetime as dt
 import importlib.util
 from pathlib import Path
@@ -181,6 +182,32 @@ def main() -> int:
     expect("attention-summary-emitted", allowed["attention_summary"]["projection_type"] == "AttentionSummary", allowed)
     expect("native-id-adapter-metadata", allowed["lifecycle_evaluator"]["effective_control_snapshot"]["threshold"]["band"] == "coordinator_routing_status_readback", allowed)
     expect("within-limit-continues", allowed["decision"] == "allow", allowed)
+
+    missing_model_packet = copy.deepcopy(packet())
+    del missing_model_packet["execution_run"]["model"]
+    missing_model = decide(missing_model_packet)
+    expect("missing-run-model-fails-closed", missing_model["decision"] == "hold_required", missing_model)
+    expect("missing-run-model-stop", "missing_execution_run_model" in missing_model["stop_conditions"], missing_model)
+    expect("unknown-model-stop", "missing_or_unknown_model" in missing_model["stop_conditions"], missing_model)
+
+    mismatched_work_id_packet = copy.deepcopy(packet())
+    mismatched_work_id_packet["execution_run"]["work_id"] = "af18-451-other"
+    mismatched_work_id = decide(mismatched_work_id_packet)
+    expect("mismatched-run-work-id-fails-closed", mismatched_work_id["decision"] == "hold_required", mismatched_work_id)
+    expect("mismatched-run-work-id-stop", "run_work_role_mismatch" in mismatched_work_id["stop_conditions"], mismatched_work_id)
+
+    mismatched_role_packet = copy.deepcopy(packet())
+    mismatched_role_packet["execution_run"]["role"] = "Reviewer"
+    mismatched_role = decide(mismatched_role_packet)
+    expect("mismatched-run-role-fails-closed", mismatched_role["decision"] == "hold_required", mismatched_role)
+    expect("mismatched-run-role-stop", "run_work_role_mismatch" in mismatched_role["stop_conditions"], mismatched_role)
+
+    missing_work_role_packet = copy.deepcopy(packet())
+    del missing_work_role_packet["work"]["role"]
+    missing_work_role = decide(missing_work_role_packet)
+    expect("missing-work-role-fails-closed", missing_work_role["decision"] == "hold_required", missing_work_role)
+    expect("missing-work-role-stop", "missing_work_role" in missing_work_role["stop_conditions"], missing_work_role)
+    expect("missing-work-role-mismatch-stop", "run_work_role_mismatch" in missing_work_role["stop_conditions"], missing_work_role)
 
     breached = decide(packet(runtime_telemetry=telemetry(total=4100)))
     expect("threshold-breach-successor", breached["decision"] == "successor_required", breached)


### PR DESCRIPTION
## Verdict
Implemented #451 MVP-2 runtime-owned controlled observation bridge as a bounded `low_limit_experiment` using a literal `EffectiveControlSnapshot`.

## Exact base/head
- Base: `codex/af18-collaboration-cost-policy-integration` at `2a737c64740fa1a680ae2ca723e9f785be3e70cd`
- Head: `22df1bd646a741054e5880047cdf795e03970a5e`

## Implementation summary
- Added `scripts/plan_af18_mvp2_observation_bridge.py`.
- Requires literal snapshot source/version/band: `#442 low_limit containment`, `af18-451-option-a-literal-v1`, `low_limit_experiment`.
- Accepts only bounded Coordinator lifecycle events; unknown/unbounded polling-like events fail closed.
- Validates #447-compatible runtime-owned capture via `validate_runtime_owned_capture.py`.
- Converts runtime-owned telemetry availability (`observed|estimated|unavailable`) into #450 lifecycle evaluator input.
- Keeps Codex/native ids as adapter metadata; Core route remains portable semantic execution mode.
- Normal low_limit threshold breach maps to automatic `successor_required` with inherited Work/root budget.
- Emits `WorkSummary` and `AttentionSummary`; ordinary raw receipts remain suppressed from default Human UX.
- Performs no dispatch, external action, runtime/config/hook mutation, activation, publication, or #452 dogfood.

## Verification
- `python3 scripts/test_af18_mvp2_observation_bridge.py` -> passed
- `python3 scripts/test_af18_mvp1_control.py` -> passed
- `python3 scripts/test_runtime_owned_capture.py` -> passed
- `python3 scripts/test_collaboration_route_planner.py` -> passed
- `python3 scripts/plan_af18_mvp2_observation_bridge.py --help` -> passed
- `python3 scripts/plan_af18_mvp1_control.py --help` -> passed
- `python3 scripts/validate_runtime_owned_capture.py --help` -> passed
- `python3 -m py_compile scripts/plan_af18_mvp2_observation_bridge.py scripts/test_af18_mvp2_observation_bridge.py scripts/plan_af18_mvp1_control.py scripts/validate_runtime_owned_capture.py` -> passed
- `git diff --check` -> passed
- `git diff --cached --check` -> passed before commit

## Negative/acceptance evidence covered
- caller-only, forged, stale, and missing runtime capture fail closed;
- unavailable measurement fails closed and never counts as zero;
- normal low_limit threshold breach yields `successor_required` and preserves root/remaining budget;
- literal snapshot mismatch rejects invented normal policy labels;
- only material attention categories enter `AttentionSummary`; ordinary receipt output remains suppressed from default Human UX;
- privacy exposure fails closed;
- unbounded/unknown lifecycle events fail closed.

## Residual risk
This remains a planner/control bridge proof. It does not execute live runtime dispatch, start #452, mutate runtime/config/hooks/custom agents, publish Vault/generated adapters, release/tag, merge to main, or activate AF18.
