### PR TITLE
Add real AF18 calibration cohort evidence

### DIFF
--- a/scripts/fixtures/af18_calibration/real-reclassified/attention_materiality.json
+++ b/scripts/fixtures/af18_calibration/real-reclassified/attention_materiality.json
@@ -1,0 +1,3092 @@
+{
+  "collection_mode": "codex_jsonl_export",
+  "protocol_version": "af18-calibration-protocol-v1",
+  "samples": [
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": "attention-summary",
+        "outcome": "suppressed",
+        "pairing": {
+          "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+          "pair_id": "attention-pair-0"
+        }
+      },
+      "execution_id": "run-attention_materiality-A-000",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T03:03:47Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-attention_materiality-A-000",
+          "observed_at": "2026-07-30T03:03:47Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 16768
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-attention_materiality-A-000",
+          "observed_at": "2026-07-30T03:03:47Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-attention_materiality-A-000",
+            "output_tokens-run-attention_materiality-A-000"
+          ],
+          "invocation_ids": [
+            "run-attention_materiality-A-000-turn-1"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-attention_materiality-A-000",
+          "observed_at": "2026-07-30T03:03:47Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17748
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-attention_materiality-A-000",
+          "observed_at": "2026-07-30T03:03:47Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 29.67
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-attention_materiality-A-000",
+          "observed_at": "2026-07-30T03:03:47Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17636
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-attention_materiality-A-000",
+          "observed_at": "2026-07-30T03:03:47Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 112
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-attention_materiality-A-000",
+          "observed_at": "2026-07-30T03:03:47Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 73
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-attention_materiality-A-000",
+          "observed_at": "2026-07-30T03:03:47Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-attention_materiality-A-000",
+          "observed_at": "2026-07-30T03:03:47Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "attention_materiality-A-000",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-attention_materiality-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "attention_materiality",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "attention_materiality",
+      "terminal_state": "completed",
+      "variant": "A",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-attention_materiality-A-000"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-attention_materiality-B-000",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T03:03:47Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "counterfactual",
+        "source": "declared-counterfactual"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cached_input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "callback_count": {
+          "availability": "unavailable",
+          "observation_id": "callback_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cumulative_resource_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "elapsed_seconds": {
+          "availability": "unavailable",
+          "observation_id": "elapsed_seconds-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": null
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "output_tokens": {
+          "availability": "unavailable",
+          "observation_id": "output_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "unavailable",
+          "observation_id": "reasoning_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "recovery_count": {
+          "availability": "unavailable",
+          "observation_id": "recovery_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "retry_count": {
+          "availability": "unavailable",
+          "observation_id": "retry_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "attention_materiality-B-000",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-attention_materiality-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "attention_materiality",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "attention_materiality",
+      "terminal_state": "completed",
+      "variant": "B",
+      "variant_declaration": {
+        "route_kind": "counterfactual"
+      },
+      "work_id": "work-attention_materiality-B-000"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "observed",
+          "value": true
+        },
+        "category": "attention-summary",
+        "outcome": "required",
+        "pairing": {
+          "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+          "pair_id": "attention-pair-0"
+        }
+      },
+      "execution_id": "run-attention_materiality-C-000",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T03:04:27Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-attention_materiality-C-000",
+          "observed_at": "2026-07-30T03:04:27Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 19200
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-attention_materiality-C-000",
+          "observed_at": "2026-07-30T03:04:27Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 1
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-attention_materiality-C-000",
+            "output_tokens-run-attention_materiality-C-000"
+          ],
+          "invocation_ids": [
+            "run-attention_materiality-C-000-turn-1",
+            "run-attention_materiality-C-000-turn-2"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-attention_materiality-C-000",
+          "observed_at": "2026-07-30T03:04:27Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35671
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-attention_materiality-C-000",
+          "observed_at": "2026-07-30T03:04:27Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 40.147
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-attention_materiality-C-000",
+          "observed_at": "2026-07-30T03:04:27Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35335
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-attention_materiality-C-000",
+          "observed_at": "2026-07-30T03:04:27Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 336
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-attention_materiality-C-000",
+          "observed_at": "2026-07-30T03:04:27Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 197
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-attention_materiality-C-000",
+          "observed_at": "2026-07-30T03:04:27Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-attention_materiality-C-000",
+          "observed_at": "2026-07-30T03:04:27Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "attention_materiality-C-000",
+      "scenario": {
+        "actual_role_route": "Coordinator>Human",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-attention_materiality-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "attention_materiality",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "attention_materiality",
+      "terminal_state": "completed",
+      "variant": "C",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-attention_materiality-C-000"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": "attention-summary",
+        "outcome": "suppressed",
+        "pairing": {
+          "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+          "pair_id": "attention-pair-1"
+        }
+      },
+      "execution_id": "run-attention_materiality-A-001",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T03:04:46Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-attention_materiality-A-001",
+          "observed_at": "2026-07-30T03:04:46Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 16768
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-attention_materiality-A-001",
+          "observed_at": "2026-07-30T03:04:46Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-attention_materiality-A-001",
+            "output_tokens-run-attention_materiality-A-001"
+          ],
+          "invocation_ids": [
+            "run-attention_materiality-A-001-turn-1"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-attention_materiality-A-001",
+          "observed_at": "2026-07-30T03:04:46Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17734
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-attention_materiality-A-001",
+          "observed_at": "2026-07-30T03:04:46Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 18.927
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-attention_materiality-A-001",
+          "observed_at": "2026-07-30T03:04:46Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17636
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-attention_materiality-A-001",
+          "observed_at": "2026-07-30T03:04:46Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 98
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-attention_materiality-A-001",
+          "observed_at": "2026-07-30T03:04:46Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 28
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-attention_materiality-A-001",
+          "observed_at": "2026-07-30T03:04:46Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-attention_materiality-A-001",
+          "observed_at": "2026-07-30T03:04:46Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "attention_materiality-A-001",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-attention_materiality-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "attention_materiality",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "attention_materiality",
+      "terminal_state": "completed",
+      "variant": "A",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-attention_materiality-A-001"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-attention_materiality-B-001",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T03:04:46Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "counterfactual",
+        "source": "declared-counterfactual"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cached_input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "callback_count": {
+          "availability": "unavailable",
+          "observation_id": "callback_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cumulative_resource_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "elapsed_seconds": {
+          "availability": "unavailable",
+          "observation_id": "elapsed_seconds-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": null
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "output_tokens": {
+          "availability": "unavailable",
+          "observation_id": "output_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "unavailable",
+          "observation_id": "reasoning_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "recovery_count": {
+          "availability": "unavailable",
+          "observation_id": "recovery_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "retry_count": {
+          "availability": "unavailable",
+          "observation_id": "retry_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "attention_materiality-B-001",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-attention_materiality-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "attention_materiality",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "attention_materiality",
+      "terminal_state": "completed",
+      "variant": "B",
+      "variant_declaration": {
+        "route_kind": "counterfactual"
+      },
+      "work_id": "work-attention_materiality-B-001"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "observed",
+          "value": true
+        },
+        "category": "attention-summary",
+        "outcome": "required",
+        "pairing": {
+          "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+          "pair_id": "attention-pair-1"
+        }
+      },
+      "execution_id": "run-attention_materiality-C-001",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T03:05:27Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-attention_materiality-C-001",
+          "observed_at": "2026-07-30T03:05:27Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 33536
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-attention_materiality-C-001",
+          "observed_at": "2026-07-30T03:05:27Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 1
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-attention_materiality-C-001",
+            "output_tokens-run-attention_materiality-C-001"
+          ],
+          "invocation_ids": [
+            "run-attention_materiality-C-001-turn-1",
+            "run-attention_materiality-C-001-turn-2"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-attention_materiality-C-001",
+          "observed_at": "2026-07-30T03:05:27Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35520
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-attention_materiality-C-001",
+          "observed_at": "2026-07-30T03:05:27Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 41.202
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-attention_materiality-C-001",
+          "observed_at": "2026-07-30T03:05:27Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35304
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-attention_materiality-C-001",
+          "observed_at": "2026-07-30T03:05:27Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 216
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-attention_materiality-C-001",
+          "observed_at": "2026-07-30T03:05:27Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 119
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-attention_materiality-C-001",
+          "observed_at": "2026-07-30T03:05:27Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-attention_materiality-C-001",
+          "observed_at": "2026-07-30T03:05:27Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "attention_materiality-C-001",
+      "scenario": {
+        "actual_role_route": "Coordinator>Human",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-attention_materiality-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "attention_materiality",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "attention_materiality",
+      "terminal_state": "completed",
+      "variant": "C",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-attention_materiality-C-001"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": "attention-summary",
+        "outcome": "suppressed",
+        "pairing": {
+          "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+          "pair_id": "attention-pair-2"
+        }
+      },
+      "execution_id": "run-attention_materiality-A-002",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T03:05:50Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-attention_materiality-A-002",
+          "observed_at": "2026-07-30T03:05:50Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 16768
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-attention_materiality-A-002",
+          "observed_at": "2026-07-30T03:05:50Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-attention_materiality-A-002",
+            "output_tokens-run-attention_materiality-A-002"
+          ],
+          "invocation_ids": [
+            "run-attention_materiality-A-002-turn-1"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-attention_materiality-A-002",
+          "observed_at": "2026-07-30T03:05:50Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 18030
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-attention_materiality-A-002",
+          "observed_at": "2026-07-30T03:05:50Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 23.047
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-attention_materiality-A-002",
+          "observed_at": "2026-07-30T03:05:50Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17636
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-attention_materiality-A-002",
+          "observed_at": "2026-07-30T03:05:50Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 394
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-attention_materiality-A-002",
+          "observed_at": "2026-07-30T03:05:50Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 359
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-attention_materiality-A-002",
+          "observed_at": "2026-07-30T03:05:50Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-attention_materiality-A-002",
+          "observed_at": "2026-07-30T03:05:50Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "attention_materiality-A-002",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-attention_materiality-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "attention_materiality",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "attention_materiality",
+      "terminal_state": "completed",
+      "variant": "A",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-attention_materiality-A-002"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-attention_materiality-B-002",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T03:05:50Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "counterfactual",
+        "source": "declared-counterfactual"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cached_input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "callback_count": {
+          "availability": "unavailable",
+          "observation_id": "callback_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cumulative_resource_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "elapsed_seconds": {
+          "availability": "unavailable",
+          "observation_id": "elapsed_seconds-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": null
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "output_tokens": {
+          "availability": "unavailable",
+          "observation_id": "output_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "unavailable",
+          "observation_id": "reasoning_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "recovery_count": {
+          "availability": "unavailable",
+          "observation_id": "recovery_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "retry_count": {
+          "availability": "unavailable",
+          "observation_id": "retry_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "attention_materiality-B-002",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-attention_materiality-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "attention_materiality",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "attention_materiality",
+      "terminal_state": "completed",
+      "variant": "B",
+      "variant_declaration": {
+        "route_kind": "counterfactual"
+      },
+      "work_id": "work-attention_materiality-B-002"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "observed",
+          "value": true
+        },
+        "category": "attention-summary",
+        "outcome": "required",
+        "pairing": {
+          "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+          "pair_id": "attention-pair-2"
+        }
+      },
+      "execution_id": "run-attention_materiality-C-002",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T03:06:29Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-attention_materiality-C-002",
+          "observed_at": "2026-07-30T03:06:29Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 33536
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-attention_materiality-C-002",
+          "observed_at": "2026-07-30T03:06:29Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 1
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-attention_materiality-C-002",
+            "output_tokens-run-attention_materiality-C-002"
+          ],
+          "invocation_ids": [
+            "run-attention_materiality-C-002-turn-1",
+            "run-attention_materiality-C-002-turn-2"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-attention_materiality-C-002",
+          "observed_at": "2026-07-30T03:06:29Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35614
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-attention_materiality-C-002",
+          "observed_at": "2026-07-30T03:06:29Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 38.706
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-attention_materiality-C-002",
+          "observed_at": "2026-07-30T03:06:29Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35336
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-attention_materiality-C-002",
+          "observed_at": "2026-07-30T03:06:29Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 278
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-attention_materiality-C-002",
+          "observed_at": "2026-07-30T03:06:29Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 108
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-attention_materiality-C-002",
+          "observed_at": "2026-07-30T03:06:29Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-attention_materiality-C-002",
+          "observed_at": "2026-07-30T03:06:29Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "attention_materiality-C-002",
+      "scenario": {
+        "actual_role_route": "Coordinator>Human",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-attention_materiality-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "attention_materiality",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "attention_materiality",
+      "terminal_state": "completed",
+      "variant": "C",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-attention_materiality-C-002"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": "attention-summary",
+        "outcome": "suppressed",
+        "pairing": {
+          "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+          "pair_id": "attention-pair-3"
+        }
+      },
+      "execution_id": "run-attention_materiality-A-003",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T03:06:48Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-attention_materiality-A-003",
+          "observed_at": "2026-07-30T03:06:48Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 16768
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-attention_materiality-A-003",
+          "observed_at": "2026-07-30T03:06:48Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-attention_materiality-A-003",
+            "output_tokens-run-attention_materiality-A-003"
+          ],
+          "invocation_ids": [
+            "run-attention_materiality-A-003-turn-1"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-attention_materiality-A-003",
+          "observed_at": "2026-07-30T03:06:48Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17811
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-attention_materiality-A-003",
+          "observed_at": "2026-07-30T03:06:48Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 19.33
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-attention_materiality-A-003",
+          "observed_at": "2026-07-30T03:06:48Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17636
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-attention_materiality-A-003",
+          "observed_at": "2026-07-30T03:06:48Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 175
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-attention_materiality-A-003",
+          "observed_at": "2026-07-30T03:06:48Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 131
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-attention_materiality-A-003",
+          "observed_at": "2026-07-30T03:06:48Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-attention_materiality-A-003",
+          "observed_at": "2026-07-30T03:06:48Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "attention_materiality-A-003",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-attention_materiality-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "attention_materiality",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "attention_materiality",
+      "terminal_state": "completed",
+      "variant": "A",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-attention_materiality-A-003"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-attention_materiality-B-003",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T03:06:48Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "counterfactual",
+        "source": "declared-counterfactual"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cached_input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "callback_count": {
+          "availability": "unavailable",
+          "observation_id": "callback_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cumulative_resource_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "elapsed_seconds": {
+          "availability": "unavailable",
+          "observation_id": "elapsed_seconds-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": null
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "output_tokens": {
+          "availability": "unavailable",
+          "observation_id": "output_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "unavailable",
+          "observation_id": "reasoning_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "recovery_count": {
+          "availability": "unavailable",
+          "observation_id": "recovery_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "retry_count": {
+          "availability": "unavailable",
+          "observation_id": "retry_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "attention_materiality-B-003",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-attention_materiality-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "attention_materiality",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "attention_materiality",
+      "terminal_state": "completed",
+      "variant": "B",
+      "variant_declaration": {
+        "route_kind": "counterfactual"
+      },
+      "work_id": "work-attention_materiality-B-003"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "observed",
+          "value": true
+        },
+        "category": "attention-summary",
+        "outcome": "required",
+        "pairing": {
+          "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+          "pair_id": "attention-pair-3"
+        }
+      },
+      "execution_id": "run-attention_materiality-C-003",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T03:07:28Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-attention_materiality-C-003",
+          "observed_at": "2026-07-30T03:07:28Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 31488
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-attention_materiality-C-003",
+          "observed_at": "2026-07-30T03:07:28Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 1
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-attention_materiality-C-003",
+            "output_tokens-run-attention_materiality-C-003"
+          ],
+          "invocation_ids": [
+            "run-attention_materiality-C-003-turn-1",
+            "run-attention_materiality-C-003-turn-2"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-attention_materiality-C-003",
+          "observed_at": "2026-07-30T03:07:28Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35313
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-attention_materiality-C-003",
+          "observed_at": "2026-07-30T03:07:28Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 39.431
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-attention_materiality-C-003",
+          "observed_at": "2026-07-30T03:07:28Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35070
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-attention_materiality-C-003",
+          "observed_at": "2026-07-30T03:07:28Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 243
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-attention_materiality-C-003",
+          "observed_at": "2026-07-30T03:07:28Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 149
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-attention_materiality-C-003",
+          "observed_at": "2026-07-30T03:07:28Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-attention_materiality-C-003",
+          "observed_at": "2026-07-30T03:07:28Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "attention_materiality-C-003",
+      "scenario": {
+        "actual_role_route": "Coordinator>Human",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-attention_materiality-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "attention_materiality",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "attention_materiality",
+      "terminal_state": "completed",
+      "variant": "C",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-attention_materiality-C-003"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": "attention-summary",
+        "outcome": "suppressed",
+        "pairing": {
+          "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+          "pair_id": "attention-pair-4"
+        }
+      },
+      "execution_id": "run-attention_materiality-A-004",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T03:07:48Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-attention_materiality-A-004",
+          "observed_at": "2026-07-30T03:07:48Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 16768
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-attention_materiality-A-004",
+          "observed_at": "2026-07-30T03:07:48Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-attention_materiality-A-004",
+            "output_tokens-run-attention_materiality-A-004"
+          ],
+          "invocation_ids": [
+            "run-attention_materiality-A-004-turn-1"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-attention_materiality-A-004",
+          "observed_at": "2026-07-30T03:07:48Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17777
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-attention_materiality-A-004",
+          "observed_at": "2026-07-30T03:07:48Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 19.991
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-attention_materiality-A-004",
+          "observed_at": "2026-07-30T03:07:48Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17636
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-attention_materiality-A-004",
+          "observed_at": "2026-07-30T03:07:48Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 141
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-attention_materiality-A-004",
+          "observed_at": "2026-07-30T03:07:48Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 58
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-attention_materiality-A-004",
+          "observed_at": "2026-07-30T03:07:48Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-attention_materiality-A-004",
+          "observed_at": "2026-07-30T03:07:48Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "attention_materiality-A-004",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-attention_materiality-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "attention_materiality",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "attention_materiality",
+      "terminal_state": "completed",
+      "variant": "A",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-attention_materiality-A-004"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-attention_materiality-B-004",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T03:07:48Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "counterfactual",
+        "source": "declared-counterfactual"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cached_input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "callback_count": {
+          "availability": "unavailable",
+          "observation_id": "callback_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cumulative_resource_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "elapsed_seconds": {
+          "availability": "unavailable",
+          "observation_id": "elapsed_seconds-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": null
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "output_tokens": {
+          "availability": "unavailable",
+          "observation_id": "output_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "unavailable",
+          "observation_id": "reasoning_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "recovery_count": {
+          "availability": "unavailable",
+          "observation_id": "recovery_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "retry_count": {
+          "availability": "unavailable",
+          "observation_id": "retry_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "attention_materiality-B-004",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-attention_materiality-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "attention_materiality",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "attention_materiality",
+      "terminal_state": "completed",
+      "variant": "B",
+      "variant_declaration": {
+        "route_kind": "counterfactual"
+      },
+      "work_id": "work-attention_materiality-B-004"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "observed",
+          "value": true
+        },
+        "category": "attention-summary",
+        "outcome": "required",
+        "pairing": {
+          "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+          "pair_id": "attention-pair-4"
+        }
+      },
+      "execution_id": "run-attention_materiality-C-004",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T03:08:28Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-attention_materiality-C-004",
+          "observed_at": "2026-07-30T03:08:28Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 33536
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-attention_materiality-C-004",
+          "observed_at": "2026-07-30T03:08:28Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 1
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-attention_materiality-C-004",
+            "output_tokens-run-attention_materiality-C-004"
+          ],
+          "invocation_ids": [
+            "run-attention_materiality-C-004-turn-1",
+            "run-attention_materiality-C-004-turn-2"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-attention_materiality-C-004",
+          "observed_at": "2026-07-30T03:08:28Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35611
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-attention_materiality-C-004",
+          "observed_at": "2026-07-30T03:08:28Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 40.421
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-attention_materiality-C-004",
+          "observed_at": "2026-07-30T03:08:28Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35336
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-attention_materiality-C-004",
+          "observed_at": "2026-07-30T03:08:28Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 275
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-attention_materiality-C-004",
+          "observed_at": "2026-07-30T03:08:28Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 127
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-attention_materiality-C-004",
+          "observed_at": "2026-07-30T03:08:28Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-attention_materiality-C-004",
+          "observed_at": "2026-07-30T03:08:28Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "attention_materiality-C-004",
+      "scenario": {
+        "actual_role_route": "Coordinator>Human",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-attention_materiality-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "attention_materiality",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "attention_materiality",
+      "terminal_state": "completed",
+      "variant": "C",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-attention_materiality-C-004"
+    }
+  ],
+  "schema_version": 1
+}

