### PR TITLE
feat: add AF18 Codex telemetry collector

### DIFF
--- a/schemas/af18-calibration-protocol.schema.yaml
+++ b/schemas/af18-calibration-protocol.schema.yaml
@@ -11,7 +11,7 @@ properties:
     type: string
     minLength: 1
   collection_mode:
-    enum: [fixture, manual_adapter_export]
+    enum: [fixture, manual_adapter_export, codex_jsonl_export]
   samples:
     type: array
     minItems: 1
@@ -77,9 +77,10 @@ $defs:
           measurement_window:
             type: object
             additionalProperties: false
-            required: [definition]
+            required: [definition, fixed_execution_window]
             properties:
               definition: {type: string, minLength: 1}
+              fixed_execution_window: {const: true}
           root_budget_unit: {const: tokens}
           anchor_type: {type: string, minLength: 1}
       work_id: {type: string, minLength: 1}
@@ -115,7 +116,7 @@ $defs:
         required: [source, collection_method, captured_at, evidence_anchor, observation_kind]
         properties:
           source: {type: string, minLength: 1}
-          collection_method: {enum: [fixture, manual_adapter_export]}
+          collection_method: {enum: [fixture, manual_adapter_export, codex_jsonl_export]}
           captured_at: {type: string, format: date-time}
           evidence_anchor: {type: string, pattern: '^https://github\\.com/'}
           observation_kind: {enum: [observed, counterfactual]}
@@ -197,6 +198,11 @@ $defs:
         minItems: 1
         uniqueItems: true
         items: {type: string, minLength: 1}
+      invocation_ids:
+        type: array
+        minItems: 1
+        uniqueItems: true
+        items: {type: string, minLength: 1}
     allOf:
       - if:
           properties: {availability: {const: unavailable}}
@@ -224,6 +230,8 @@ $defs:
     allOf:
       - $ref: '#/$defs/measurement'
       - oneOf:
+          - properties:
+              availability: {const: unavailable}
           - required: [derived_total_component_ids, observation_basis]
             properties:
               observation_basis: {const: derived}

--- a/scripts/collect_af18_codex_telemetry.py
+++ b/scripts/collect_af18_codex_telemetry.py
@@ -18,9 +18,9 @@ assert spec.loader is not None
 sys.modules[spec.name] = calibration
 spec.loader.exec_module(calibration)
 
-EVENT_KEYS = {"type", "invocation_id", "completed_at", "usage"}
+EVENT_KEYS = {"type", "invocation_id", "execution_id", "completed_at", "usage"}
 USAGE_KEYS = {"input_tokens", "cached_input_tokens", "output_tokens", "reasoning_tokens"}
-METADATA_KEYS = {"schema_version", "protocol_version", "sample", "captured_at", "evidence_anchor", "invocation_ids"}
+METADATA_KEYS = {"schema_version", "protocol_version", "sample", "captured_at", "evidence_anchor", "invocation_ids", "execution_id", "execution_window"}
 RAW_KEYS = calibration.FORBIDDEN_KEYS | {"response", "request", "event", "error", "model", "instructions"}
 
 
@@ -54,15 +54,22 @@ def observed(name: str, value: int, captured_at: str) -> dict[str, Any]:
     return {"observation_id": f"codex-jsonl-{name}", "availability": "observed", "value": value, "unit": "tokens", "source": "codex_jsonl_completed_export", "observed_at": captured_at}
 
 
-def read_events(path: str, invocation_ids: list[str]) -> list[dict[str, Any]]:
+def read_events(path: str, invocation_ids: list[str], execution_id: str, execution_window: dict[str, str]) -> list[dict[str, Any]]:
+    window_start = calibration.utc(execution_window["started_at"])
+    window_end = calibration.utc(execution_window["ended_at"])
+    if window_end < window_start:
+        raise ValueError("invalid_execution_window")
     events: dict[str, dict[str, Any]] = {}
     for line_number, line in enumerate(Path(path).read_text(encoding="utf-8").splitlines(), 1):
         if not line.strip():
             continue
         value = json.loads(line)
         reject_unknown(value, EVENT_KEYS, "completed_event")
-        if value.get("type") != "codex.completed" or not isinstance(value.get("invocation_id"), str) or not value["invocation_id"] or not isinstance(value.get("completed_at"), str):
+        if value.get("type") != "codex.completed" or not isinstance(value.get("invocation_id"), str) or not value["invocation_id"] or value.get("execution_id") != execution_id or not isinstance(value.get("completed_at"), str):
             raise ValueError(f"invalid_completed_event:{line_number}")
+        completed_at = calibration.utc(value["completed_at"])
+        if not window_start <= completed_at <= window_end:
+            raise ValueError(f"completed_event_outside_execution_window:{line_number}")
         usage = value.get("usage")
         reject_unknown(usage, USAGE_KEYS, "usage")
         if any(not isinstance(usage.get(key), int) or isinstance(usage.get(key), bool) or usage[key] < 0 for key in ("input_tokens", "output_tokens")):
