### PR TITLE
docs: clarify AF18 role conversation lifecycle

### DIFF
--- a/docs/multi-agent-collaboration.md
+++ b/docs/multi-agent-collaboration.md
@@ -79,6 +79,42 @@ branches.
 Implementer 做 scoped change，Tester 提供测试证据，Reviewer 做独立审查，Human 做真实
 产品/风险决策，Harvester 把经验整理成候选资产。
 
+## Human-Facing Role Conversations
+
+Human collaboration needs a stable way to return to Architect, Coordinator,
+Reviewer, or another role for questions, design discussion, interruption, and
+decision making. That need is distinct from a bounded implementation or review
+run.
+
+Use this model:
+
+```text
+RoleConversation -> ContextWindow -> role operation
+Issue -> Work -> ExecutionRun
+```
+
+`RoleConversation` is the stable Human-facing role relationship. A `Work` is a
+bounded delivery unit linked to an Issue. A conversation can discuss several
+Issues without silently becoming a Work; when a request needs execution,
+evidence, acceptance, or routing, it binds or creates the appropriate Work.
+
+The active `ContextWindow` may be replaced to avoid unbounded context growth.
+The successor receives a compact capsule and durable anchors, not full chat or
+tool history. The Human continues to address the same role. A refresh normally
+does not require approval, but a continuity notice is required when the active
+window changes; missing anchors, evidence conflict, escalation, or unavailable
+measurement must hold instead.
+
+`RoleHub` is one optional project-level directory of current role conversations,
+Work summaries, and material attention. It is not a replacement for role
+conversation, a per-role hub, an execution controller, or a source of truth.
+GitHub issue/PR/comment state remains durable authority.
+
+**中文要点：** Human 需要持续与 Architect、Coordinator 等角色对话；这不等同于让
+同一个物理 thread 无限增长。`RoleConversation` 保持角色身份，`ContextWindow` 可以
+自动 successor。RoleHub 只有一个项目级入口，负责投影和跳转，不取代角色对话或 GitHub
+权威状态。
+
 ## Standard Flow
 
 | Step | Owner | What happens | Exit signal |

--- a/docs/roadmap/milestones-af16-af18.md
+++ b/docs/roadmap/milestones-af16-af18.md
@@ -85,12 +85,22 @@ AF18 Core owns these portable concepts:
 - `WorkSummary`: compact Human-facing projection of current objective, owner, decisions, evidence, risk, and next action.
 - `AttentionSummary`: Human-facing projection only for material attention events.
 - Resource observations with `observed`, `estimated`, or `unavailable` provenance; unavailable is never zero.
+- `RoleConversation`: a stable Human-facing relationship to one role.
+- `ContextWindow`: a bounded context within a `RoleConversation`, joined to its
+  successor by a privacy-safe capsule rather than by full chat history.
+- `RoleHub`: one optional project-level projection and entry directory for all
+  roles. It is not a role-specific thread, policy authority, telemetry store,
+  or execution controller.
 
-Coordinator internals are modeled separately:
+Every role uses the same Human-continuity model:
 
 ```text
-CoordinatorSession -> CoordinationWindow -> coordination operation
+RoleConversation -> ContextWindow -> role operation
 ```
+
+For Coordinator, the role operation is a coordination operation; the
+`CoordinatorSession` / `CoordinationWindow` names describe that specialization,
+not a second competing lifecycle. A RoleConversation may span many Issues.
 
 Project work remains:
 
