### PR TITLE
feat: add AF18 Codex context observation bridge

### DIFF
--- a/scripts/collect_af18_codex_telemetry.py
+++ b/scripts/collect_af18_codex_telemetry.py
@@ -21,6 +21,8 @@ spec.loader.exec_module(calibration)
 EVENT_KEYS = {"type", "invocation_id", "execution_id", "completed_at", "usage"}
 USAGE_KEYS = {"input_tokens", "cached_input_tokens", "output_tokens", "reasoning_tokens"}
 METADATA_KEYS = {"schema_version", "protocol_version", "sample", "captured_at", "evidence_anchor", "invocation_ids", "execution_id", "execution_window"}
+CONTEXT_OBSERVATION_KEYS = {"type", "execution_id", "work_id", "execution_anchor", "context_anchor", "execution_window", "observed_at", "context_window_started_at", "total_context_tokens", "producer"}
+CONTEXT_PRODUCER_KEYS = {"runtime_id", "adapter", "runtime_owned"}
 RAW_KEYS = calibration.FORBIDDEN_KEYS | {"response", "request", "event", "error", "model", "instructions"}
 
 
@@ -28,6 +30,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--input", required=True, help="Completed-event JSONL input.")
     parser.add_argument("--metadata", required=True, help="Explicit allowlisted metadata JSON.")
+    parser.add_argument("--context-observations", help="Optional runtime-owned context-observation JSONL input.")
     parser.add_argument("--output", help="Output JSON path; stdout is used otherwise.")
     return parser.parse_args()
 
@@ -52,6 +55,53 @@ def unavailable(name: str) -> dict[str, Any]:
 
 def observed(name: str, value: int, captured_at: str) -> dict[str, Any]:
     return {"observation_id": f"codex-jsonl-{name}", "availability": "observed", "value": value, "unit": "tokens", "source": "codex_jsonl_completed_export", "observed_at": captured_at}