@@ -89,6 +96,16 @@ def collect(metadata: dict[str, Any], events: list[dict[str, Any]]) -> dict[str,
         raise ValueError("invalid_observed_sample_metadata")
     if calibration.forbidden_paths(sample):
         raise ValueError("raw_content_or_unknown_field_rejected")
+    execution_id = metadata.get("execution_id")
+    execution_window = metadata.get("execution_window")
+    if not isinstance(execution_id, str) or not execution_id:
+        raise ValueError("invalid_execution_id")
+    if not isinstance(execution_window, dict) or set(execution_window) != {"started_at", "ended_at"}:
+        raise ValueError("invalid_execution_window")
+    if sample.get("execution_id") != execution_id or sample.get("anchors", {}).get("execution") != metadata.get("evidence_anchor"):
+        raise ValueError("execution_anchor_binding_mismatch")
+    if sample.get("scenario", {}).get("measurement_window", {}).get("fixed_execution_window") is not True:
+        raise ValueError("fixed_execution_window_required")
     captured_at = metadata.get("captured_at")
     if not isinstance(captured_at, str) or not calibration.is_anchor(metadata.get("evidence_anchor")):
         raise ValueError("invalid_metadata_provenance")
@@ -115,7 +132,7 @@ def main() -> int:
     try:
         metadata = read_json(args.metadata)
         invocation_ids = metadata.get("invocation_ids")
-        events = read_events(args.input, invocation_ids if isinstance(invocation_ids, list) else [])
+        events = read_events(args.input, invocation_ids if isinstance(invocation_ids, list) else [], metadata.get("execution_id", ""), metadata.get("execution_window", {}))
         output = json.dumps(collect(metadata, events), indent=2, sort_keys=True) + "\n"
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         print(json.dumps({"error": str(exc), "mutation_performed": False}, sort_keys=True), file=sys.stderr)

--- a/scripts/collect_af18_codex_telemetry.py
+++ b/scripts/collect_af18_codex_telemetry.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Export privacy-safe AF18 calibration evidence from completed Codex JSONL."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+CALIBRATION = ROOT / "scripts" / "run_af18_calibration.py"
+spec = importlib.util.spec_from_file_location("af18_calibration", CALIBRATION)
+calibration = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = calibration
+spec.loader.exec_module(calibration)
+
+EVENT_KEYS = {"type", "invocation_id", "completed_at", "usage"}
+USAGE_KEYS = {"input_tokens", "cached_input_tokens", "output_tokens", "reasoning_tokens"}
+METADATA_KEYS = {"schema_version", "protocol_version", "sample", "captured_at", "evidence_anchor", "invocation_ids"}
+RAW_KEYS = calibration.FORBIDDEN_KEYS | {"response", "request", "event", "error", "model", "instructions"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, help="Completed-event JSONL input.")
+    parser.add_argument("--metadata", required=True, help="Explicit allowlisted metadata JSON.")
+    parser.add_argument("--output", help="Output JSON path; stdout is used otherwise.")
+    return parser.parse_args()
+
+
+def reject_unknown(value: Any, allowed: set[str], label: str) -> None:
+    if not isinstance(value, dict) or set(value) - allowed:
+        raise ValueError(f"invalid_{label}_fields")
+    if calibration.forbidden_paths(value) or any(key.lower() in RAW_KEYS for key in value):
+        raise ValueError("raw_content_or_unknown_field_rejected")
+
+
+def read_json(path: str) -> dict[str, Any]:
+    value = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("metadata_must_be_object")
+    return value
+
+
+def unavailable(name: str) -> dict[str, Any]:
+    return {"observation_id": f"codex-jsonl-{name}", "availability": "unavailable", "value": None, "unit": "tokens" if "tokens" in name else "count" if name.endswith("count") else "bytes" if name.endswith("bytes") else "hours" if name.endswith("hours") else "seconds", "source": "codex_jsonl_completed_export", "observed_at": None, "reason": "not_exposed"}
+
+
+def observed(name: str, value: int, captured_at: str) -> dict[str, Any]:
+    return {"observation_id": f"codex-jsonl-{name}", "availability": "observed", "value": value, "unit": "tokens", "source": "codex_jsonl_completed_export", "observed_at": captured_at}
+
+
+def read_events(path: str, invocation_ids: list[str]) -> list[dict[str, Any]]:
+    events: dict[str, dict[str, Any]] = {}
+    for line_number, line in enumerate(Path(path).read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        value = json.loads(line)
+        reject_unknown(value, EVENT_KEYS, "completed_event")
+        if value.get("type") != "codex.completed" or not isinstance(value.get("invocation_id"), str) or not value["invocation_id"] or not isinstance(value.get("completed_at"), str):
+            raise ValueError(f"invalid_completed_event:{line_number}")
+        usage = value.get("usage")
+        reject_unknown(usage, USAGE_KEYS, "usage")
+        if any(not isinstance(usage.get(key), int) or isinstance(usage.get(key), bool) or usage[key] < 0 for key in ("input_tokens", "output_tokens")):
+            raise ValueError(f"missing_completed_turn_usage:{line_number}")
+        if usage.get("cached_input_tokens") is not None and (not isinstance(usage["cached_input_tokens"], int) or usage["cached_input_tokens"] < 0 or usage["cached_input_tokens"] > usage["input_tokens"]):
+            raise ValueError(f"invalid_cached_input_tokens:{line_number}")
+        if usage.get("reasoning_tokens") is not None and (not isinstance(usage["reasoning_tokens"], int) or usage["reasoning_tokens"] < 0 or usage["reasoning_tokens"] > usage["output_tokens"]):
+            raise ValueError(f"invalid_reasoning_tokens:{line_number}")
+        if value["invocation_id"] in events:
+            raise ValueError(f"duplicate_invocation_id:{value['invocation_id']}")
+        events[value["invocation_id"]] = value
+    if set(events) != set(invocation_ids):
+        raise ValueError("invocation_ids_must_match_completed_jsonl")
+    return [events[item] for item in invocation_ids]
+
+
+def collect(metadata: dict[str, Any], events: list[dict[str, Any]]) -> dict[str, Any]:
+    reject_unknown(metadata, METADATA_KEYS, "metadata")
+    invocation_ids = metadata.get("invocation_ids")
+    if not isinstance(invocation_ids, list) or not invocation_ids or any(not isinstance(item, str) or not item for item in invocation_ids) or len(invocation_ids) != len(set(invocation_ids)):
+        raise ValueError("invalid_invocation_ids")
+    sample = metadata.get("sample")
+    if not isinstance(sample, dict) or "resources" in sample or "provenance" in sample or sample.get("variant") == "B":
+        raise ValueError("invalid_observed_sample_metadata")
+    if calibration.forbidden_paths(sample):
+        raise ValueError("raw_content_or_unknown_field_rejected")
+    captured_at = metadata.get("captured_at")
+    if not isinstance(captured_at, str) or not calibration.is_anchor(metadata.get("evidence_anchor")):
+        raise ValueError("invalid_metadata_provenance")
+    totals = {key: sum(event["usage"].get(key, 0) for event in events) for key in USAGE_KEYS}
+    resources = {name: unavailable(name) for name in calibration.REQUIRED_RESOURCES}
+    for name in ("input_tokens", "output_tokens"):
+        resources[name] = observed(name, totals[name], captured_at)
+    for name in ("cached_input_tokens", "reasoning_tokens"):
+        if all(name in event["usage"] for event in events):
+            resources[name] = observed(name, totals[name], captured_at)
+    resources["cumulative_resource_tokens"] = {"observation_id": "codex-jsonl-cumulative_resource_tokens", "availability": "observed", "value": totals["input_tokens"] + totals["output_tokens"], "unit": "tokens", "source": "codex_jsonl_completed_export", "observed_at": captured_at, "observation_basis": "derived", "derived_total_component_ids": [resources["input_tokens"]["observation_id"], resources["output_tokens"]["observation_id"]], "invocation_ids": invocation_ids}
+    output_sample = dict(sample)
+    output_sample["provenance"] = {"source": "codex_jsonl_completed_export", "collection_method": "codex_jsonl_export", "captured_at": captured_at, "evidence_anchor": metadata["evidence_anchor"], "observation_kind": "observed"}
+    output_sample["resources"] = resources
+    packet = {"schema_version": metadata.get("schema_version"), "protocol_version": metadata.get("protocol_version"), "collection_mode": "codex_jsonl_export", "samples": [output_sample]}
+    result = calibration.run(packet, calibration.utc(captured_at), 24 * 365 * 10)
+    if result["invalid_evidence"]:
+        raise ValueError("invalid_calibration_export:" + ",".join(result["invalid_evidence"][0]["errors"]))
+    return packet
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        metadata = read_json(args.metadata)
+        invocation_ids = metadata.get("invocation_ids")
+        events = read_events(args.input, invocation_ids if isinstance(invocation_ids, list) else [])
+        output = json.dumps(collect(metadata, events), indent=2, sort_keys=True) + "\n"
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(json.dumps({"error": str(exc), "mutation_performed": False}, sort_keys=True), file=sys.stderr)
+        return 2
+    if args.output:
+        Path(args.output).write_text(output, encoding="utf-8")
+    else:
+        sys.stdout.write(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fixtures/af18_calibration/representative-fixture.json
+++ b/scripts/fixtures/af18_calibration/representative-fixture.json
@@ -25,7 +25,8 @@
           "python3"
         ],
         "measurement_window": {
-          "definition": "execution-to-terminal"
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
         },
         "root_budget_unit": "tokens",
         "anchor_type": "issue"
@@ -182,26 +183,21 @@
           "unit": "tokens",
           "source": "fixture",
           "observed_at": "2026-07-29T08:00:00Z",
-          "observation_basis": "derived",
-          "derived_total_component_ids": [
-            "A-0-input_tokens",
-            "A-0-cached_input_tokens"
-          ]
+          "observation_basis": "independent_observed"
         },
         "cumulative_resource_tokens": {
           "observation_id": "A-0-cumulative_resource_tokens",
           "availability": "observed",
-          "value": 300,
+          "value": 140,
           "unit": "tokens",
           "source": "fixture",
           "observed_at": "2026-07-29T08:00:00Z",
           "observation_basis": "derived",
           "derived_total_component_ids": [
             "A-0-input_tokens",
-            "A-0-cached_input_tokens",
-            "A-0-output_tokens",
-            "A-0-reasoning_tokens"
-          ]
+            "A-0-output_tokens"
+          ],
+          "invocation_ids": ["fixture-invocation-A"]
         }
       }
     },