--- a/scripts/fixtures/af18_calibration/real-reclassified/bounded_successor_hold_recovery.json
+++ b/scripts/fixtures/af18_calibration/real-reclassified/bounded_successor_hold_recovery.json
@@ -1,0 +1,3242 @@
+{
+  "collection_mode": "codex_jsonl_export",
+  "protocol_version": "af18-calibration-protocol-v1",
+  "samples": [
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457",
+        "predecessor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-predecessor",
+        "successor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-successor"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-bounded_successor_hold_recovery-A-000",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:57:06Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-bounded_successor_hold_recovery-A-000",
+          "observed_at": "2026-07-30T02:57:06Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 16768
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-bounded_successor_hold_recovery-A-000",
+          "observed_at": "2026-07-30T02:57:06Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-bounded_successor_hold_recovery-A-000",
+            "output_tokens-run-bounded_successor_hold_recovery-A-000"
+          ],
+          "invocation_ids": [
+            "run-bounded_successor_hold_recovery-A-000-turn-1"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-bounded_successor_hold_recovery-A-000",
+          "observed_at": "2026-07-30T02:57:06Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17767
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-bounded_successor_hold_recovery-A-000",
+          "observed_at": "2026-07-30T02:57:06Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 23.34
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-bounded_successor_hold_recovery-A-000",
+          "observed_at": "2026-07-30T02:57:06Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17639
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-bounded_successor_hold_recovery-A-000",
+          "observed_at": "2026-07-30T02:57:06Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 128
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-bounded_successor_hold_recovery-A-000",
+          "observed_at": "2026-07-30T02:57:06Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 27
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-bounded_successor_hold_recovery-A-000",
+          "observed_at": "2026-07-30T02:57:06Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-bounded_successor_hold_recovery-A-000",
+          "observed_at": "2026-07-30T02:57:06Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "bounded_successor_hold_recovery-A-000",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-bounded_successor_hold_recovery-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "bounded_successor_hold_recovery",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "bounded_successor_hold_recovery",
+      "terminal_state": "completed",
+      "variant": "A",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-bounded_successor_hold_recovery-A-000",
+      "successor_continuity": {
+        "predecessor_work_id": "work-bounded_successor_hold_recovery-A-000",
+        "successor_work_id": "work-bounded_successor_hold_recovery-A-000",
+        "predecessor_root_budget": 100000,
+        "successor_root_budget": 100000,
+        "predecessor_remaining_budget": 100000,
+        "successor_remaining_budget": 100000
+      }
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457",
+        "predecessor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-predecessor",
+        "successor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-successor"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-bounded_successor_hold_recovery-B-000",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:57:06Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "counterfactual",
+        "source": "declared-counterfactual"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cached_input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "callback_count": {
+          "availability": "unavailable",
+          "observation_id": "callback_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cumulative_resource_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "elapsed_seconds": {
+          "availability": "unavailable",
+          "observation_id": "elapsed_seconds-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": null
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "output_tokens": {
+          "availability": "unavailable",
+          "observation_id": "output_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "unavailable",
+          "observation_id": "reasoning_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "recovery_count": {
+          "availability": "unavailable",
+          "observation_id": "recovery_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "retry_count": {
+          "availability": "unavailable",
+          "observation_id": "retry_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "bounded_successor_hold_recovery-B-000",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-bounded_successor_hold_recovery-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "bounded_successor_hold_recovery",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "bounded_successor_hold_recovery",
+      "terminal_state": "completed",
+      "variant": "B",
+      "variant_declaration": {
+        "route_kind": "counterfactual"
+      },
+      "work_id": "work-bounded_successor_hold_recovery-B-000",
+      "successor_continuity": {
+        "predecessor_work_id": "work-bounded_successor_hold_recovery-B-000",
+        "successor_work_id": "work-bounded_successor_hold_recovery-B-000",
+        "predecessor_root_budget": 100000,
+        "successor_root_budget": 100000,
+        "predecessor_remaining_budget": 100000,
+        "successor_remaining_budget": 100000
+      }
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457",
+        "predecessor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-predecessor",
+        "successor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-successor"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-bounded_successor_hold_recovery-C-000",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:57:41Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-bounded_successor_hold_recovery-C-000",
+          "observed_at": "2026-07-30T02:57:41Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 29440
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-bounded_successor_hold_recovery-C-000",
+          "observed_at": "2026-07-30T02:57:41Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 1
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-bounded_successor_hold_recovery-C-000",
+            "output_tokens-run-bounded_successor_hold_recovery-C-000"
+          ],
+          "invocation_ids": [
+            "run-bounded_successor_hold_recovery-C-000-turn-1",
+            "run-bounded_successor_hold_recovery-C-000-turn-2"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-bounded_successor_hold_recovery-C-000",
+          "observed_at": "2026-07-30T02:57:41Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35590
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-bounded_successor_hold_recovery-C-000",
+          "observed_at": "2026-07-30T02:57:41Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 34.386
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-bounded_successor_hold_recovery-C-000",
+          "observed_at": "2026-07-30T02:57:41Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35362
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-bounded_successor_hold_recovery-C-000",
+          "observed_at": "2026-07-30T02:57:41Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 228
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-bounded_successor_hold_recovery-C-000",
+          "observed_at": "2026-07-30T02:57:41Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 44
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-bounded_successor_hold_recovery-C-000",
+          "observed_at": "2026-07-30T02:57:41Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-bounded_successor_hold_recovery-C-000",
+          "observed_at": "2026-07-30T02:57:41Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "bounded_successor_hold_recovery-C-000",
+      "scenario": {
+        "actual_role_route": "Coordinator>Successor",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-bounded_successor_hold_recovery-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "bounded_successor_hold_recovery",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "bounded_successor_hold_recovery",
+      "terminal_state": "completed",
+      "variant": "C",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-bounded_successor_hold_recovery-C-000",
+      "successor_continuity": {
+        "predecessor_work_id": "work-bounded_successor_hold_recovery-C-000",
+        "successor_work_id": "work-bounded_successor_hold_recovery-C-000",
+        "predecessor_root_budget": 100000,
+        "successor_root_budget": 100000,
+        "predecessor_remaining_budget": 100000,
+        "successor_remaining_budget": 100000
+      }
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457",
+        "predecessor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-predecessor",
+        "successor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-successor"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-bounded_successor_hold_recovery-A-001",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:58:00Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-bounded_successor_hold_recovery-A-001",
+          "observed_at": "2026-07-30T02:58:00Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 2432
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-bounded_successor_hold_recovery-A-001",
+          "observed_at": "2026-07-30T02:58:00Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-bounded_successor_hold_recovery-A-001",
+            "output_tokens-run-bounded_successor_hold_recovery-A-001"
+          ],
+          "invocation_ids": [
+            "run-bounded_successor_hold_recovery-A-001-turn-1"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-bounded_successor_hold_recovery-A-001",
+          "observed_at": "2026-07-30T02:58:00Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17753
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-bounded_successor_hold_recovery-A-001",
+          "observed_at": "2026-07-30T02:58:00Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 18.758
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-bounded_successor_hold_recovery-A-001",
+          "observed_at": "2026-07-30T02:58:00Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17639
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-bounded_successor_hold_recovery-A-001",
+          "observed_at": "2026-07-30T02:58:00Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 114
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-bounded_successor_hold_recovery-A-001",
+          "observed_at": "2026-07-30T02:58:00Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 24
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-bounded_successor_hold_recovery-A-001",
+          "observed_at": "2026-07-30T02:58:00Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-bounded_successor_hold_recovery-A-001",
+          "observed_at": "2026-07-30T02:58:00Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "bounded_successor_hold_recovery-A-001",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-bounded_successor_hold_recovery-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "bounded_successor_hold_recovery",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "bounded_successor_hold_recovery",
+      "terminal_state": "completed",
+      "variant": "A",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-bounded_successor_hold_recovery-A-001",
+      "successor_continuity": {
+        "predecessor_work_id": "work-bounded_successor_hold_recovery-A-001",
+        "successor_work_id": "work-bounded_successor_hold_recovery-A-001",
+        "predecessor_root_budget": 100000,
+        "successor_root_budget": 100000,
+        "predecessor_remaining_budget": 100000,
+        "successor_remaining_budget": 100000
+      }
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457",
+        "predecessor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-predecessor",
+        "successor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-successor"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-bounded_successor_hold_recovery-B-001",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:58:00Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "counterfactual",
+        "source": "declared-counterfactual"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cached_input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "callback_count": {
+          "availability": "unavailable",
+          "observation_id": "callback_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cumulative_resource_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "elapsed_seconds": {
+          "availability": "unavailable",
+          "observation_id": "elapsed_seconds-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": null
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "output_tokens": {
+          "availability": "unavailable",
+          "observation_id": "output_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "unavailable",
+          "observation_id": "reasoning_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "recovery_count": {
+          "availability": "unavailable",
+          "observation_id": "recovery_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "retry_count": {
+          "availability": "unavailable",
+          "observation_id": "retry_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "bounded_successor_hold_recovery-B-001",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-bounded_successor_hold_recovery-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "bounded_successor_hold_recovery",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "bounded_successor_hold_recovery",
+      "terminal_state": "completed",
+      "variant": "B",
+      "variant_declaration": {
+        "route_kind": "counterfactual"
+      },
+      "work_id": "work-bounded_successor_hold_recovery-B-001",
+      "successor_continuity": {
+        "predecessor_work_id": "work-bounded_successor_hold_recovery-B-001",
+        "successor_work_id": "work-bounded_successor_hold_recovery-B-001",
+        "predecessor_root_budget": 100000,
+        "successor_root_budget": 100000,
+        "predecessor_remaining_budget": 100000,
+        "successor_remaining_budget": 100000
+      }
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457",
+        "predecessor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-predecessor",
+        "successor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-successor"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-bounded_successor_hold_recovery-C-001",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:58:37Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-bounded_successor_hold_recovery-C-001",
+          "observed_at": "2026-07-30T02:58:37Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 33536
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-bounded_successor_hold_recovery-C-001",
+          "observed_at": "2026-07-30T02:58:37Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 1
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-bounded_successor_hold_recovery-C-001",
+            "output_tokens-run-bounded_successor_hold_recovery-C-001"
+          ],
+          "invocation_ids": [
+            "run-bounded_successor_hold_recovery-C-001-turn-1",
+            "run-bounded_successor_hold_recovery-C-001-turn-2"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-bounded_successor_hold_recovery-C-001",
+          "observed_at": "2026-07-30T02:58:37Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35644
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-bounded_successor_hold_recovery-C-001",
+          "observed_at": "2026-07-30T02:58:37Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 37.259
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-bounded_successor_hold_recovery-C-001",
+          "observed_at": "2026-07-30T02:58:37Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35367
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-bounded_successor_hold_recovery-C-001",
+          "observed_at": "2026-07-30T02:58:37Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 277
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-bounded_successor_hold_recovery-C-001",
+          "observed_at": "2026-07-30T02:58:37Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 96
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-bounded_successor_hold_recovery-C-001",
+          "observed_at": "2026-07-30T02:58:37Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-bounded_successor_hold_recovery-C-001",
+          "observed_at": "2026-07-30T02:58:37Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "bounded_successor_hold_recovery-C-001",
+      "scenario": {
+        "actual_role_route": "Coordinator>Successor",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-bounded_successor_hold_recovery-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "bounded_successor_hold_recovery",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "bounded_successor_hold_recovery",
+      "terminal_state": "completed",
+      "variant": "C",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-bounded_successor_hold_recovery-C-001",
+      "successor_continuity": {
+        "predecessor_work_id": "work-bounded_successor_hold_recovery-C-001",
+        "successor_work_id": "work-bounded_successor_hold_recovery-C-001",
+        "predecessor_root_budget": 100000,
+        "successor_root_budget": 100000,
+        "predecessor_remaining_budget": 100000,
+        "successor_remaining_budget": 100000
+      }
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457",
+        "predecessor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-predecessor",
+        "successor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-successor"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-bounded_successor_hold_recovery-A-002",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:59:00Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-bounded_successor_hold_recovery-A-002",
+          "observed_at": "2026-07-30T02:59:00Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 16768
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-bounded_successor_hold_recovery-A-002",
+          "observed_at": "2026-07-30T02:59:00Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-bounded_successor_hold_recovery-A-002",
+            "output_tokens-run-bounded_successor_hold_recovery-A-002"
+          ],
+          "invocation_ids": [
+            "run-bounded_successor_hold_recovery-A-002-turn-1"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-bounded_successor_hold_recovery-A-002",
+          "observed_at": "2026-07-30T02:59:00Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17760
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-bounded_successor_hold_recovery-A-002",
+          "observed_at": "2026-07-30T02:59:00Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 22.694
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-bounded_successor_hold_recovery-A-002",
+          "observed_at": "2026-07-30T02:59:00Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17639
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-bounded_successor_hold_recovery-A-002",
+          "observed_at": "2026-07-30T02:59:00Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 121
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-bounded_successor_hold_recovery-A-002",
+          "observed_at": "2026-07-30T02:59:00Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 28
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-bounded_successor_hold_recovery-A-002",
+          "observed_at": "2026-07-30T02:59:00Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-bounded_successor_hold_recovery-A-002",
+          "observed_at": "2026-07-30T02:59:00Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "bounded_successor_hold_recovery-A-002",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-bounded_successor_hold_recovery-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "bounded_successor_hold_recovery",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "bounded_successor_hold_recovery",
+      "terminal_state": "completed",
+      "variant": "A",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-bounded_successor_hold_recovery-A-002",
+      "successor_continuity": {
+        "predecessor_work_id": "work-bounded_successor_hold_recovery-A-002",
+        "successor_work_id": "work-bounded_successor_hold_recovery-A-002",
+        "predecessor_root_budget": 100000,
+        "successor_root_budget": 100000,
+        "predecessor_remaining_budget": 100000,
+        "successor_remaining_budget": 100000
+      }
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457",
+        "predecessor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-predecessor",
+        "successor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-successor"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-bounded_successor_hold_recovery-B-002",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:59:00Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "counterfactual",
+        "source": "declared-counterfactual"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cached_input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "callback_count": {
+          "availability": "unavailable",
+          "observation_id": "callback_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cumulative_resource_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "elapsed_seconds": {
+          "availability": "unavailable",
+          "observation_id": "elapsed_seconds-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": null
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "output_tokens": {
+          "availability": "unavailable",
+          "observation_id": "output_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "unavailable",
+          "observation_id": "reasoning_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "recovery_count": {
+          "availability": "unavailable",
+          "observation_id": "recovery_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "retry_count": {
+          "availability": "unavailable",
+          "observation_id": "retry_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "bounded_successor_hold_recovery-B-002",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-bounded_successor_hold_recovery-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "bounded_successor_hold_recovery",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "bounded_successor_hold_recovery",
+      "terminal_state": "completed",
+      "variant": "B",
+      "variant_declaration": {
+        "route_kind": "counterfactual"
+      },
+      "work_id": "work-bounded_successor_hold_recovery-B-002",
+      "successor_continuity": {
+        "predecessor_work_id": "work-bounded_successor_hold_recovery-B-002",
+        "successor_work_id": "work-bounded_successor_hold_recovery-B-002",
+        "predecessor_root_budget": 100000,
+        "successor_root_budget": 100000,
+        "predecessor_remaining_budget": 100000,
+        "successor_remaining_budget": 100000
+      }
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457",
+        "predecessor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-predecessor",
+        "successor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-successor"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-bounded_successor_hold_recovery-C-002",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:59:40Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-bounded_successor_hold_recovery-C-002",
+          "observed_at": "2026-07-30T02:59:40Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 33536
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-bounded_successor_hold_recovery-C-002",
+          "observed_at": "2026-07-30T02:59:40Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 1
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-bounded_successor_hold_recovery-C-002",
+            "output_tokens-run-bounded_successor_hold_recovery-C-002"
+          ],
+          "invocation_ids": [
+            "run-bounded_successor_hold_recovery-C-002-turn-1",
+            "run-bounded_successor_hold_recovery-C-002-turn-2"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-bounded_successor_hold_recovery-C-002",
+          "observed_at": "2026-07-30T02:59:40Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35370
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-bounded_successor_hold_recovery-C-002",
+          "observed_at": "2026-07-30T02:59:40Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 40.763
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-bounded_successor_hold_recovery-C-002",
+          "observed_at": "2026-07-30T02:59:40Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35136
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-bounded_successor_hold_recovery-C-002",
+          "observed_at": "2026-07-30T02:59:40Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 234
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-bounded_successor_hold_recovery-C-002",
+          "observed_at": "2026-07-30T02:59:40Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 54
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-bounded_successor_hold_recovery-C-002",
+          "observed_at": "2026-07-30T02:59:40Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-bounded_successor_hold_recovery-C-002",
+          "observed_at": "2026-07-30T02:59:40Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "bounded_successor_hold_recovery-C-002",
+      "scenario": {
+        "actual_role_route": "Coordinator>Successor",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-bounded_successor_hold_recovery-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "bounded_successor_hold_recovery",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "bounded_successor_hold_recovery",
+      "terminal_state": "completed",
+      "variant": "C",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-bounded_successor_hold_recovery-C-002",
+      "successor_continuity": {
+        "predecessor_work_id": "work-bounded_successor_hold_recovery-C-002",
+        "successor_work_id": "work-bounded_successor_hold_recovery-C-002",
+        "predecessor_root_budget": 100000,
+        "successor_root_budget": 100000,
+        "predecessor_remaining_budget": 100000,
+        "successor_remaining_budget": 100000
+      }
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457",
+        "predecessor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-predecessor",
+        "successor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-successor"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-bounded_successor_hold_recovery-A-003",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:59:59Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-bounded_successor_hold_recovery-A-003",
+          "observed_at": "2026-07-30T02:59:59Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 16768
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-bounded_successor_hold_recovery-A-003",
+          "observed_at": "2026-07-30T02:59:59Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-bounded_successor_hold_recovery-A-003",
+            "output_tokens-run-bounded_successor_hold_recovery-A-003"
+          ],
+          "invocation_ids": [
+            "run-bounded_successor_hold_recovery-A-003-turn-1"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-bounded_successor_hold_recovery-A-003",
+          "observed_at": "2026-07-30T02:59:59Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17758
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-bounded_successor_hold_recovery-A-003",
+          "observed_at": "2026-07-30T02:59:59Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 18.957
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-bounded_successor_hold_recovery-A-003",
+          "observed_at": "2026-07-30T02:59:59Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17639
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-bounded_successor_hold_recovery-A-003",
+          "observed_at": "2026-07-30T02:59:59Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 119
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-bounded_successor_hold_recovery-A-003",
+          "observed_at": "2026-07-30T02:59:59Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 18
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-bounded_successor_hold_recovery-A-003",
+          "observed_at": "2026-07-30T02:59:59Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-bounded_successor_hold_recovery-A-003",
+          "observed_at": "2026-07-30T02:59:59Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "bounded_successor_hold_recovery-A-003",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-bounded_successor_hold_recovery-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "bounded_successor_hold_recovery",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "bounded_successor_hold_recovery",
+      "terminal_state": "completed",
+      "variant": "A",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-bounded_successor_hold_recovery-A-003",
+      "successor_continuity": {
+        "predecessor_work_id": "work-bounded_successor_hold_recovery-A-003",
+        "successor_work_id": "work-bounded_successor_hold_recovery-A-003",
+        "predecessor_root_budget": 100000,
+        "successor_root_budget": 100000,
+        "predecessor_remaining_budget": 100000,
+        "successor_remaining_budget": 100000
+      }
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457",
+        "predecessor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-predecessor",
+        "successor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-successor"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-bounded_successor_hold_recovery-B-003",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:59:59Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "counterfactual",
+        "source": "declared-counterfactual"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cached_input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "callback_count": {
+          "availability": "unavailable",
+          "observation_id": "callback_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cumulative_resource_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "elapsed_seconds": {
+          "availability": "unavailable",
+          "observation_id": "elapsed_seconds-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": null
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "output_tokens": {
+          "availability": "unavailable",
+          "observation_id": "output_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "unavailable",
+          "observation_id": "reasoning_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "recovery_count": {
+          "availability": "unavailable",
+          "observation_id": "recovery_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "retry_count": {
+          "availability": "unavailable",
+          "observation_id": "retry_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "bounded_successor_hold_recovery-B-003",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-bounded_successor_hold_recovery-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "bounded_successor_hold_recovery",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "bounded_successor_hold_recovery",
+      "terminal_state": "completed",
+      "variant": "B",
+      "variant_declaration": {
+        "route_kind": "counterfactual"
+      },
+      "work_id": "work-bounded_successor_hold_recovery-B-003",
+      "successor_continuity": {
+        "predecessor_work_id": "work-bounded_successor_hold_recovery-B-003",
+        "successor_work_id": "work-bounded_successor_hold_recovery-B-003",
+        "predecessor_root_budget": 100000,
+        "successor_root_budget": 100000,
+        "predecessor_remaining_budget": 100000,
+        "successor_remaining_budget": 100000
+      }
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457",
+        "predecessor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-predecessor",
+        "successor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-successor"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-bounded_successor_hold_recovery-C-003",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T03:00:49Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-bounded_successor_hold_recovery-C-003",
+          "observed_at": "2026-07-30T03:00:49Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 33536
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-bounded_successor_hold_recovery-C-003",
+          "observed_at": "2026-07-30T03:00:49Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 1
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-bounded_successor_hold_recovery-C-003",
+            "output_tokens-run-bounded_successor_hold_recovery-C-003"
+          ],
+          "invocation_ids": [
+            "run-bounded_successor_hold_recovery-C-003-turn-1",
+            "run-bounded_successor_hold_recovery-C-003-turn-2"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-bounded_successor_hold_recovery-C-003",
+          "observed_at": "2026-07-30T03:00:49Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35594
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-bounded_successor_hold_recovery-C-003",
+          "observed_at": "2026-07-30T03:00:49Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 49.785
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-bounded_successor_hold_recovery-C-003",
+          "observed_at": "2026-07-30T03:00:49Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35362
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-bounded_successor_hold_recovery-C-003",
+          "observed_at": "2026-07-30T03:00:49Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 232
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-bounded_successor_hold_recovery-C-003",
+          "observed_at": "2026-07-30T03:00:49Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 62
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-bounded_successor_hold_recovery-C-003",
+          "observed_at": "2026-07-30T03:00:49Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-bounded_successor_hold_recovery-C-003",
+          "observed_at": "2026-07-30T03:00:49Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "bounded_successor_hold_recovery-C-003",
+      "scenario": {
+        "actual_role_route": "Coordinator>Successor",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-bounded_successor_hold_recovery-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "bounded_successor_hold_recovery",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "bounded_successor_hold_recovery",
+      "terminal_state": "completed",
+      "variant": "C",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-bounded_successor_hold_recovery-C-003",
+      "successor_continuity": {
+        "predecessor_work_id": "work-bounded_successor_hold_recovery-C-003",
+        "successor_work_id": "work-bounded_successor_hold_recovery-C-003",
+        "predecessor_root_budget": 100000,
+        "successor_root_budget": 100000,
+        "predecessor_remaining_budget": 100000,
+        "successor_remaining_budget": 100000
+      }
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457",
+        "predecessor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-predecessor",
+        "successor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-successor"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-bounded_successor_hold_recovery-A-004",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T03:01:09Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-bounded_successor_hold_recovery-A-004",
+          "observed_at": "2026-07-30T03:01:09Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 14720
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-bounded_successor_hold_recovery-A-004",
+          "observed_at": "2026-07-30T03:01:09Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-bounded_successor_hold_recovery-A-004",
+            "output_tokens-run-bounded_successor_hold_recovery-A-004"
+          ],
+          "invocation_ids": [
+            "run-bounded_successor_hold_recovery-A-004-turn-1"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-bounded_successor_hold_recovery-A-004",
+          "observed_at": "2026-07-30T03:01:09Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17757
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-bounded_successor_hold_recovery-A-004",
+          "observed_at": "2026-07-30T03:01:09Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 20.159
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-bounded_successor_hold_recovery-A-004",
+          "observed_at": "2026-07-30T03:01:09Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17639
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-bounded_successor_hold_recovery-A-004",
+          "observed_at": "2026-07-30T03:01:09Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 118
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-bounded_successor_hold_recovery-A-004",
+          "observed_at": "2026-07-30T03:01:09Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 22
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-bounded_successor_hold_recovery-A-004",
+          "observed_at": "2026-07-30T03:01:09Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-bounded_successor_hold_recovery-A-004",
+          "observed_at": "2026-07-30T03:01:09Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "bounded_successor_hold_recovery-A-004",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-bounded_successor_hold_recovery-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "bounded_successor_hold_recovery",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "bounded_successor_hold_recovery",
+      "terminal_state": "completed",
+      "variant": "A",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-bounded_successor_hold_recovery-A-004",
+      "successor_continuity": {
+        "predecessor_work_id": "work-bounded_successor_hold_recovery-A-004",
+        "successor_work_id": "work-bounded_successor_hold_recovery-A-004",
+        "predecessor_root_budget": 100000,
+        "successor_root_budget": 100000,
+        "predecessor_remaining_budget": 100000,
+        "successor_remaining_budget": 100000
+      }
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457",
+        "predecessor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-predecessor",
+        "successor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-successor"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-bounded_successor_hold_recovery-B-004",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T03:01:09Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "counterfactual",
+        "source": "declared-counterfactual"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cached_input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "callback_count": {
+          "availability": "unavailable",
+          "observation_id": "callback_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cumulative_resource_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "elapsed_seconds": {
+          "availability": "unavailable",
+          "observation_id": "elapsed_seconds-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": null
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "output_tokens": {
+          "availability": "unavailable",
+          "observation_id": "output_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "unavailable",
+          "observation_id": "reasoning_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "recovery_count": {
+          "availability": "unavailable",
+          "observation_id": "recovery_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "retry_count": {
+          "availability": "unavailable",
+          "observation_id": "retry_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "bounded_successor_hold_recovery-B-004",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-bounded_successor_hold_recovery-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "bounded_successor_hold_recovery",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "bounded_successor_hold_recovery",
+      "terminal_state": "completed",
+      "variant": "B",
+      "variant_declaration": {
+        "route_kind": "counterfactual"
+      },
+      "work_id": "work-bounded_successor_hold_recovery-B-004",
+      "successor_continuity": {
+        "predecessor_work_id": "work-bounded_successor_hold_recovery-B-004",
+        "successor_work_id": "work-bounded_successor_hold_recovery-B-004",
+        "predecessor_root_budget": 100000,
+        "successor_root_budget": 100000,
+        "predecessor_remaining_budget": 100000,
+        "successor_remaining_budget": 100000
+      }
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457",
+        "predecessor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-predecessor",
+        "successor": "https://github.com/farmerhunter/agent-foundry/issues/457#successor-successor"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-bounded_successor_hold_recovery-C-004",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T03:01:46Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-bounded_successor_hold_recovery-C-004",
+          "observed_at": "2026-07-30T03:01:46Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 33536
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-bounded_successor_hold_recovery-C-004",
+          "observed_at": "2026-07-30T03:01:46Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 1
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-bounded_successor_hold_recovery-C-004",
+            "output_tokens-run-bounded_successor_hold_recovery-C-004"
+          ],
+          "invocation_ids": [
+            "run-bounded_successor_hold_recovery-C-004-turn-1",
+            "run-bounded_successor_hold_recovery-C-004-turn-2"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-bounded_successor_hold_recovery-C-004",
+          "observed_at": "2026-07-30T03:01:46Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35613
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-bounded_successor_hold_recovery-C-004",
+          "observed_at": "2026-07-30T03:01:46Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 37.266000000000005
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-bounded_successor_hold_recovery-C-004",
+          "observed_at": "2026-07-30T03:01:46Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35363
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-bounded_successor_hold_recovery-C-004",
+          "observed_at": "2026-07-30T03:01:46Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 250
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-bounded_successor_hold_recovery-C-004",
+          "observed_at": "2026-07-30T03:01:46Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 59
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-bounded_successor_hold_recovery-C-004",
+          "observed_at": "2026-07-30T03:01:46Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-bounded_successor_hold_recovery-C-004",
+          "observed_at": "2026-07-30T03:01:46Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "bounded_successor_hold_recovery-C-004",
+      "scenario": {
+        "actual_role_route": "Coordinator>Successor",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-bounded_successor_hold_recovery-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "bounded_successor_hold_recovery",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "bounded_successor_hold_recovery",
+      "terminal_state": "completed",
+      "variant": "C",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-bounded_successor_hold_recovery-C-004",
+      "successor_continuity": {
+        "predecessor_work_id": "work-bounded_successor_hold_recovery-C-004",
+        "successor_work_id": "work-bounded_successor_hold_recovery-C-004",
+        "predecessor_root_budget": 100000,
+        "successor_root_budget": 100000,
+        "predecessor_remaining_budget": 100000,
+        "successor_remaining_budget": 100000
+      }
+    }
+  ],
+  "schema_version": 1
+}

--- a/scripts/fixtures/af18_calibration/real-reclassified/independent_review_or_test_handoff.json
+++ b/scripts/fixtures/af18_calibration/real-reclassified/independent_review_or_test_handoff.json
@@ -1,0 +1,3092 @@
+{
+  "collection_mode": "codex_jsonl_export",
+  "protocol_version": "af18-calibration-protocol-v1",
+  "samples": [
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-independent_review_or_test_handoff-A-000",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:51:59Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-independent_review_or_test_handoff-A-000",
+          "observed_at": "2026-07-30T02:51:59Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 9600
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-independent_review_or_test_handoff-A-000",
+          "observed_at": "2026-07-30T02:51:59Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-independent_review_or_test_handoff-A-000",
+            "output_tokens-run-independent_review_or_test_handoff-A-000"
+          ],
+          "invocation_ids": [
+            "run-independent_review_or_test_handoff-A-000-turn-1"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-independent_review_or_test_handoff-A-000",
+          "observed_at": "2026-07-30T02:51:59Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17736
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-independent_review_or_test_handoff-A-000",
+          "observed_at": "2026-07-30T02:51:59Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 25.515
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-independent_review_or_test_handoff-A-000",
+          "observed_at": "2026-07-30T02:51:59Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17638
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-independent_review_or_test_handoff-A-000",
+          "observed_at": "2026-07-30T02:51:59Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 98
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-independent_review_or_test_handoff-A-000",
+          "observed_at": "2026-07-30T02:51:59Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 20
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-independent_review_or_test_handoff-A-000",
+          "observed_at": "2026-07-30T02:51:59Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-independent_review_or_test_handoff-A-000",
+          "observed_at": "2026-07-30T02:51:59Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "independent_review_or_test_handoff-A-000",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-independent_review_or_test_handoff-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "independent_review_or_test_handoff",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "independent_review_or_test_handoff",
+      "terminal_state": "completed",
+      "variant": "A",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-independent_review_or_test_handoff-A-000"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-independent_review_or_test_handoff-B-000",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:51:59Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "counterfactual",
+        "source": "declared-counterfactual"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cached_input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "callback_count": {
+          "availability": "unavailable",
+          "observation_id": "callback_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cumulative_resource_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "elapsed_seconds": {
+          "availability": "unavailable",
+          "observation_id": "elapsed_seconds-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": null
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "output_tokens": {
+          "availability": "unavailable",
+          "observation_id": "output_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "unavailable",
+          "observation_id": "reasoning_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "recovery_count": {
+          "availability": "unavailable",
+          "observation_id": "recovery_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "retry_count": {
+          "availability": "unavailable",
+          "observation_id": "retry_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "independent_review_or_test_handoff-B-000",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-independent_review_or_test_handoff-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "independent_review_or_test_handoff",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "independent_review_or_test_handoff",
+      "terminal_state": "completed",
+      "variant": "B",
+      "variant_declaration": {
+        "route_kind": "counterfactual"
+      },
+      "work_id": "work-independent_review_or_test_handoff-B-000"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-independent_review_or_test_handoff-C-000",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:52:39Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-independent_review_or_test_handoff-C-000",
+          "observed_at": "2026-07-30T02:52:39Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 31488
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-independent_review_or_test_handoff-C-000",
+          "observed_at": "2026-07-30T02:52:39Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 1
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-independent_review_or_test_handoff-C-000",
+            "output_tokens-run-independent_review_or_test_handoff-C-000"
+          ],
+          "invocation_ids": [
+            "run-independent_review_or_test_handoff-C-000-turn-1",
+            "run-independent_review_or_test_handoff-C-000-turn-2"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-independent_review_or_test_handoff-C-000",
+          "observed_at": "2026-07-30T02:52:39Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35607
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-independent_review_or_test_handoff-C-000",
+          "observed_at": "2026-07-30T02:52:39Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 39.724999999999994
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-independent_review_or_test_handoff-C-000",
+          "observed_at": "2026-07-30T02:52:39Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35356
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-independent_review_or_test_handoff-C-000",
+          "observed_at": "2026-07-30T02:52:39Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 251
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-independent_review_or_test_handoff-C-000",
+          "observed_at": "2026-07-30T02:52:39Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 65
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-independent_review_or_test_handoff-C-000",
+          "observed_at": "2026-07-30T02:52:39Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-independent_review_or_test_handoff-C-000",
+          "observed_at": "2026-07-30T02:52:39Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "independent_review_or_test_handoff-C-000",
+      "scenario": {
+        "actual_role_route": "Implementer>Tester",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-independent_review_or_test_handoff-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "independent_review_or_test_handoff",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "independent_review_or_test_handoff",
+      "terminal_state": "completed",
+      "variant": "C",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-independent_review_or_test_handoff-C-000"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-independent_review_or_test_handoff-A-001",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:52:54Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-independent_review_or_test_handoff-A-001",
+          "observed_at": "2026-07-30T02:52:54Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 16768
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-independent_review_or_test_handoff-A-001",
+          "observed_at": "2026-07-30T02:52:54Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-independent_review_or_test_handoff-A-001",
+            "output_tokens-run-independent_review_or_test_handoff-A-001"
+          ],
+          "invocation_ids": [
+            "run-independent_review_or_test_handoff-A-001-turn-1"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-independent_review_or_test_handoff-A-001",
+          "observed_at": "2026-07-30T02:52:54Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17750
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-independent_review_or_test_handoff-A-001",
+          "observed_at": "2026-07-30T02:52:54Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 15.34
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-independent_review_or_test_handoff-A-001",
+          "observed_at": "2026-07-30T02:52:54Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17638
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-independent_review_or_test_handoff-A-001",
+          "observed_at": "2026-07-30T02:52:54Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 112
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-independent_review_or_test_handoff-A-001",
+          "observed_at": "2026-07-30T02:52:54Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 28
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-independent_review_or_test_handoff-A-001",
+          "observed_at": "2026-07-30T02:52:54Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-independent_review_or_test_handoff-A-001",
+          "observed_at": "2026-07-30T02:52:54Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "independent_review_or_test_handoff-A-001",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-independent_review_or_test_handoff-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "independent_review_or_test_handoff",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "independent_review_or_test_handoff",
+      "terminal_state": "completed",
+      "variant": "A",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-independent_review_or_test_handoff-A-001"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-independent_review_or_test_handoff-B-001",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:52:54Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "counterfactual",
+        "source": "declared-counterfactual"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cached_input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "callback_count": {
+          "availability": "unavailable",
+          "observation_id": "callback_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cumulative_resource_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "elapsed_seconds": {
+          "availability": "unavailable",
+          "observation_id": "elapsed_seconds-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": null
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "output_tokens": {
+          "availability": "unavailable",
+          "observation_id": "output_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "unavailable",
+          "observation_id": "reasoning_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "recovery_count": {
+          "availability": "unavailable",
+          "observation_id": "recovery_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "retry_count": {
+          "availability": "unavailable",
+          "observation_id": "retry_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "independent_review_or_test_handoff-B-001",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-independent_review_or_test_handoff-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "independent_review_or_test_handoff",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "independent_review_or_test_handoff",
+      "terminal_state": "completed",
+      "variant": "B",
+      "variant_declaration": {
+        "route_kind": "counterfactual"
+      },
+      "work_id": "work-independent_review_or_test_handoff-B-001"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-independent_review_or_test_handoff-C-001",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:53:30Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-independent_review_or_test_handoff-C-001",
+          "observed_at": "2026-07-30T02:53:30Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 31488
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-independent_review_or_test_handoff-C-001",
+          "observed_at": "2026-07-30T02:53:30Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 1
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-independent_review_or_test_handoff-C-001",
+            "output_tokens-run-independent_review_or_test_handoff-C-001"
+          ],
+          "invocation_ids": [
+            "run-independent_review_or_test_handoff-C-001-turn-1",
+            "run-independent_review_or_test_handoff-C-001-turn-2"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-independent_review_or_test_handoff-C-001",
+          "observed_at": "2026-07-30T02:53:30Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35624
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-independent_review_or_test_handoff-C-001",
+          "observed_at": "2026-07-30T02:53:30Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 36.105000000000004
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-independent_review_or_test_handoff-C-001",
+          "observed_at": "2026-07-30T02:53:30Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35360
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-independent_review_or_test_handoff-C-001",
+          "observed_at": "2026-07-30T02:53:30Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 264
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-independent_review_or_test_handoff-C-001",
+          "observed_at": "2026-07-30T02:53:30Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 78
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-independent_review_or_test_handoff-C-001",
+          "observed_at": "2026-07-30T02:53:30Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-independent_review_or_test_handoff-C-001",
+          "observed_at": "2026-07-30T02:53:30Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "independent_review_or_test_handoff-C-001",
+      "scenario": {
+        "actual_role_route": "Implementer>Tester",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-independent_review_or_test_handoff-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "independent_review_or_test_handoff",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "independent_review_or_test_handoff",
+      "terminal_state": "completed",
+      "variant": "C",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-independent_review_or_test_handoff-C-001"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-independent_review_or_test_handoff-A-002",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:53:48Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-independent_review_or_test_handoff-A-002",
+          "observed_at": "2026-07-30T02:53:48Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 16768
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-independent_review_or_test_handoff-A-002",
+          "observed_at": "2026-07-30T02:53:48Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-independent_review_or_test_handoff-A-002",
+            "output_tokens-run-independent_review_or_test_handoff-A-002"
+          ],
+          "invocation_ids": [
+            "run-independent_review_or_test_handoff-A-002-turn-1"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-independent_review_or_test_handoff-A-002",
+          "observed_at": "2026-07-30T02:53:48Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17788
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-independent_review_or_test_handoff-A-002",
+          "observed_at": "2026-07-30T02:53:48Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 17.966
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-independent_review_or_test_handoff-A-002",
+          "observed_at": "2026-07-30T02:53:48Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17638
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-independent_review_or_test_handoff-A-002",
+          "observed_at": "2026-07-30T02:53:48Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 150
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-independent_review_or_test_handoff-A-002",
+          "observed_at": "2026-07-30T02:53:48Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 25
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-independent_review_or_test_handoff-A-002",
+          "observed_at": "2026-07-30T02:53:48Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-independent_review_or_test_handoff-A-002",
+          "observed_at": "2026-07-30T02:53:48Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "independent_review_or_test_handoff-A-002",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-independent_review_or_test_handoff-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "independent_review_or_test_handoff",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "independent_review_or_test_handoff",
+      "terminal_state": "completed",
+      "variant": "A",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-independent_review_or_test_handoff-A-002"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-independent_review_or_test_handoff-B-002",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:53:48Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "counterfactual",
+        "source": "declared-counterfactual"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cached_input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "callback_count": {
+          "availability": "unavailable",
+          "observation_id": "callback_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cumulative_resource_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "elapsed_seconds": {
+          "availability": "unavailable",
+          "observation_id": "elapsed_seconds-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": null
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "output_tokens": {
+          "availability": "unavailable",
+          "observation_id": "output_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "unavailable",
+          "observation_id": "reasoning_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "recovery_count": {
+          "availability": "unavailable",
+          "observation_id": "recovery_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "retry_count": {
+          "availability": "unavailable",
+          "observation_id": "retry_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "independent_review_or_test_handoff-B-002",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-independent_review_or_test_handoff-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "independent_review_or_test_handoff",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "independent_review_or_test_handoff",
+      "terminal_state": "completed",
+      "variant": "B",
+      "variant_declaration": {
+        "route_kind": "counterfactual"
+      },
+      "work_id": "work-independent_review_or_test_handoff-B-002"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-independent_review_or_test_handoff-C-002",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:54:23Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-independent_review_or_test_handoff-C-002",
+          "observed_at": "2026-07-30T02:54:23Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 33536
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-independent_review_or_test_handoff-C-002",
+          "observed_at": "2026-07-30T02:54:23Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 1
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-independent_review_or_test_handoff-C-002",
+            "output_tokens-run-independent_review_or_test_handoff-C-002"
+          ],
+          "invocation_ids": [
+            "run-independent_review_or_test_handoff-C-002-turn-1",
+            "run-independent_review_or_test_handoff-C-002-turn-2"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-independent_review_or_test_handoff-C-002",
+          "observed_at": "2026-07-30T02:54:23Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35581
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-independent_review_or_test_handoff-C-002",
+          "observed_at": "2026-07-30T02:54:23Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 34.22
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-independent_review_or_test_handoff-C-002",
+          "observed_at": "2026-07-30T02:54:23Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35342
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-independent_review_or_test_handoff-C-002",
+          "observed_at": "2026-07-30T02:54:23Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 239
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-independent_review_or_test_handoff-C-002",
+          "observed_at": "2026-07-30T02:54:23Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 83
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-independent_review_or_test_handoff-C-002",
+          "observed_at": "2026-07-30T02:54:23Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-independent_review_or_test_handoff-C-002",
+          "observed_at": "2026-07-30T02:54:23Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "independent_review_or_test_handoff-C-002",
+      "scenario": {
+        "actual_role_route": "Implementer>Tester",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-independent_review_or_test_handoff-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "independent_review_or_test_handoff",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "independent_review_or_test_handoff",
+      "terminal_state": "completed",
+      "variant": "C",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-independent_review_or_test_handoff-C-002"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-independent_review_or_test_handoff-A-003",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:54:40Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-independent_review_or_test_handoff-A-003",
+          "observed_at": "2026-07-30T02:54:40Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 16768
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-independent_review_or_test_handoff-A-003",
+          "observed_at": "2026-07-30T02:54:40Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-independent_review_or_test_handoff-A-003",
+            "output_tokens-run-independent_review_or_test_handoff-A-003"
+          ],
+          "invocation_ids": [
+            "run-independent_review_or_test_handoff-A-003-turn-1"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-independent_review_or_test_handoff-A-003",
+          "observed_at": "2026-07-30T02:54:40Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17785
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-independent_review_or_test_handoff-A-003",
+          "observed_at": "2026-07-30T02:54:40Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 17.674
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-independent_review_or_test_handoff-A-003",
+          "observed_at": "2026-07-30T02:54:40Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17638
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-independent_review_or_test_handoff-A-003",
+          "observed_at": "2026-07-30T02:54:40Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 147
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-independent_review_or_test_handoff-A-003",
+          "observed_at": "2026-07-30T02:54:40Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 34
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-independent_review_or_test_handoff-A-003",
+          "observed_at": "2026-07-30T02:54:40Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-independent_review_or_test_handoff-A-003",
+          "observed_at": "2026-07-30T02:54:40Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "independent_review_or_test_handoff-A-003",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-independent_review_or_test_handoff-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "independent_review_or_test_handoff",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "independent_review_or_test_handoff",
+      "terminal_state": "completed",
+      "variant": "A",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-independent_review_or_test_handoff-A-003"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-independent_review_or_test_handoff-B-003",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:54:40Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "counterfactual",
+        "source": "declared-counterfactual"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cached_input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "callback_count": {
+          "availability": "unavailable",
+          "observation_id": "callback_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cumulative_resource_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "elapsed_seconds": {
+          "availability": "unavailable",
+          "observation_id": "elapsed_seconds-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": null
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "output_tokens": {
+          "availability": "unavailable",
+          "observation_id": "output_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "unavailable",
+          "observation_id": "reasoning_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "recovery_count": {
+          "availability": "unavailable",
+          "observation_id": "recovery_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "retry_count": {
+          "availability": "unavailable",
+          "observation_id": "retry_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "independent_review_or_test_handoff-B-003",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-independent_review_or_test_handoff-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "independent_review_or_test_handoff",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "independent_review_or_test_handoff",
+      "terminal_state": "completed",
+      "variant": "B",
+      "variant_declaration": {
+        "route_kind": "counterfactual"
+      },
+      "work_id": "work-independent_review_or_test_handoff-B-003"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-independent_review_or_test_handoff-C-003",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:55:15Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-independent_review_or_test_handoff-C-003",
+          "observed_at": "2026-07-30T02:55:15Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 33536
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-independent_review_or_test_handoff-C-003",
+          "observed_at": "2026-07-30T02:55:15Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 1
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-independent_review_or_test_handoff-C-003",
+            "output_tokens-run-independent_review_or_test_handoff-C-003"
+          ],
+          "invocation_ids": [
+            "run-independent_review_or_test_handoff-C-003-turn-1",
+            "run-independent_review_or_test_handoff-C-003-turn-2"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-independent_review_or_test_handoff-C-003",
+          "observed_at": "2026-07-30T02:55:15Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35684
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-independent_review_or_test_handoff-C-003",
+          "observed_at": "2026-07-30T02:55:15Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 34.559
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-independent_review_or_test_handoff-C-003",
+          "observed_at": "2026-07-30T02:55:15Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35370
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-independent_review_or_test_handoff-C-003",
+          "observed_at": "2026-07-30T02:55:15Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 314
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-independent_review_or_test_handoff-C-003",
+          "observed_at": "2026-07-30T02:55:15Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 114
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-independent_review_or_test_handoff-C-003",
+          "observed_at": "2026-07-30T02:55:15Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-independent_review_or_test_handoff-C-003",
+          "observed_at": "2026-07-30T02:55:15Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "independent_review_or_test_handoff-C-003",
+      "scenario": {
+        "actual_role_route": "Implementer>Tester",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-independent_review_or_test_handoff-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "independent_review_or_test_handoff",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "independent_review_or_test_handoff",
+      "terminal_state": "completed",
+      "variant": "C",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-independent_review_or_test_handoff-C-003"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-independent_review_or_test_handoff-A-004",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:55:34Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-independent_review_or_test_handoff-A-004",
+          "observed_at": "2026-07-30T02:55:34Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 14720
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-independent_review_or_test_handoff-A-004",
+          "observed_at": "2026-07-30T02:55:34Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-independent_review_or_test_handoff-A-004",
+            "output_tokens-run-independent_review_or_test_handoff-A-004"
+          ],
+          "invocation_ids": [
+            "run-independent_review_or_test_handoff-A-004-turn-1"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-independent_review_or_test_handoff-A-004",
+          "observed_at": "2026-07-30T02:55:34Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17736
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-independent_review_or_test_handoff-A-004",
+          "observed_at": "2026-07-30T02:55:34Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 18.902
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-independent_review_or_test_handoff-A-004",
+          "observed_at": "2026-07-30T02:55:34Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 17638
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-independent_review_or_test_handoff-A-004",
+          "observed_at": "2026-07-30T02:55:34Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 98
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-independent_review_or_test_handoff-A-004",
+          "observed_at": "2026-07-30T02:55:34Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 20
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-independent_review_or_test_handoff-A-004",
+          "observed_at": "2026-07-30T02:55:34Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-independent_review_or_test_handoff-A-004",
+          "observed_at": "2026-07-30T02:55:34Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "independent_review_or_test_handoff-A-004",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-independent_review_or_test_handoff-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "independent_review_or_test_handoff",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "independent_review_or_test_handoff",
+      "terminal_state": "completed",
+      "variant": "A",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-independent_review_or_test_handoff-A-004"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-independent_review_or_test_handoff-B-004",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:55:34Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "counterfactual",
+        "source": "declared-counterfactual"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cached_input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "callback_count": {
+          "availability": "unavailable",
+          "observation_id": "callback_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "unavailable",
+          "observation_id": "cumulative_resource_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "elapsed_seconds": {
+          "availability": "unavailable",
+          "observation_id": "elapsed_seconds-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": null
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "unavailable",
+          "observation_id": "input_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "output_tokens": {
+          "availability": "unavailable",
+          "observation_id": "output_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "unavailable",
+          "observation_id": "reasoning_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        },
+        "recovery_count": {
+          "availability": "unavailable",
+          "observation_id": "recovery_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "retry_count": {
+          "availability": "unavailable",
+          "observation_id": "retry_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "independent_review_or_test_handoff-B-004",
+      "scenario": {
+        "actual_role_route": "Implementer",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-independent_review_or_test_handoff-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "independent_review_or_test_handoff",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "independent_review_or_test_handoff",
+      "terminal_state": "completed",
+      "variant": "B",
+      "variant_declaration": {
+        "route_kind": "counterfactual"
+      },
+      "work_id": "work-independent_review_or_test_handoff-B-004"
+    },
+    {
+      "anchors": {
+        "context": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "execution": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "work": "https://github.com/farmerhunter/agent-foundry/issues/457"
+      },
+      "attention": {
+        "acknowledgement": {
+          "availability": "unavailable",
+          "value": null
+        },
+        "category": null,
+        "outcome": "not_required",
+        "pairing": {
+          "evidence_anchor": null,
+          "pair_id": null
+        }
+      },
+      "execution_id": "run-independent_review_or_test_handoff-C-004",
+      "policy_version": "normal-observation-v1",
+      "protocol_version": "af18-calibration-protocol-v1",
+      "provenance": {
+        "captured_at": "2026-07-30T02:56:08Z",
+        "collection_method": "codex_jsonl_export",
+        "evidence_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#issuecomment-5125638653",
+        "observation_kind": "observed",
+        "source": "codex_jsonl_export"
+      },
+      "quality": {
+        "passed": true,
+        "reason": "pilot route completed"
+      },
+      "remaining_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "resources": {
+        "cached_input_tokens": {
+          "availability": "observed",
+          "observation_id": "cached_input_tokens-run-independent_review_or_test_handoff-C-004",
+          "observed_at": "2026-07-30T02:56:08Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 33536
+        },
+        "callback_count": {
+          "availability": "observed",
+          "observation_id": "callback-run-independent_review_or_test_handoff-C-004",
+          "observed_at": "2026-07-30T02:56:08Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 1
+        },
+        "compact_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "compact_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "context_age_hours": {
+          "availability": "unavailable",
+          "observation_id": "context_age_hours-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "hours",
+          "value": null
+        },
+        "cumulative_resource_tokens": {
+          "availability": "observed",
+          "derived_total_component_ids": [
+            "input_tokens-run-independent_review_or_test_handoff-C-004",
+            "output_tokens-run-independent_review_or_test_handoff-C-004"
+          ],
+          "invocation_ids": [
+            "run-independent_review_or_test_handoff-C-004-turn-1",
+            "run-independent_review_or_test_handoff-C-004-turn-2"
+          ],
+          "observation_basis": "derived",
+          "observation_id": "cumulative-run-independent_review_or_test_handoff-C-004",
+          "observed_at": "2026-07-30T02:56:08Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35606
+        },
+        "elapsed_seconds": {
+          "availability": "observed",
+          "observation_id": "elapsed-run-independent_review_or_test_handoff-C-004",
+          "observed_at": "2026-07-30T02:56:08Z",
+          "source": "host_collection",
+          "unit": "seconds",
+          "value": 34.504999999999995
+        },
+        "full_rehydration_count": {
+          "availability": "unavailable",
+          "observation_id": "full_rehydration_count-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "count",
+          "value": null
+        },
+        "input_tokens": {
+          "availability": "observed",
+          "observation_id": "input_tokens-run-independent_review_or_test_handoff-C-004",
+          "observed_at": "2026-07-30T02:56:08Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 35342
+        },
+        "output_tokens": {
+          "availability": "observed",
+          "observation_id": "output_tokens-run-independent_review_or_test_handoff-C-004",
+          "observed_at": "2026-07-30T02:56:08Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 264
+        },
+        "packet_bytes": {
+          "availability": "unavailable",
+          "observation_id": "packet_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "reasoning_tokens": {
+          "availability": "observed",
+          "observation_id": "reasoning_tokens-run-independent_review_or_test_handoff-C-004",
+          "observed_at": "2026-07-30T02:56:08Z",
+          "source": "codex_jsonl_export",
+          "unit": "tokens",
+          "value": 98
+        },
+        "recovery_count": {
+          "availability": "observed",
+          "observation_id": "recovery-run-independent_review_or_test_handoff-C-004",
+          "observed_at": "2026-07-30T02:56:08Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "retry_count": {
+          "availability": "observed",
+          "observation_id": "retry-run-independent_review_or_test_handoff-C-004",
+          "observed_at": "2026-07-30T02:56:08Z",
+          "source": "host_collection",
+          "unit": "count",
+          "value": 0
+        },
+        "tool_output_bytes": {
+          "availability": "unavailable",
+          "observation_id": "tool_output_bytes-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "bytes",
+          "value": null
+        },
+        "total_context_tokens": {
+          "availability": "unavailable",
+          "observation_id": "total_context_tokens-unavailable",
+          "observed_at": null,
+          "reason": "not_exposed",
+          "source": "host_collection",
+          "unit": "tokens",
+          "value": null
+        }
+      },
+      "root_budget": {
+        "unit": "tokens",
+        "value": 100000
+      },
+      "sample_id": "independent_review_or_test_handoff-C-004",
+      "scenario": {
+        "actual_role_route": "Implementer>Tester",
+        "anchor_type": "issue-comment",
+        "canonical_allowed_tools": [
+          "codex"
+        ],
+        "complexity": "small",
+        "measurement_window": {
+          "definition": "execution-to-terminal",
+          "fixed_execution_window": true
+        },
+        "model_class": "gpt-5.5-medium",
+        "objective_or_acceptance_fixture_id": "real-independent_review_or_test_handoff-v1",
+        "quality_rubric_version": "v1",
+        "risk": "low",
+        "root_budget_unit": "tokens",
+        "route_family": "real-route-family-v1",
+        "scenario_id": "independent_review_or_test_handoff",
+        "scenario_variant": "real-pilot-v1"
+      },
+      "task_class": "independent_review_or_test_handoff",
+      "terminal_state": "completed",
+      "variant": "C",
+      "variant_declaration": {
+        "route_kind": "observed_normal_route"
+      },
+      "work_id": "work-independent_review_or_test_handoff-C-004"
+    }
+  ],
+  "schema_version": 1
+}

--- a/scripts/test_af18_calibration.py
+++ b/scripts/test_af18_calibration.py
@@ -236,7 +236,7 @@ def main():
     expect("fixture-evidence-only", "fixture evidence only" in fixture_result["human_summary"], fixture_result)
     fixture_candidate = fixture_result["cohorts"][0]["candidate_recommendation"]
     expect("fixture-hold-only-insufficient-sample", fixture_candidate["candidate_status"] == "candidate_hold" and fixture_candidate["candidate_hold_reasons"] == ["insufficient_observed_C_context_age_hours", "insufficient_observed_C_cumulative_resource_tokens", "insufficient_observed_C_total_context_tokens", "requires_at_least_five_valid_A_B_C_rows"], fixture_candidate)
-    for real_name in ("single_session_baseline", "compact_cross_role"):
+    for real_name in ("single_session_baseline", "compact_cross_role", "independent_review_or_test_handoff", "bounded_successor_hold_recovery", "attention_materiality"):
         real_packet = json.loads((REAL_FIXTURES / f"{real_name}.json").read_text())
         real_result = calibration.run(real_packet, NOW, 24 * 365 * 10)
         expect(f"real-reclassified-{real_name}-valid", len(real_result["invalid_evidence"]) == 0 and len(real_result["cohorts"]) == 1, real_result)


### PR DESCRIPTION
## Scope
- Add durable, privacy-safe real A/B/C packets for the remaining three AF18 calibration classes.
- Extend replay tests to cover all five real-reclassified classes.

## Evidence
- Each class replays to one cohort with A/B/C = 5/5/5.
- `attention_materiality`: 5 paired material observations and required C attention rate 1.0.
- Candidate remains `candidate_hold` because Codex does not expose `context_age_hours` and `total_context_tokens`; no threshold or policy is inferred.
- Packets contain metadata, scalar observations, provenance, and durable anchors only; no raw prompt, transcript, message, or tool output.

## Verification
- `python3 scripts/test_af18_calibration.py`
- `python3 scripts/test_af18_mvp1_control.py`
- `python3 scripts/test_af18_mvp2_observation_bridge.py`
- `python3 scripts/test_runtime_owned_capture.py`
- `python3 scripts/check_consistency.py`
- `git diff --check`

Target: AF18 integration branch only. #457 remains high-risk and requires independent review plus Human merge approval.