@@ -98,14 +108,26 @@ Project work remains:
 Issue -> Work -> ExecutionRun
 ```
 
-Do not force every Coordinator operation to become one Human-visible Work.
+Do not force every role operation to become one Human-visible Work. A Work is
+created or bound only when an Issue contract requires bounded execution,
+evidence, acceptance, or routing.
+
+The Core defines the continuity semantics, capsule exclusions, successor
+relationship, and state invariants. An adapter measures context and maps a
+ContextWindow to a native mechanism. For Codex, a context refresh may require
+creating a successor thread, passing the capsule plus durable anchors,
+confirming it is usable, marking the predecessor `superseded`, and repointing
+the RoleHub entry. The predecessor is not deleted or blindly archived. If an
+adapter cannot perform that transition, it must expose one recovery path rather
+than pretend the old thread has lost its history.
 
 ### AF18 Policy Layers
 
 Do not collapse policy layers:
 
 - Current `low_limit` is emergency containment and readback protection.
-- Future resource profiles such as economy/normal/performance require dogfood calibration and Human policy freeze.
+- No named normal operating modes or default thresholds are approved yet.
+  Dogfood calibration and a Human policy-freeze decision must determine them.
 - `EffectiveControlSnapshot` records the exact source/version/band, window/root-budget constraints, measurement rules, and stop conditions used by a released literal contract.
 - Runtime receipts record facts; they do not self-tune policy.
 
@@ -124,21 +146,20 @@ Current canonical path:
 | Runtime-owned capture | #436 / #446 / #447 | Superseded input to MVP path | Runtime-owned observation evidence informed #449/#451. |
 | Integrated MVP scope | #449 | Accepted and closed | Defines bounded MVP path, portability, Human attention, and roadmap to calibration/freeze. |
 | MVP-1 control plane | #450 / PR #453 | Completed | Static/read-only portable control-plane and Human summary proof. |
-| MVP-2 observation bridge | #451 | Current Human gate | Release only with literal `EffectiveControlSnapshot`; Option A is low_limit experiment, not normal policy. |
-| MVP-3 dogfood | #452 | Held | Starts only after #451 is accepted. |
-| Post-MVP operational readiness | #454 | Dependency-held | Starts only after #450/#451/#452 have independent acceptance evidence; reconciles calibration, policy freeze, adapter enablement, Human UX, recovery/rollback, limited rollout, and final readiness. |
+| MVP-2 observation bridge | #451 / PR #455 | Completed low-limit experiment | Proves bounded runtime-owned observation/lifecycle bridge; it does not establish normal operating thresholds or activation readiness. |
+| MVP-3 dogfood | #452 | Held pending literal release | May start only under its bounded contract after #451 acceptance; it supplies evidence, not automatic policy freeze or activation. |
+| Post-MVP operational readiness | #454 | Dependency-held | Starts only after #450/#451/#452 have independent acceptance evidence; reconciles calibration, policy freeze, adapter enablement, RoleConversation/RoleHub UX, recovery/rollback, limited rollout, and final readiness. |
 | Parent Epic/readiness | #418 / #426 / #427 | Held | Final publish/runtime activation/readiness remain later gates. |
 
-### AF18 Current Active Gate
+### AF18 Next Gated Work
 
-Current active decision is #451:
+The next dependency-held work is #452. Its release must name the exact bounded
+route, `EffectiveControlSnapshot`, root budget, run cap, measurements, stop
+conditions, and independent acceptance evidence. #451's low-limit experiment
+does not authorize a normal operating policy or final activation.
 
-- Option A: release #451 as a bounded `low_limit_experiment` with literal `EffectiveControlSnapshot`.
-- Option B: hold #451 until a normal operating policy exists after dogfood calibration and Human freeze.
+Until #452 is explicitly released and accepted:
 
-Until #451 is resolved:
-
-- Do not release #452.
 - Do not release #454.
 - Do not resume #435's old pre-reset implementation route.
 - Do not treat #442 values as normal Coordinator/session policy.
@@ -156,7 +177,7 @@ Older AF18 issues may be closed or superseded only after compact evidence commen
 
 - #435 is stale as an active implementation route and should not keep `needs:implementer`.
 - #444/#445/#433/#436/#432 need narrow closure/supersession packets before closing.
-- #426/#427/#451/#452/#454/#418 remain open gates.
+- #426/#427/#452/#454/#418 remain open gates; #451 is complete evidence input.
 
 ### AF18 Acceptance Criteria
 

--- a/workflows/coordinate-agent-work.md
+++ b/workflows/coordinate-agent-work.md
@@ -40,6 +40,10 @@ The portable Core owns:
 - `SuccessorPacket`: compact cursor-only continuation packet for a successor
   context;
 - `TransitionReceipt`: privacy-safe control-plane evidence for a transition;
+- `RoleConversation`: stable Human-facing relationship to a role;
+- `ContextWindow`: bounded context inside that relationship, with a compact
+  successor capsule instead of full-history transfer;
+- `RoleHub`: optional project-level projection and role-entry directory;
 - resource observations with `observed`, `estimated`, or `unavailable`
   provenance;
 - budget inheritance, fail-closed measurement policy, duplicate prevention, and
@@ -54,9 +58,9 @@ Do not collapse AF18 policy layers:
 
 - Current `low_limit` is emergency containment and readback protection. It is
   not the normal Coordinator/session operating policy.
-- Future versioned operating policy, including resource profiles such as
-  economy/normal/performance, is only proposed after dogfood calibration and a
-  Human policy-freeze decision.
+- No named normal operating modes or default thresholds are approved yet.
+  A future versioned operating policy is proposed only after dogfood calibration
+  and a Human policy-freeze decision.
 - `EffectiveControlSnapshot` records the exact approved source/version/band,
   window/root-budget constraints, measurement rules, and stop conditions used
   by a released literal contract.
@@ -66,13 +70,18 @@ Do not collapse AF18 policy layers:
 If an AF18 experiment uses #442 values, evidence must label that band as
 `low_limit_experiment`, not normal operation.
 
-## AF18 Coordinator Lifecycle
+## AF18 Role Conversation And Coordinator Lifecycle
 
-Coordinator internals have their own lifecycle:
+Every role has a stable Human-facing conversation relationship:
 
 ```text