@@ -227,7 +223,8 @@
           "python3"
         ],
         "measurement_window": {
-          "definition": "execution-to-terminal"
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
         },
         "root_budget_unit": "tokens",
         "anchor_type": "issue"
@@ -384,26 +381,21 @@
           "unit": "tokens",
           "source": "fixture-counterfactual",
           "observed_at": "2026-07-29T08:00:00Z",
-          "observation_basis": "derived",
-          "derived_total_component_ids": [
-            "B-0-input_tokens",
-            "B-0-cached_input_tokens"
-          ]
+          "observation_basis": "independent_observed"
         },
         "cumulative_resource_tokens": {
           "observation_id": "B-0-cumulative_resource_tokens",
           "availability": "estimated",
-          "value": 300,
+          "value": 140,
           "unit": "tokens",
           "source": "fixture-counterfactual",
           "observed_at": "2026-07-29T08:00:00Z",
           "observation_basis": "derived",
           "derived_total_component_ids": [
             "B-0-input_tokens",
-            "B-0-cached_input_tokens",
-            "B-0-output_tokens",
-            "B-0-reasoning_tokens"
-          ]
+            "B-0-output_tokens"
+          ],
+          "invocation_ids": ["fixture-invocation-B"]
         }
       }
     },
@@ -429,7 +421,8 @@
           "python3"
         ],
         "measurement_window": {
-          "definition": "execution-to-terminal"
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
         },
         "root_budget_unit": "tokens",
         "anchor_type": "issue"
@@ -586,26 +579,21 @@
           "unit": "tokens",
           "source": "fixture",
           "observed_at": "2026-07-29T08:00:00Z",
-          "observation_basis": "derived",
-          "derived_total_component_ids": [
-            "C-0-input_tokens",
-            "C-0-cached_input_tokens"
-          ]
+          "observation_basis": "independent_observed"
         },
         "cumulative_resource_tokens": {
           "observation_id": "C-0-cumulative_resource_tokens",
           "availability": "observed",
-          "value": 300,
+          "value": 140,
           "unit": "tokens",
           "source": "fixture",
           "observed_at": "2026-07-29T08:00:00Z",
           "observation_basis": "derived",
           "derived_total_component_ids": [
             "C-0-input_tokens",
-            "C-0-cached_input_tokens",
-            "C-0-output_tokens",
-            "C-0-reasoning_tokens"
-          ]
+            "C-0-output_tokens"
+          ],
+          "invocation_ids": ["fixture-invocation-C"]
         }
       }
     }