+
+
+def validate_context_observation(metadata: dict[str, Any], value: Any, line_number: int) -> dict[str, Any]:
+    reject_unknown(value, CONTEXT_OBSERVATION_KEYS, "context_observation")
+    if value.get("type") != "codex.context_observation":
+        raise ValueError(f"invalid_context_observation:{line_number}")
+    sample = metadata.get("sample")
+    execution_window = metadata.get("execution_window")
+    if not isinstance(sample, dict) or not isinstance(execution_window, dict):
+        raise ValueError("invalid_context_observation_metadata")
+    if value.get("execution_id") != metadata.get("execution_id") or value.get("work_id") != sample.get("work_id"):
+        raise ValueError(f"context_observation_execution_or_work_mismatch:{line_number}")
+    anchors = sample.get("anchors", {})
+    if value.get("execution_anchor") != metadata.get("evidence_anchor") or value.get("context_anchor") != anchors.get("context"):
+        raise ValueError(f"context_observation_anchor_mismatch:{line_number}")
+    if value.get("execution_window") != execution_window:
+        raise ValueError(f"context_observation_window_mismatch:{line_number}")
+    producer = value.get("producer")
+    reject_unknown(producer, CONTEXT_PRODUCER_KEYS, "context_observation_producer")
+    if producer.get("runtime_id") != "codex" or producer.get("adapter") != "codex" or producer.get("runtime_owned") is not True:
+        raise ValueError(f"context_observation_not_runtime_owned:{line_number}")
+    if not isinstance(value.get("total_context_tokens"), int) or isinstance(value["total_context_tokens"], bool) or value["total_context_tokens"] < 0:
+        raise ValueError(f"invalid_total_context_tokens:{line_number}")
+    try:
+        observed_at = calibration.utc(value.get("observed_at"))
+        window_started_at = calibration.utc(value.get("context_window_started_at"))
+        execution_started_at = calibration.utc(execution_window["started_at"])
+        execution_ended_at = calibration.utc(execution_window["ended_at"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(f"invalid_context_observation_timestamp:{line_number}") from exc
+    if not execution_started_at <= observed_at <= execution_ended_at:
+        raise ValueError(f"context_observation_outside_execution_window:{line_number}")
+    if window_started_at > observed_at:
+        raise ValueError(f"invalid_context_window_timestamp:{line_number}")
+    return value
+
+
+def context_observation(metadata: dict[str, Any], path: str | None) -> dict[str, Any] | None:
+    if path is None:
+        return None
+    matches: list[dict[str, Any]] = []
+    for line_number, line in enumerate(Path(path).read_text(encoding="utf-8").splitlines(), 1):
+        if line.strip():
+            matches.append(validate_context_observation(metadata, json.loads(line), line_number))
+    if len(matches) > 1:
+        raise ValueError("duplicate_context_observation")
+    return matches[0] if matches else None
 
 
 def read_events(path: str, invocation_ids: list[str], execution_id: str, execution_window: dict[str, str]) -> list[dict[str, Any]]:
@@ -86,7 +136,7 @@ def read_events(path: str, invocation_ids: list[str], execution_id: str, executi
     return [events[item] for item in invocation_ids]
 
 
-def collect(metadata: dict[str, Any], events: list[dict[str, Any]]) -> dict[str, Any]:
+def collect(metadata: dict[str, Any], events: list[dict[str, Any]], context: dict[str, Any] | None = None) -> dict[str, Any]:
     reject_unknown(metadata, METADATA_KEYS, "metadata")
     invocation_ids = metadata.get("invocation_ids")
     if not isinstance(invocation_ids, list) or not invocation_ids or any(not isinstance(item, str) or not item for item in invocation_ids) or len(invocation_ids) != len(set(invocation_ids)):
@@ -109,6 +159,8 @@ def collect(metadata: dict[str, Any], events: list[dict[str, Any]]) -> dict[str,
     captured_at = metadata.get("captured_at")
     if not isinstance(captured_at, str) or not calibration.is_anchor(metadata.get("evidence_anchor")):
         raise ValueError("invalid_metadata_provenance")
+    if context is not None:
+        context = validate_context_observation(metadata, context, 0)
     totals = {key: sum(event["usage"].get(key, 0) for event in events) for key in USAGE_KEYS}
     resources = {name: unavailable(name) for name in calibration.REQUIRED_RESOURCES}
     for name in ("input_tokens", "output_tokens"):
@@ -116,6 +168,11 @@ def collect(metadata: dict[str, Any], events: list[dict[str, Any]]) -> dict[str,
     for name in ("cached_input_tokens", "reasoning_tokens"):
         if all(name in event["usage"] for event in events):
             resources[name] = observed(name, totals[name], captured_at)
+    if context is not None:
+        context_age_hours = int((calibration.utc(context["observed_at"]) - calibration.utc(context["context_window_started_at"])).total_seconds() // 3600)
+        source = "codex_runtime_context_observation"
+        resources["context_age_hours"] = {"observation_id": "codex-runtime-context_age_hours", "availability": "observed", "value": context_age_hours, "unit": "hours", "source": source, "observed_at": context["observed_at"]}
+        resources["total_context_tokens"] = {"observation_id": "codex-runtime-total_context_tokens", "availability": "observed", "value": context["total_context_tokens"], "unit": "tokens", "source": source, "observed_at": context["observed_at"], "observation_basis": "independent_observed"}
     resources["cumulative_resource_tokens"] = {"observation_id": "codex-jsonl-cumulative_resource_tokens", "availability": "observed", "value": totals["input_tokens"] + totals["output_tokens"], "unit": "tokens", "source": "codex_jsonl_completed_export", "observed_at": captured_at, "observation_basis": "derived", "derived_total_component_ids": [resources["input_tokens"]["observation_id"], resources["output_tokens"]["observation_id"]], "invocation_ids": invocation_ids}
     output_sample = dict(sample)
     output_sample["provenance"] = {"source": "codex_jsonl_completed_export", "collection_method": "codex_jsonl_export", "captured_at": captured_at, "evidence_anchor": metadata["evidence_anchor"], "observation_kind": "observed"}
@@ -133,7 +190,8 @@ def main() -> int:
         metadata = read_json(args.metadata)
         invocation_ids = metadata.get("invocation_ids")
         events = read_events(args.input, invocation_ids if isinstance(invocation_ids, list) else [], metadata.get("execution_id", ""), metadata.get("execution_window", {}))
-        output = json.dumps(collect(metadata, events), indent=2, sort_keys=True) + "\n"
+        context = context_observation(metadata, args.context_observations)
+        output = json.dumps(collect(metadata, events, context), indent=2, sort_keys=True) + "\n"
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         print(json.dumps({"error": str(exc), "mutation_performed": False}, sort_keys=True), file=sys.stderr)
         return 2

--- a/scripts/test_af18_calibration.py
+++ b/scripts/test_af18_calibration.py
@@ -185,6 +185,11 @@ def main():
     expect("collector-input-output-only-total", collected_resources["cumulative_resource_tokens"]["value"] == 200 and collected_resources["cumulative_resource_tokens"]["derived_total_component_ids"] == ["codex-jsonl-input_tokens", "codex-jsonl-output_tokens"], collected)
     expect("collector-unavailable-host-metrics", collected_resources["tool_output_bytes"]["availability"] == "unavailable" and collected_resources["tool_output_bytes"]["value"] is None and collected_resources["tool_output_bytes"]["reason"] == "not_exposed", collected)
     expect("collector-missing-breakdown-unavailable", collected_resources["cached_input_tokens"]["availability"] == "unavailable", collected)
+    context = {"type": "codex.context_observation", "execution_id": collector_sample["execution_id"], "work_id": collector_sample["work_id"], "execution_anchor": metadata["evidence_anchor"], "context_anchor": collector_sample["anchors"]["context"], "execution_window": metadata["execution_window"], "observed_at": "2026-07-29T09:01:00Z", "context_window_started_at": "2026-07-29T08:00:00Z", "total_context_tokens": 321, "producer": {"runtime_id": "codex", "adapter": "codex", "runtime_owned": True}}
+    observed_context = collector.collect(metadata, events, context)
+    observed_resources = observed_context["samples"][0]["resources"]
+    expect("collector-runtime-context-observed", observed_resources["context_age_hours"] == {"observation_id": "codex-runtime-context_age_hours", "availability": "observed", "value": 1, "unit": "hours", "source": "codex_runtime_context_observation", "observed_at": context["observed_at"]}, observed_context)
+    expect("collector-runtime-total-independent", observed_resources["total_context_tokens"]["availability"] == "observed" and observed_resources["total_context_tokens"]["value"] == 321 and observed_resources["total_context_tokens"]["observation_basis"] == "independent_observed" and "derived_total_component_ids" not in observed_resources["total_context_tokens"], observed_context)
     with tempfile.TemporaryDirectory() as directory:
         jsonl = Path(directory) / "completed.jsonl"
         jsonl.write_text("\n".join(json.dumps(event) for event in events) + "\n", encoding="utf-8")
@@ -204,6 +209,26 @@ def main():
             expect("collector-raw-content-rejected", "invalid_completed_event_fields" in str(exc), str(exc))
         else:
             raise AssertionError("collector raw content must fail")
+        context_jsonl = Path(directory) / "context.jsonl"
+        context_jsonl.write_text(json.dumps(context) + "\n", encoding="utf-8")
+        loaded_context = collector.context_observation(metadata, str(context_jsonl))
+        expect("collector-context-observation-read", loaded_context == context, loaded_context)
+        for name, mutate, error in [
+            ("context-duplicate", lambda x: [x, x], "duplicate_context_observation"),
+            ("context-malformed", lambda x: [{**x, "total_context_tokens": -1}], "invalid_total_context_tokens"),
+            ("context-execution-mismatch", lambda x: [{**x, "execution_id": "other"}], "context_observation_execution_or_work_mismatch"),
+            ("context-anchor-mismatch", lambda x: [{**x, "context_anchor": "https://github.com/farmerhunter/agent-foundry/issues/457#other"}], "context_observation_anchor_mismatch"),
+            ("context-window-mismatch", lambda x: [{**x, "execution_window": {"started_at": "2026-07-29T08:58:00Z", "ended_at": "2026-07-29T09:02:00Z"}}], "context_observation_window_mismatch"),
+            ("context-caller-supplied", lambda x: [{**x, "producer": {**x["producer"], "runtime_owned": False}}], "context_observation_not_runtime_owned"),
+            ("context-raw-content", lambda x: [{**x, "messages": ["raw"]}], "invalid_context_observation_fields"),
+        ]:
+            context_jsonl.write_text("\n".join(json.dumps(item) for item in mutate(copy.deepcopy(context))) + "\n", encoding="utf-8")
+            try:
+                collector.context_observation(metadata, str(context_jsonl))
+            except ValueError as exc:
+                expect(name, error in str(exc), str(exc))
+            else:
+                raise AssertionError(f"{name} must fail closed")
 
     expect("route-variants-merge-by-family", len([item for item in result["cohorts"] if item["task_class"] == "compact_cross_role"]) == 1, result)
     route_variants = copy.deepcopy(rows)


### PR DESCRIPTION
## Scope

Implements the smallest read-only Codex adapter boundary for #467. An optional `--context-observations` JSONL input accepts only a runtime-owned `codex.context_observation` record with matching execution/work/context anchors and an identical fixed execution window.

- `context_age_hours` is calculated only from explicit runtime-provided context-window and observation timestamps.
- `total_context_tokens` is accepted only as runtime context accounting with `independent_observed` basis.
- Missing context observation data remains `unavailable` with `value: null` and `reason: not_exposed`; it is never inferred from usage totals, packet size, or wall-clock estimates.
- Duplicate, malformed, mismatched, caller-supplied, out-of-window, and raw-content records fail closed.

## Capability proof result

A single read-only, ephemeral Codex CLI `--json` probe did not complete successfully and emitted only `thread.started`, `turn.started`, and `turn.failed` event shapes. It exposed neither a completed usage event nor a runtime-owned context-observation record. The bridge therefore produces the explicit fail-closed unavailable result for both required metrics. No 25-sample calibration is released.

## Verification

- `python3 scripts/test_af18_calibration.py`
- All 28 `scripts/test_*.py` scripts passed.
- `git diff --check`

## Boundaries and residual risk

No policy write, threshold/mode selection, runtime activation/configuration, dispatch behavior change, RoleHub, ledger, Vault/generated mutation, external route, archive, or deletion. The current Codex CLI event surface still does not supply the runtime-owned context record needed for an observed proof; a later runtime surface exposing that exact allowlisted record requires independent Tester/Reviewer replay before any calibration release.

Closes #467