-CoordinatorSession -> CoordinationWindow -> coordination operation
+RoleConversation -> ContextWindow -> role operation
 ```
+
+Coordinator is the specialization whose role operation is a coordination
+operation; `CoordinatorSession` and `CoordinationWindow` are names for that
+specialization, not a separate lifecycle model. The logical role remains
+stable while an adapter may replace its physical context window.
 
 This is separate from the project object hierarchy:
 
@@ -80,13 +89,19 @@ This is separate from the project object hierarchy:
 Issue -> Work -> ExecutionRun
 ```
 
-A Coordinator window may safely span multiple issues without becoming one
-Human-visible Work per coordination operation. Coordinator lifecycle evaluation
+A role conversation may safely span multiple issues without becoming one
+Human-visible Work per role operation. A Coordinator lifecycle evaluation
 should happen only at bounded meaningful events: before new Issue/Work routing,
 after compact durable readback, after materially increased input/tool output,
 before or after dispatch/callback, before Human/HDC output, and on policy,
 evidence, budget, or measurement anomalies. Continuous Coordinator polling is
 not part of AF18 MVP.
+
+The Core owns the capsule, successor, privacy, and state semantics. The adapter
+owns measurement and native thread/session behavior. In Codex, a real refresh
+may require a successor thread, capsule transfer, readiness confirmation, and a
+`superseded` predecessor. Do not delete or automatically archive the old thread.
+If a successor cannot be created or linked, hold with one recovery path.
 
 ## AF18 Human Attention
 
@@ -96,6 +111,11 @@ observation feeds. Attention is reserved for material HDC, risk, privacy,
 external side effect, model/reasoning escalation, context/budget policy action,
 retry/claim anomaly, evidence conflict, phase completion, and stale/no-owner
 events.
+
+RoleHub is one project-level optional projection: it links each role to its
+current RoleConversation and summarizes current Work and material attention. It
+does not replace direct Human-to-role conversation, create a RoleHub per role,
+or make raw receipts the default feed.
 
 ## Non-Scope
 


### PR DESCRIPTION
## Summary

Clarifies the Human-facing AF18 role model without expanding runtime scope.

- Defines `RoleConversation`, `ContextWindow`, and one project-level RoleHub.
- Separates role conversation from `Issue -> Work -> ExecutionRun`.
- Describes portable Core versus Codex adapter responsibility for successor context windows.
- Corrects documentation that implied unapproved named normal operating modes.
- Updates the roadmap after #451 / PR #455 completion and keeps #452/#454 dependency-held.

## Verification

- `git diff --check`
- `python3 scripts/check_consistency.py`

## Boundaries

Docs-only. No schema/runtime/config/hook, RoleHub implementation, activation, policy freeze, local-ledger, or issue release changes.