--- a/scripts/run_af18_calibration.py
+++ b/scripts/run_af18_calibration.py
@@ -259,6 +259,18 @@ def validate_sample(sample: Any, packet: dict[str, Any], now: dt.datetime, max_a
         if len(observation_ids) != len(set(observation_ids)):
             errors.append("duplicate_resource_observation_id")
         known_ids = set(observation_ids)
+        input_item = normalized_resources.get("input_tokens", {})
+        cached_item = normalized_resources.get("cached_input_tokens", {})
+        output_item = normalized_resources.get("output_tokens", {})
+        reasoning_item = normalized_resources.get("reasoning_tokens", {})
+        if (input_item.get("availability") != "unavailable" and cached_item.get("availability") != "unavailable"
+                and isinstance(input_item.get("value"), (int, float)) and isinstance(cached_item.get("value"), (int, float))
+                and cached_item["value"] > input_item["value"]):
+            errors.append("cached_input_tokens_exceeds_input_tokens")
+        if (output_item.get("availability") != "unavailable" and reasoning_item.get("availability") != "unavailable"
+                and isinstance(output_item.get("value"), (int, float)) and isinstance(reasoning_item.get("value"), (int, float))
+                and reasoning_item["value"] > output_item["value"]):
+            errors.append("reasoning_tokens_exceeds_output_tokens")
         for name in DERIVED_TOTALS:
             item = normalized_resources.get(name, {})
             component_ids = item.get("derived_total_component_ids")

--- a/scripts/run_af18_calibration.py
+++ b/scripts/run_af18_calibration.py
@@ -122,7 +122,7 @@ def validate_measurement(name: str, item: Any, errors: list[str]) -> dict[str, A
     if not isinstance(item, dict):
         errors.append(f"missing_measurement:{name}")
         return {"observation_id": None, "availability": "unavailable", "value": None, "unit": None, "source": None, "observed_at": None}
-    reject_unknown(item, {"observation_id", "availability", "value", "unit", "source", "observed_at", "reason", "observation_basis", "derived_total_component_ids"}, f"measurement_{name}", errors)
+    reject_unknown(item, {"observation_id", "availability", "value", "unit", "source", "observed_at", "reason", "observation_basis", "derived_total_component_ids", "invocation_ids"}, f"measurement_{name}", errors)
     availability = item.get("availability")
     value = item.get("value")
     if not isinstance(item.get("observation_id"), str) or not item["observation_id"]:
@@ -150,7 +150,10 @@ def validate_measurement(name: str, item: Any, errors: list[str]) -> dict[str, A
         errors.append(f"derived_components_require_derived_basis:{name}")
     if basis == "independent_observed" and component_ids is not None:
         errors.append(f"independent_observation_must_not_have_components:{name}")
-    return {key: item.get(key) for key in ("observation_id", "availability", "value", "unit", "source", "observed_at", "reason", "observation_basis", "derived_total_component_ids")}
+    invocation_ids = item.get("invocation_ids")
+    if invocation_ids is not None and (not isinstance(invocation_ids, list) or not invocation_ids or any(not isinstance(value, str) or not value for value in invocation_ids) or len(invocation_ids) != len(set(invocation_ids))):
+        errors.append(f"invalid_invocation_ids:{name}")
+    return {key: item.get(key) for key in ("observation_id", "availability", "value", "unit", "source", "observed_at", "reason", "observation_basis", "derived_total_component_ids", "invocation_ids")}
 
 
 def reject_unknown(value: Any, allowed: set[str], label: str, errors: list[str]) -> None:
@@ -183,11 +186,11 @@ def validate_sample(sample: Any, packet: dict[str, Any], now: dt.datetime, max_a
         errors.append("low_limit_not_normal_policy_sample")
     scenario = sample.get("scenario")
     fields = ("scenario_id", "scenario_variant", "objective_or_acceptance_fixture_id", "complexity", "risk", "role_route", "model_class", "quality_rubric_version", "root_budget_unit", "anchor_type")
-    if not isinstance(scenario, dict) or any(not scenario.get(field) for field in fields) or not isinstance(scenario.get("canonical_allowed_tools"), list) or not scenario["canonical_allowed_tools"] or any(not isinstance(tool, str) or not tool for tool in scenario["canonical_allowed_tools"]) or not isinstance(scenario.get("measurement_window"), dict) or not isinstance(scenario["measurement_window"].get("definition"), str) or not scenario["measurement_window"]["definition"]:
+    if not isinstance(scenario, dict) or any(not scenario.get(field) for field in fields) or not isinstance(scenario.get("canonical_allowed_tools"), list) or not scenario["canonical_allowed_tools"] or any(not isinstance(tool, str) or not tool for tool in scenario["canonical_allowed_tools"]) or not isinstance(scenario.get("measurement_window"), dict) or not isinstance(scenario["measurement_window"].get("definition"), str) or not scenario["measurement_window"]["definition"] or scenario["measurement_window"].get("fixed_execution_window") is not True:
         errors.append("invalid_scenario_comparability")
     else:
         reject_unknown(scenario, set(fields) | {"canonical_allowed_tools", "measurement_window"}, "scenario", errors)
-        reject_unknown(scenario["measurement_window"], {"definition"}, "measurement_window", errors)
+        reject_unknown(scenario["measurement_window"], {"definition", "fixed_execution_window"}, "measurement_window", errors)
     declaration = sample.get("variant_declaration")
     expected_route = "counterfactual" if sample.get("variant") == "B" else "observed_normal_route"
     if not isinstance(declaration, dict) or declaration.get("route_kind") != expected_route:
@@ -210,7 +213,7 @@ def validate_sample(sample: Any, packet: dict[str, Any], now: dt.datetime, max_a
     elif isinstance(budget, dict) and isinstance(budget.get("value"), int) and remaining["value"] > budget["value"]:
         errors.append("remaining_budget_exceeds_root_budget")
     provenance = sample.get("provenance")
-    if not isinstance(provenance, dict) or not is_anchor(provenance.get("evidence_anchor")) or provenance.get("collection_method") not in {"fixture", "manual_adapter_export"} or not provenance.get("source"):
+    if not isinstance(provenance, dict) or not is_anchor(provenance.get("evidence_anchor")) or provenance.get("collection_method") not in {"fixture", "manual_adapter_export", "codex_jsonl_export"} or not provenance.get("source"):
         errors.append("malformed_provenance")
     else:
         try:
@@ -259,7 +262,7 @@ def validate_sample(sample: Any, packet: dict[str, Any], now: dt.datetime, max_a
         for name in DERIVED_TOTALS:
             item = normalized_resources.get(name, {})
             component_ids = item.get("derived_total_component_ids")
-            if not component_ids and item.get("observation_basis") != "independent_observed":
+            if item.get("availability") != "unavailable" and not component_ids and item.get("observation_basis") != "independent_observed":
                 errors.append(f"missing_derived_total_component_ids:{name}")
             if component_ids:
                 if item.get("observation_id") in component_ids or not set(component_ids).issubset(known_ids):
@@ -270,6 +273,22 @@ def validate_sample(sample: Any, packet: dict[str, Any], now: dt.datetime, max_a
                 )
                 if unavailable_component and item.get("availability") != "unavailable":
                     errors.append(f"derived_total_must_be_unavailable_with_unavailable_component:{name}")
+        cumulative = normalized_resources.get("cumulative_resource_tokens", {})
+        cumulative_components = cumulative.get("derived_total_component_ids")
+        required_components = {normalized_resources.get(name, {}).get("observation_id") for name in ("input_tokens", "output_tokens")}
+        if cumulative.get("availability") != "unavailable":
+            if set(cumulative_components or []) != required_components or len(cumulative_components or []) != 2:
+                errors.append("cumulative_resource_tokens_must_derive_input_plus_output_only")
+            input_value = normalized_resources.get("input_tokens", {}).get("value")
+            output_value = normalized_resources.get("output_tokens", {}).get("value")
+            if (not isinstance(input_value, (int, float)) or isinstance(input_value, bool)
+                    or not isinstance(output_value, (int, float)) or isinstance(output_value, bool)
+                    or normalized_resources.get("input_tokens", {}).get("availability") == "unavailable"
+                    or normalized_resources.get("output_tokens", {}).get("availability") == "unavailable"
+                    or cumulative.get("value") != input_value + output_value):
+                errors.append("invalid_cumulative_resource_tokens_derivation")
+            if not cumulative.get("invocation_ids"):
+                errors.append("cumulative_resource_tokens_requires_invocation_ids")
         if sample.get("variant") == "B":
             observed = sorted(name for name, item in normalized_resources.items() if item["availability"] == "observed")
             if observed:
@@ -343,8 +362,9 @@ def analyze(valid: list[dict[str, Any]], invalid: list[dict[str, Any]]) -> list[
         holds: list[str] = []
         if any(len(variants[variant]) < 5 for variant in ("A", "B", "C")):
             holds.append("requires_at_least_five_valid_A_B_C_rows")
-        if summaries["C"].get("cumulative_resource_tokens", {}).get("n_observed", 0) < 5:
-            holds.append("insufficient_observed_C_cumulative_resource_tokens")
+        for metric in ("cumulative_resource_tokens", "total_context_tokens", "context_age_hours"):
+            if summaries["C"].get(metric, {}).get("n_observed", 0) < 5:
+                holds.append(f"insufficient_observed_C_{metric}")
         attention_required = sum(row["attention"]["outcome"] == "required" for row in variants["C"])
         attention_conflicts, attention_pair_count, attention_material_count = attention_pairing_conflicts(variants) if task_class == "attention_materiality" else ([], 0, 0)
         failed_or_held = sum(row["terminal_state"] in {"failed", "held"} for row in variants["C"])
@@ -376,7 +396,7 @@ def run(packet: dict[str, Any], now: dt.datetime, max_age: int) -> dict[str, Any
     packet_errors: list[str] = []
     if forbidden_paths(packet):
         packet_errors.append("privacy_forbidden_raw_content")
-    if packet.get("schema_version") != 1 or packet.get("protocol_version") != PROTOCOL_VERSION or packet.get("collection_mode") not in {"fixture", "manual_adapter_export"} or not isinstance(packet.get("samples"), list):
+    if packet.get("schema_version") != 1 or packet.get("protocol_version") != PROTOCOL_VERSION or packet.get("collection_mode") not in {"fixture", "manual_adapter_export", "codex_jsonl_export"} or not isinstance(packet.get("samples"), list):
         packet_errors.append("invalid_protocol_packet")
     reject_unknown(packet, {"schema_version", "protocol_version", "collection_mode", "samples"}, "packet", packet_errors)
     valid: list[dict[str, Any]] = []

--- a/scripts/test_af18_calibration.py
+++ b/scripts/test_af18_calibration.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "run_af18_calibration.py"
+COLLECTOR = ROOT / "scripts" / "collect_af18_codex_telemetry.py"
 SCHEMA = ROOT / "schemas" / "af18-calibration-protocol.schema.yaml"
 FIXTURE = ROOT / "scripts" / "fixtures" / "af18_calibration" / "representative-fixture.json"
 spec = importlib.util.spec_from_file_location("calibration", SCRIPT)
@@ -20,6 +21,11 @@ calibration = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
 sys.modules[spec.name] = calibration
 spec.loader.exec_module(calibration)
+collector_spec = importlib.util.spec_from_file_location("collector", COLLECTOR)
+collector = importlib.util.module_from_spec(collector_spec)
+assert collector_spec.loader is not None
+sys.modules[collector_spec.name] = collector
+collector_spec.loader.exec_module(collector)
 NOW = calibration.utc("2026-07-29T10:00:00Z")
 
 
@@ -45,9 +51,12 @@ def sample(task_class, variant, index=0, **overrides):
     if task_class == "attention_materiality" and variant == "C":
         attention = {"outcome": "required", "category": "attention-summary", "acknowledgement": {"availability": "observed", "value": True}, "pairing": {"pair_id": pair_id, "evidence_anchor": f"https://github.com/farmerhunter/agent-foundry/issues/457#pair-{index}"}}
     resources = {name: measurement(name, value, unit, variant, index) for name, value, unit in (("input_tokens", 100, "tokens"), ("cached_input_tokens", 20, "tokens"), ("output_tokens", 40, "tokens"), ("reasoning_tokens", 30, "tokens"), ("tool_output_bytes", 80, "bytes"), ("context_age_hours", 1, "hours"), ("packet_bytes", 200, "bytes"), ("callback_count", 1, "count"), ("compact_rehydration_count", 1, "count"), ("full_rehydration_count", 0, "count"), ("retry_count", 0, "count"), ("recovery_count", 0, "count"), ("elapsed_seconds", 10, "seconds"))}
-    resources["total_context_tokens"] = measurement("total_context_tokens", 120, "tokens", variant, index, ("input_tokens", "cached_input_tokens"))
-    resources["cumulative_resource_tokens"] = measurement("cumulative_resource_tokens", 300, "tokens", variant, index, ("input_tokens", "cached_input_tokens", "output_tokens", "reasoning_tokens"))
-    base = {"sample_id": f"{task_class}-{variant}-{index}", "protocol_version": calibration.PROTOCOL_VERSION, "task_class": task_class, "variant": variant, "variant_declaration": {"route_kind": "counterfactual" if variant == "B" else "observed_normal_route"}, "scenario": {"scenario_id": task_class, "scenario_variant": "default", "objective_or_acceptance_fixture_id": f"fixture-{task_class}", "complexity": "small", "risk": "low", "role_route": route, "model_class": "standard", "quality_rubric_version": "v1", "canonical_allowed_tools": ["gh", "python3"], "measurement_window": {"definition": "execution-to-terminal"}, "root_budget_unit": "tokens", "anchor_type": "issue"}, "work_id": f"work-{task_class}-{index}", "execution_id": f"run-{task_class}-{variant}-{index}", "anchors": {"work": "https://github.com/farmerhunter/agent-foundry/issues/457", "execution": f"https://github.com/farmerhunter/agent-foundry/issues/457#{task_class}-{variant}-{index}", "context": "https://github.com/farmerhunter/agent-foundry/issues/457#context", **({"predecessor": "https://github.com/farmerhunter/agent-foundry/issues/457#predecessor", "successor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor"} if task_class == "bounded_successor_hold_recovery" else {})}, "root_budget": {"value": 1000, "unit": "tokens"}, "remaining_budget": {"value": 800, "unit": "tokens"}, "policy_version": "normal-observation-v1", "provenance": {"source": "test-export", "collection_method": "manual_adapter_export", "captured_at": "2026-07-29T09:00:00Z", "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#evidence", "observation_kind": "counterfactual" if variant == "B" else "observed"}, "terminal_state": "completed", "quality": {"passed": True, "reason": "test"}, "attention": attention, "resources": resources}
+    resources["total_context_tokens"] = measurement("total_context_tokens", 120, "tokens", variant, index)
+    resources["total_context_tokens"]["observation_basis"] = "independent_observed"
+    resources["cumulative_resource_tokens"] = measurement("cumulative_resource_tokens", 140, "tokens", variant, index, ("input_tokens", "output_tokens"))
+    resources["cumulative_resource_tokens"]["value"] = resources["input_tokens"]["value"] + resources["output_tokens"]["value"]
+    resources["cumulative_resource_tokens"]["invocation_ids"] = [f"invocation-{variant}-{index}"]
+    base = {"sample_id": f"{task_class}-{variant}-{index}", "protocol_version": calibration.PROTOCOL_VERSION, "task_class": task_class, "variant": variant, "variant_declaration": {"route_kind": "counterfactual" if variant == "B" else "observed_normal_route"}, "scenario": {"scenario_id": task_class, "scenario_variant": "default", "objective_or_acceptance_fixture_id": f"fixture-{task_class}", "complexity": "small", "risk": "low", "role_route": route, "model_class": "standard", "quality_rubric_version": "v1", "canonical_allowed_tools": ["gh", "python3"], "measurement_window": {"definition": "execution-to-terminal", "fixed_execution_window": True}, "root_budget_unit": "tokens", "anchor_type": "issue"}, "work_id": f"work-{task_class}-{index}", "execution_id": f"run-{task_class}-{variant}-{index}", "anchors": {"work": "https://github.com/farmerhunter/agent-foundry/issues/457", "execution": f"https://github.com/farmerhunter/agent-foundry/issues/457#{task_class}-{variant}-{index}", "context": "https://github.com/farmerhunter/agent-foundry/issues/457#context", **({"predecessor": "https://github.com/farmerhunter/agent-foundry/issues/457#predecessor", "successor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor"} if task_class == "bounded_successor_hold_recovery" else {})}, "root_budget": {"value": 1000, "unit": "tokens"}, "remaining_budget": {"value": 800, "unit": "tokens"}, "policy_version": "normal-observation-v1", "provenance": {"source": "test-export", "collection_method": "manual_adapter_export", "captured_at": "2026-07-29T09:00:00Z", "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#evidence", "observation_kind": "counterfactual" if variant == "B" else "observed"}, "terminal_state": "completed", "quality": {"passed": True, "reason": "test"}, "attention": attention, "resources": resources}
     if task_class == "bounded_successor_hold_recovery":
         base["successor_continuity"] = {"predecessor_work_id": base["work_id"], "successor_work_id": base["work_id"], "predecessor_root_budget": 1000, "successor_root_budget": 1000, "predecessor_remaining_budget": 900, "successor_remaining_budget": 800}
     base.update(overrides)
@@ -79,7 +88,7 @@ def main():
     for index, row in enumerate(item for item in declared_roots if item["task_class"] == "single_session_baseline" and item["variant"] == "C"):
         row["root_budget"]["value"] = 21000 + index * 1000
     root_candidate = cohort(calibration.run(packet(declared_roots), NOW, 168), "single_session_baseline")["candidate_recommendation"]["candidate_root_budget_band"]
-    expect("candidate-root-budget-from-C-cumulative", root_candidate["max"] == 304 and root_candidate["max"] != 25000, root_candidate)
+    expect("candidate-root-budget-from-C-cumulative", root_candidate["max"] == 148 and root_candidate["max"] != 25000, root_candidate)
 
     unavailable = copy.deepcopy(rows)
     unavailable[0]["resources"]["tool_output_bytes"] = {"observation_id": "unavailable-tool", "availability": "unavailable", "value": None, "unit": "bytes", "source": "adapter", "observed_at": None, "reason": "not_exposed"}
@@ -103,11 +112,21 @@ def main():
         ("unavailable-without-reason", lambda x: x["resources"]["input_tokens"].update({"availability": "unavailable", "value": None, "observed_at": None, "reason": None}), "unavailable_measurement_must_be_null_with_reason:input_tokens"),
         ("derived-unavailable", lambda x: (x["resources"]["input_tokens"].update({"availability": "unavailable", "value": None, "observed_at": None, "reason": "not_exposed"}), x["resources"]["cumulative_resource_tokens"].update({"availability": "estimated"})), "derived_total_must_be_unavailable_with_unavailable_component:cumulative_resource_tokens"),
         ("independent-with-components", lambda x: x["resources"]["cumulative_resource_tokens"].update({"observation_basis": "independent_observed"}), "derived_components_require_derived_basis:cumulative_resource_tokens"),
+        ("cached-reasoning-double-count", lambda x: x["resources"]["cumulative_resource_tokens"].update({"value": 190, "derived_total_component_ids": [x["resources"]["input_tokens"]["observation_id"], x["resources"]["cached_input_tokens"]["observation_id"], x["resources"]["output_tokens"]["observation_id"], x["resources"]["reasoning_tokens"]["observation_id"]]}), "cumulative_resource_tokens_must_derive_input_plus_output_only"),
+        ("invalid-derived-total", lambda x: x["resources"]["cumulative_resource_tokens"].update({"value": 141}), "invalid_cumulative_resource_tokens_derivation"),
+        ("duplicate-invocation", lambda x: x["resources"]["cumulative_resource_tokens"].update({"invocation_ids": ["duplicate", "duplicate"]}), "invalid_invocation_ids:cumulative_resource_tokens"),
+        ("missing-durable-anchor", lambda x: x["anchors"].pop("context"), "missing_or_unbound_durable_anchor"),
+        ("non-fixed-execution-window", lambda x: x["scenario"]["measurement_window"].update({"fixed_execution_window": False}), "invalid_scenario_comparability"),
         ("privacy", lambda x: x.update({"prompt": "secret"}), "privacy_forbidden_raw_content"),
         ("low-limit", lambda x: x.update({"policy_version": "low_limit_experiment"}), "low_limit_not_normal_policy_sample"),
     ]:
         bad = copy.deepcopy(rows); mutate(bad[0]); output = calibration.run(packet(bad), NOW, 168)
         expect(name, error in output["invalid_evidence"][0]["errors"], output)
+
+    B_observed = copy.deepcopy(rows)
+    next(row for row in B_observed if row["variant"] == "B")["resources"]["input_tokens"]["availability"] = "observed"
+    B_observed_result = calibration.run(packet(B_observed), NOW, 168)
+    expect("B-observed-rejected", "counterfactual_resources_must_not_be_observed:input_tokens" in B_observed_result["invalid_evidence"][0]["errors"], B_observed_result)
 
     for name, mutate, reason in [
         ("missing-pair", lambda x: x["attention"]["pairing"].update({"pair_id": "missing"}), "attention_pairing_missing_required_pair"),
@@ -141,16 +160,39 @@ def main():
 
     expect("comparability-boundary-encoded", set(calibration.PACKET_GLOBAL_OR_VALIDITY_CONSTRAINED) == {"task_class", "protocol_version", "root_budget_unit"}, calibration.PACKET_GLOBAL_OR_VALIDITY_CONSTRAINED)
 
-    independent_total = copy.deepcopy(rows)
-    independent_total[0]["resources"]["total_context_tokens"].pop("derived_total_component_ids")
-    independent_total[0]["resources"]["total_context_tokens"]["observation_basis"] = "independent_observed"
-    independent_result = calibration.run(packet(independent_total), NOW, 168)
+    independent_result = calibration.run(packet(rows), NOW, 168)
     expect("independent-total-valid", not independent_result["invalid_evidence"], independent_result)
 
     schema_text = SCHEMA.read_text(encoding="utf-8")
     expect("schema-unavailable-null-reason", "value: {type: 'null'}" in schema_text and "reason: {enum: [not_exposed, redacted, not_collected, invalid]}" in schema_text, schema_text)
     expect("schema-derived-total-reference", "total_context_tokens: {$ref: '#/$defs/derived_total_measurement'}" in schema_text and "cumulative_resource_tokens: {$ref: '#/$defs/derived_total_measurement'}" in schema_text, schema_text)
     expect("schema-independent-total-excludes-components", "observation_basis: {enum: [derived, independent_observed]}" in schema_text and "not: {required: [derived_total_component_ids]}" in schema_text, schema_text)
+    expect("schema-invocation-ids", "invocation_ids:" in schema_text, schema_text)
+
+    collector_sample = sample("single_session_baseline", "C")
+    collector_sample.pop("resources")
+    collector_sample.pop("provenance")
+    metadata = {"schema_version": 1, "protocol_version": calibration.PROTOCOL_VERSION, "sample": collector_sample, "captured_at": "2026-07-29T09:00:00Z", "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#telemetry", "invocation_ids": ["invocation-1", "invocation-2"]}
+    events = [
+        {"type": "codex.completed", "invocation_id": "invocation-1", "completed_at": "2026-07-29T09:00:00Z", "usage": {"input_tokens": 100, "cached_input_tokens": 20, "output_tokens": 40, "reasoning_tokens": 30}},
+        {"type": "codex.completed", "invocation_id": "invocation-2", "completed_at": "2026-07-29T09:01:00Z", "usage": {"input_tokens": 50, "output_tokens": 10}},
+    ]
+    collected = collector.collect(metadata, events)
+    collected_resources = collected["samples"][0]["resources"]
+    expect("collector-input-output-only-total", collected_resources["cumulative_resource_tokens"]["value"] == 200 and collected_resources["cumulative_resource_tokens"]["derived_total_component_ids"] == ["codex-jsonl-input_tokens", "codex-jsonl-output_tokens"], collected)
+    expect("collector-unavailable-host-metrics", collected_resources["tool_output_bytes"]["availability"] == "unavailable" and collected_resources["tool_output_bytes"]["value"] is None and collected_resources["tool_output_bytes"]["reason"] == "not_exposed", collected)
+    expect("collector-missing-breakdown-unavailable", collected_resources["cached_input_tokens"]["availability"] == "unavailable", collected)
+    with tempfile.TemporaryDirectory() as directory:
+        jsonl = Path(directory) / "completed.jsonl"
+        jsonl.write_text("\n".join(json.dumps(event) for event in events) + "\n", encoding="utf-8")
+        expect("collector-jsonl-dedup", len(collector.read_events(str(jsonl), ["invocation-1", "invocation-2"])) == 2, jsonl.read_text())
+        jsonl.write_text(json.dumps({**events[0], "messages": ["raw"]}) + "\n", encoding="utf-8")
+        try:
+            collector.read_events(str(jsonl), ["invocation-1"])
+        except ValueError as exc:
+            expect("collector-raw-content-rejected", "invalid_completed_event_fields" in str(exc), str(exc))
+        else:
+            raise AssertionError("collector raw content must fail")
 
     for dimension in ("scenario_id", "scenario_variant", "objective_or_acceptance_fixture_id", "complexity", "risk", "role_route", "model_class", "quality_rubric_version", "policy_version", "canonical_allowed_tools", "measurement_window", "anchor_type"):
         split = copy.deepcopy(rows)
@@ -170,7 +212,7 @@ def main():
     fixture_result = calibration.run(fixture, NOW, 168)
     expect("fixture-evidence-only", "fixture evidence only" in fixture_result["human_summary"], fixture_result)
     fixture_candidate = fixture_result["cohorts"][0]["candidate_recommendation"]
-    expect("fixture-hold-only-insufficient-sample", fixture_candidate["candidate_status"] == "candidate_hold" and fixture_candidate["candidate_hold_reasons"] == ["insufficient_observed_C_cumulative_resource_tokens", "requires_at_least_five_valid_A_B_C_rows"], fixture_candidate)
+    expect("fixture-hold-only-insufficient-sample", fixture_candidate["candidate_status"] == "candidate_hold" and fixture_candidate["candidate_hold_reasons"] == ["insufficient_observed_C_context_age_hours", "insufficient_observed_C_cumulative_resource_tokens", "insufficient_observed_C_total_context_tokens", "requires_at_least_five_valid_A_B_C_rows"], fixture_candidate)
     with tempfile.TemporaryDirectory() as directory:
         output_path = Path(directory) / "packet.json"
         completed = subprocess.run([sys.executable, str(SCRIPT), "--input", str(FIXTURE), "--output", str(output_path), "--now", "2026-07-29T10:00:00Z"], text=True, capture_output=True, check=False)

--- a/scripts/test_af18_calibration.py
+++ b/scripts/test_af18_calibration.py
@@ -113,6 +113,8 @@ def main():
         ("derived-unavailable", lambda x: (x["resources"]["input_tokens"].update({"availability": "unavailable", "value": None, "observed_at": None, "reason": "not_exposed"}), x["resources"]["cumulative_resource_tokens"].update({"availability": "estimated"})), "derived_total_must_be_unavailable_with_unavailable_component:cumulative_resource_tokens"),
         ("independent-with-components", lambda x: x["resources"]["cumulative_resource_tokens"].update({"observation_basis": "independent_observed"}), "derived_components_require_derived_basis:cumulative_resource_tokens"),
         ("cached-reasoning-double-count", lambda x: x["resources"]["cumulative_resource_tokens"].update({"value": 190, "derived_total_component_ids": [x["resources"]["input_tokens"]["observation_id"], x["resources"]["cached_input_tokens"]["observation_id"], x["resources"]["output_tokens"]["observation_id"], x["resources"]["reasoning_tokens"]["observation_id"]]}), "cumulative_resource_tokens_must_derive_input_plus_output_only"),
+        ("cached-input-breakdown", lambda x: x["resources"]["cached_input_tokens"].update({"value": x["resources"]["input_tokens"]["value"] + 1}), "cached_input_tokens_exceeds_input_tokens"),
+        ("reasoning-output-breakdown", lambda x: x["resources"]["reasoning_tokens"].update({"value": x["resources"]["output_tokens"]["value"] + 1}), "reasoning_tokens_exceeds_output_tokens"),
         ("invalid-derived-total", lambda x: x["resources"]["cumulative_resource_tokens"].update({"value": 141}), "invalid_cumulative_resource_tokens_derivation"),
         ("duplicate-invocation", lambda x: x["resources"]["cumulative_resource_tokens"].update({"invocation_ids": ["duplicate", "duplicate"]}), "invalid_invocation_ids:cumulative_resource_tokens"),
         ("missing-durable-anchor", lambda x: x["anchors"].pop("context"), "missing_or_unbound_durable_anchor"),
@@ -172,10 +174,10 @@ def main():
     collector_sample = sample("single_session_baseline", "C")
     collector_sample.pop("resources")
     collector_sample.pop("provenance")
-    metadata = {"schema_version": 1, "protocol_version": calibration.PROTOCOL_VERSION, "sample": collector_sample, "captured_at": "2026-07-29T09:00:00Z", "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#telemetry", "invocation_ids": ["invocation-1", "invocation-2"]}
+    metadata = {"schema_version": 1, "protocol_version": calibration.PROTOCOL_VERSION, "sample": collector_sample, "captured_at": "2026-07-29T09:00:00Z", "evidence_anchor": collector_sample["anchors"]["execution"], "invocation_ids": ["invocation-1", "invocation-2"], "execution_id": collector_sample["execution_id"], "execution_window": {"started_at": "2026-07-29T08:59:00Z", "ended_at": "2026-07-29T09:02:00Z"}}
     events = [
-        {"type": "codex.completed", "invocation_id": "invocation-1", "completed_at": "2026-07-29T09:00:00Z", "usage": {"input_tokens": 100, "cached_input_tokens": 20, "output_tokens": 40, "reasoning_tokens": 30}},
-        {"type": "codex.completed", "invocation_id": "invocation-2", "completed_at": "2026-07-29T09:01:00Z", "usage": {"input_tokens": 50, "output_tokens": 10}},
+        {"type": "codex.completed", "invocation_id": "invocation-1", "execution_id": collector_sample["execution_id"], "completed_at": "2026-07-29T09:00:00Z", "usage": {"input_tokens": 100, "cached_input_tokens": 20, "output_tokens": 40, "reasoning_tokens": 30}},
+        {"type": "codex.completed", "invocation_id": "invocation-2", "execution_id": collector_sample["execution_id"], "completed_at": "2026-07-29T09:01:00Z", "usage": {"input_tokens": 50, "output_tokens": 10}},
     ]
     collected = collector.collect(metadata, events)
     collected_resources = collected["samples"][0]["resources"]
@@ -185,10 +187,18 @@ def main():
     with tempfile.TemporaryDirectory() as directory:
         jsonl = Path(directory) / "completed.jsonl"
         jsonl.write_text("\n".join(json.dumps(event) for event in events) + "\n", encoding="utf-8")
-        expect("collector-jsonl-dedup", len(collector.read_events(str(jsonl), ["invocation-1", "invocation-2"])) == 2, jsonl.read_text())
+        expect("collector-jsonl-dedup", len(collector.read_events(str(jsonl), ["invocation-1", "invocation-2"], collector_sample["execution_id"], metadata["execution_window"])) == 2, jsonl.read_text())
+        outside_window = {**events[0], "completed_at": "2020-01-01T00:00:00Z"}
+        jsonl.write_text(json.dumps(outside_window) + "\n", encoding="utf-8")
+        try:
+            collector.read_events(str(jsonl), ["invocation-1"], collector_sample["execution_id"], metadata["execution_window"])
+        except ValueError as exc:
+            expect("collector-window-boundary", "completed_event_outside_execution_window" in str(exc), str(exc))
+        else:
+            raise AssertionError("collector must reject events outside fixed execution window")
         jsonl.write_text(json.dumps({**events[0], "messages": ["raw"]}) + "\n", encoding="utf-8")
         try:
-            collector.read_events(str(jsonl), ["invocation-1"])
+            collector.read_events(str(jsonl), ["invocation-1"], collector_sample["execution_id"], metadata["execution_window"])
         except ValueError as exc:
             expect("collector-raw-content-rejected", "invalid_completed_event_fields" in str(exc), str(exc))
         else:


### PR DESCRIPTION
Implements the binding #457 metric-semantics amendment:
https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125340321

Scope:
- privacy-safe, read-only Codex JSONL telemetry export;
- corrected input/cached/reasoning semantics;
- fail-closed unavailable metrics and fixed-window invocation de-duplication;
- schema, harness, fixture, and focused coverage.

Non-goals: no live cohort collection, policy/runtime/config/hook changes, local ledger, threshold freeze, or activation.

Verification:
- python3 scripts/test_af18_calibration.py
- python3 scripts/test_af18_mvp1_control.py
- python3 scripts/test_af18_mvp2_observation_bridge.py
- python3 scripts/test_runtime_owned_capture.py
- python3 scripts/check_consistency.py
- git diff --check