### PR TITLE
AF18: add role lifecycle and incident dry-run controls

### DIFF
--- a/schemas/af18-control-plane.schema.yaml
+++ b/schemas/af18-control-plane.schema.yaml
@@ -390,3 +390,213 @@ properties:
     type: array
     items:
       type: object
+  role_lifecycle:
+    type: object
+    additionalProperties: false
+    required:
+      - action
+      - conversation
+    properties:
+      action:
+        enum:
+          - onboard_fresh
+          - adopt_legacy
+          - request_successor
+          - recover_successor
+      onboarding_key:
+        type: string
+        minLength: 1
+      explicit_adoption:
+        type: boolean
+      compactness_preflight:
+        enum:
+          - passed
+          - unavailable
+          - not_run
+      recovery_attempts:
+        type: integer
+        minimum: 0
+        maximum: 1
+      existing_conversations:
+        type: array
+        items:
+          type: object
+      conversation:
+        type: object
+        additionalProperties: false
+        required:
+          - role_conversation_id
+          - project_id
+          - role
+          - work_id
+          - issue
+          - durable_anchor
+          - profile
+          - model
+          - reasoning
+          - root_budget_tokens
+          - max_age_hours
+          - max_turns
+        properties:
+          role_conversation_id:
+            type: string
+            minLength: 1
+          project_id:
+            type: string
+            minLength: 1
+          role:
+            type: string
+            minLength: 1
+          state:
+            enum: [current, historical_reference]
+          legacy:
+            type: boolean
+          work_id:
+            type: string
+            minLength: 1
+          issue:
+            type: integer
+            minimum: 1
+          durable_anchor:
+            type: string
+            minLength: 1
+          profile:
+            const: normal
+          model:
+            const: gpt-5.6-terra
+          reasoning:
+            const: medium
+          root_budget_tokens:
+            const: 120000
+          max_age_hours:
+            const: 24
+          max_turns:
+            const: 12
+      successor:
+        type: object
+        additionalProperties: false
+        required:
+          - context_window_id
+          - compact_capsule
+          - issue
+          - durable_anchor
+          - work_id
+          - root_budget_tokens
+          - remaining_budget_tokens
+          - max_age_hours
+          - max_turns
+          - ready
+        properties:
+          context_window_id:
+            type: string
+            minLength: 1
+          compact_capsule:
+            type: object
+            additionalProperties: false
+            required: [evidence_refs]
+            properties:
+              evidence_refs:
+                type: array
+                minItems: 1
+                items:
+                  type: string
+                  minLength: 1
+          issue:
+            type: integer
+            minimum: 1
+          durable_anchor:
+            type: string
+            minLength: 1
+          work_id:
+            type: string
+            minLength: 1
+          root_budget_tokens:
+            const: 120000
+          remaining_budget_tokens:
+            type: integer
+            minimum: 0
+            maximum: 120000
+          max_age_hours:
+            const: 24
+          max_turns:
+            const: 12
+          ready:
+            type: boolean
+  incident:
+    type: object
+    additionalProperties: false
+    required:
+      - category
+      - event_time
+      - sequence
+      - work_id
+      - issue
+      - durable_anchor
+      - root_budget_tokens
+      - remaining_budget_tokens
+    properties:
+      category:
+        enum:
+          - stale_no_owner
+          - evidence_conflict
+          - budget_breach
+          - unavailable_observation
+          - duplicate_dispatch
+          - successor_failure
+          - escalation_failure
+      event_time:
+        type: string
+        format: date-time
+      sequence:
+        type: integer
+        minimum: 1
+      work_id:
+        type: string
+        minLength: 1
+      issue:
+        type: integer
+        minimum: 1
+      durable_anchor:
+        type: string
+        minLength: 1
+      root_budget_tokens:
+        const: 120000
+      remaining_budget_tokens:
+        type: integer
+        minimum: 0
+        maximum: 120000
+      owner:
+        type: string
+        minLength: 1
+      reason:
+        type: string
+        minLength: 1
+      evidence_ref:
+        type: string
+        minLength: 1
+      capability:
+        type: string
+        minLength: 1
+      observation:
+        type: object
+        additionalProperties: false
+        required: [provenance]
+        properties:
+          provenance:
+            enum: [observed, estimated, unavailable]
+      recovery_attempts:
+        type: integer
+        minimum: 0
+        maximum: 1
+      requested_model:
+        type: string
+        minLength: 1
+      effective_model:
+        type: string
+        minLength: 1
+      requested_reasoning:
+        type: string
+        minLength: 1
+      effective_reasoning:
+        type: string
+        minLength: 1

--- a/scripts/plan_af18_mvp1_control.py
+++ b/scripts/plan_af18_mvp1_control.py
@@ -455,7 +455,7 @@ def role_lifecycle_projection(packet: dict[str, Any], now: dt.datetime) -> dict[
     elif action in {"request_successor", "recover_successor"}:
         successor = request.get("successor") if isinstance(request.get("successor"), dict) else {}
         recovery_attempts = request.get("recovery_attempts", 0)
-        if not isinstance(recovery_attempts, int) or recovery_attempts < 0:
+        if type(recovery_attempts) is not int or recovery_attempts not in {0, 1}:
             stops.append("invalid_recovery_attempts")
             recovery_attempts = 1
         for field in (

--- a/scripts/plan_af18_mvp1_control.py
+++ b/scripts/plan_af18_mvp1_control.py
@@ -16,6 +16,15 @@ import plan_collaboration_routes as cost_policy
 POLICY_SOURCE = "scripts/plan_collaboration_routes.py"
 POLICY_VERSION = "af18-cost-policy-440-442"
 CONTROL_VERSION = "af18-mvp1-control-plane-v1"
+ROLE_LIFECYCLE_VERSION = "af18-role-lifecycle-v1"
+NORMAL_WORK_RESOURCES = {
+    "profile": "normal",
+    "model": "gpt-5.6-terra",
+    "reasoning": "medium",
+    "root_budget_tokens": 120000,
+    "max_age_hours": 24,
+    "max_turns": 12,
+}
 ROUTE_PERMISSIONS = {
     "isolated_execution": "allow",
     "interactive_execution": "successor_required",
@@ -44,6 +53,15 @@ SUPPRESSED_EVENT_CATEGORIES = {
     "successor_retry_mechanic",
     "ordinary_receipt",
 }
+INCIDENT_RULES = {
+    "stale_no_owner": ("hold", "Coordinator", "assign an owner or request a Human decision", False),
+    "evidence_conflict": ("quarantine", "Coordinator", "review the durable evidence anchor", False),
+    "budget_breach": ("stop", "Human", "preserve the receipt and request an explicit budget decision", False),
+    "unavailable_observation": ("hold", "Coordinator", "obtain a trusted observation without inference", False),
+    "duplicate_dispatch": ("reject_allocation", "Coordinator", "retain the canonical active Work", False),
+    "successor_failure": ("hold", "current_owner", "attempt the single bounded recovery", True),
+    "escalation_failure": ("hold", "Human", "request explicit model or reasoning approval", False),
+}
 FORBIDDEN_PACKET_KEYS = {
     "prompt",
     "body",
@@ -66,7 +84,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--input", help="Control-plane packet JSON path. Defaults to stdin when provided.")
     parser.add_argument(
         "--mode",
-        choices=("preflight", "readout", "explain", "work-summary", "attention-summary"),
+        choices=("preflight", "readout", "explain", "work-summary", "attention-summary", "role-lifecycle", "incident"),
         default="preflight",
     )
     parser.add_argument("--now", help="Current UTC timestamp for deterministic tests.")
@@ -355,6 +373,246 @@ def successor_packet(work: dict[str, Any], run: dict[str, Any], route: str, now:
     }
 
 
+def role_lifecycle_projection(packet: dict[str, Any], now: dt.datetime) -> dict[str, Any]:
+    request = packet.get("role_lifecycle")
+    stops: list[str] = []
+    if not isinstance(request, dict):
+        request = {}
+        stops.append("missing_role_lifecycle")
+    action = request.get("action")
+    conversation = request.get("conversation") if isinstance(request.get("conversation"), dict) else {}
+    for field in ("role_conversation_id", "project_id", "role", "work_id", "issue", "durable_anchor", "root_budget_tokens"):
+        if missing(conversation.get(field)):
+            stops.append(f"missing_role_conversation_{field}")
+    for field, expected in NORMAL_WORK_RESOURCES.items():
+        if conversation.get(field) != expected:
+            stops.append(f"role_conversation_{field}_does_not_match_normal_work")
+    if find_forbidden(request):
+        stops.append("privacy_exposure")
+
+    result: dict[str, Any] = {
+        "projection_type": "RoleLifecyclePlan",
+        "lifecycle_version": ROLE_LIFECYCLE_VERSION,
+        "action": action,
+        "role_conversation_id": conversation.get("role_conversation_id"),
+        "logical_identity": {
+            "project_id": conversation.get("project_id"),
+            "role": conversation.get("role"),
+        },
+        "work_id": conversation.get("work_id"),
+        "issue": conversation.get("issue"),
+        "durable_anchor": conversation.get("durable_anchor"),
+        "root_budget_tokens": conversation.get("root_budget_tokens"),
+        "operation_allowed": False,
+        "materialization_required": False,
+        "legacy_disposition": "not_legacy",
+        "predecessor_state": conversation.get("state", "current"),
+        "successor_state": "not_requested",
+        "one_recovery_remaining": False,
+        "stop_conditions": [],
+        "read_only": True,
+        "mutation_performed": False,
+        "dispatch_performed": False,
+    }
+
+    if action == "onboard_fresh":
+        onboarding_key = request.get("onboarding_key")
+        if missing(onboarding_key):
+            stops.append("missing_onboarding_key")
+        existing = request.get("existing_conversations")
+        if not isinstance(existing, list):
+            stops.append("invalid_existing_conversations")
+            existing = []
+        match = next(
+            (
+                item
+                for item in existing
+                if isinstance(item, dict)
+                and item.get("project_id") == conversation.get("project_id")
+                and item.get("role") == conversation.get("role")
+                and item.get("onboarding_key") == onboarding_key
+            ),
+            None,
+        )
+        result["materialization_required"] = match is None and not stops
+        result["idempotent_reuse"] = match is not None
+        result["effective_role_conversation_id"] = (
+            match.get("role_conversation_id") if isinstance(match, dict) else conversation.get("role_conversation_id")
+        )
+        result["operation_allowed"] = not stops
+    elif action == "adopt_legacy":
+        if conversation.get("legacy") is not True:
+            stops.append("adoption_requires_legacy_conversation")
+        if request.get("explicit_adoption") is not True:
+            result["legacy_disposition"] = "historical_reference"
+            stops.append("legacy_adoption_not_explicit")
+        elif request.get("compactness_preflight") != "passed":
+            result["legacy_disposition"] = "historical_reference"
+            stops.append("legacy_adoption_compactness_not_proven")
+        else:
+            result["legacy_disposition"] = "adoption_planned"
+            result["operation_allowed"] = not stops
+    elif action in {"request_successor", "recover_successor"}:
+        successor = request.get("successor") if isinstance(request.get("successor"), dict) else {}
+        recovery_attempts = request.get("recovery_attempts", 0)
+        if not isinstance(recovery_attempts, int) or recovery_attempts < 0:
+            stops.append("invalid_recovery_attempts")
+            recovery_attempts = 1
+        for field in (
+            "context_window_id",
+            "compact_capsule",
+            "issue",
+            "durable_anchor",
+            "work_id",
+            "root_budget_tokens",
+            "remaining_budget_tokens",
+            "ready",
+            "max_age_hours",
+            "max_turns",
+        ):
+            if missing(successor.get(field)):
+                stops.append(f"missing_successor_{field}")
+        capsule = successor.get("compact_capsule")
+        if not isinstance(capsule, dict) or not capsule.get("evidence_refs") or find_forbidden(capsule):
+            stops.append("invalid_or_private_successor_capsule")
+        for field in ("issue", "durable_anchor", "work_id", "root_budget_tokens"):
+            if successor.get(field) != conversation.get(field):
+                stops.append(f"successor_{field}_continuity_mismatch")
+        for field in ("max_age_hours", "max_turns"):
+            if successor.get(field) != NORMAL_WORK_RESOURCES[field]:
+                stops.append(f"successor_{field}_does_not_match_normal_work")
+        remaining = successor.get("remaining_budget_tokens")
+        if not isinstance(remaining, int) or remaining < 0 or remaining > conversation.get("root_budget_tokens", -1):
+            stops.append("successor_remaining_budget_invalid")
+        if successor.get("ready") is not True:
+            stops.append("successor_not_ready")
+        if stops:
+            result["predecessor_state"] = "current"
+            result["successor_state"] = "failed"
+            result["one_recovery_remaining"] = recovery_attempts < 1
+            result["recovery_action"] = (
+                "prepare one corrected compact successor packet" if recovery_attempts < 1 else None
+            )
+        else:
+            result["predecessor_state"] = "supersede_planned"
+            result["successor_state"] = "ready"
+            result["operation_allowed"] = True
+            result["successor_packet"] = {
+                "context_window_id": successor.get("context_window_id"),
+                "compact_capsule": capsule,
+                "issue": successor.get("issue"),
+                "durable_anchor": successor.get("durable_anchor"),
+                "work_id": successor.get("work_id"),
+                "root_budget_tokens": successor.get("root_budget_tokens"),
+                "remaining_budget_tokens": successor.get("remaining_budget_tokens"),
+                "max_age_hours": successor.get("max_age_hours"),
+                "max_turns": successor.get("max_turns"),
+            }
+    else:
+        stops.append("unknown_role_lifecycle_action")
+
+    result["stop_conditions"] = sorted(set(stops))
+    result["decision"] = "ready" if result["operation_allowed"] and not stops else "hold_required"
+    result["human_attention_required"] = bool(stops)
+    result["reason"] = (
+        "Role lifecycle dry-run is ready."
+        if not stops
+        else f"Role lifecycle held: {sorted(set(stops))[0]}."
+    )
+    return result
+
+
+def incident_projection(packet: dict[str, Any], now: dt.datetime) -> dict[str, Any]:
+    incident = packet.get("incident")
+    stops: list[str] = []
+    if not isinstance(incident, dict):
+        incident = {}
+        stops.append("missing_incident")
+    category = incident.get("category")
+    rule = INCIDENT_RULES.get(category)
+    if rule is None:
+        stops.append("unknown_incident_category")
+        rule = ("hold", "Coordinator", "provide a supported incident category", False)
+    required = ("event_time", "sequence", "work_id", "issue", "durable_anchor", "root_budget_tokens", "remaining_budget_tokens")
+    for field in required:
+        if missing(incident.get(field)):
+            stops.append(f"missing_incident_{field}")
+    try:
+        event_time = cost_policy.parse_timestamp(incident.get("event_time"), "incident.event_time")
+    except (TypeError, ValueError):
+        event_time = None
+        stops.append("invalid_incident_event_time")
+    if event_time is not None and event_time > now:
+        stops.append("incident_event_from_future")
+    if not isinstance(incident.get("sequence"), int) or incident.get("sequence", 0) < 1:
+        stops.append("invalid_incident_sequence")
+    root_budget = incident.get("root_budget_tokens")
+    remaining = incident.get("remaining_budget_tokens")
+    if not isinstance(root_budget, int) or root_budget <= 0 or not isinstance(remaining, int) or remaining < 0:
+        stops.append("invalid_incident_budget")
+    if isinstance(root_budget, int) and isinstance(remaining, int) and remaining > root_budget:
+        stops.append("incident_budget_continuity_breach")
+    if category == "unavailable_observation":
+        observation = incident.get("observation") if isinstance(incident.get("observation"), dict) else {}
+        if observation.get("provenance") != "unavailable" or "value" in observation:
+            stops.append("unavailable_observation_must_not_supply_value")
+    if category == "successor_failure" and incident.get("recovery_attempts") not in (0, 1):
+        stops.append("successor_recovery_limit_invalid")
+    if category == "escalation_failure":
+        if incident.get("requested_model") != incident.get("effective_model"):
+            stops.append("silent_model_change_forbidden")
+        if incident.get("requested_reasoning") != incident.get("effective_reasoning"):
+            stops.append("silent_reasoning_change_forbidden")
+    forbidden = find_forbidden(incident)
+    if forbidden:
+        stops.append("privacy_exposure")
+
+    action, owner, corrective_action, recovery_allowed = rule
+    if category == "successor_failure" and incident.get("recovery_attempts") == 1:
+        recovery_allowed = False
+    receipt = {
+        "receipt_type": "IncidentReceipt",
+        "category": category,
+        "state": action,
+        "event_time": incident.get("event_time"),
+        "sequence": incident.get("sequence"),
+        "work_id": incident.get("work_id"),
+        "issue": incident.get("issue"),
+        "durable_anchor": incident.get("durable_anchor"),
+        "root_budget_tokens": root_budget,
+        "remaining_budget_tokens": remaining,
+        "owner": incident.get("owner") or owner,
+        "corrective_action": corrective_action,
+        "capability": incident.get("capability"),
+        "provenance": incident.get("observation", {}).get("provenance")
+        if isinstance(incident.get("observation"), dict)
+        else None,
+    }
+    attention = {
+        "projection_type": "AttentionSummary",
+        "human_attention_required": True,
+        "category": category,
+        "reason": compact_reason(incident.get("reason"), corrective_action),
+        "owner": owner,
+        "evidence_ref": incident.get("evidence_ref"),
+        "read_only": True,
+    }
+    return {
+        "projection_type": "IncidentPlan",
+        "valid": not stops,
+        "decision": action if not stops else "hold",
+        "incident_receipt": receipt,
+        "attention_summary": attention,
+        "predecessor_state": "current" if category == "successor_failure" else "not_applicable",
+        "successor_allowed": category == "successor_failure" and recovery_allowed and not stops,
+        "recovery_attempts_remaining": 1 if category == "successor_failure" and recovery_allowed else 0,
+        "stop_conditions": sorted(set(stops)),
+        "read_only": True,
+        "mutation_performed": False,
+        "dispatch_performed": False,
+    }
+
+
 def compact_reason(raw: Any, fallback: str) -> str:
     if isinstance(raw, str) and raw.strip():
         words = raw.strip().split()
@@ -585,6 +843,10 @@ def main() -> int:
         result = work_summary_projection(packet, now)
     elif args.mode == "attention-summary":
         result = attention_summary_projection(packet, now)
+    elif args.mode == "role-lifecycle":
+        result = role_lifecycle_projection(packet, now)
+    elif args.mode == "incident":
+        result = incident_projection(packet, now)
     else:
         result = plan_preflight(packet, now)
     print(json.dumps(result, indent=2, sort_keys=True))

--- a/scripts/plan_codex_route_adapter.py
+++ b/scripts/plan_codex_route_adapter.py
@@ -32,6 +32,13 @@ NO_ADAPTER_ROUTES = {
 DISPATCH_ADVISORY_ROUTES = {"dispatch_advisory"} | set(ROUTE_DECISION_TO_TOPOLOGY)
 VALID_STATUSES = {"supported", "unsupported", "unknown", "degraded", "not_available"}
 HOST_COLLECTION_MODE = "host_collected"
+ROLE_OPERATION_CAPABILITIES = {
+    "create": "create",
+    "link": "link",
+    "navigate": "navigate",
+    "measure": "measure",
+}
+FORBIDDEN_RECEIPT_KEYS = {"prompt", "body", "message", "messages", "content", "transcript", "tool_output", "raw_log"}
 
 
 def fail(message: str) -> None:
@@ -50,6 +57,20 @@ def require_object(root: dict[str, Any], name: str) -> dict[str, Any]:
     if not isinstance(value, dict):
         fail(f"missing object: {name}")
     return value
+
+
+def forbidden_paths(value: Any, path: str = "$") -> list[str]:
+    if isinstance(value, dict):
+        found: list[str] = []
+        for key, item in value.items():
+            child = f"{path}.{key}"
+            if key in FORBIDDEN_RECEIPT_KEYS:
+                found.append(child)
+            found.extend(forbidden_paths(item, child))
+        return found
+    if isinstance(value, list):
+        return [item for index, value_item in enumerate(value) for item in forbidden_paths(value_item, f"{path}[{index}]")]
+    return []
 
 
 def parse_timestamp(value: Any) -> datetime | None:
@@ -186,7 +207,71 @@ def role_task_dispatch_evidence(portable: dict[str, Any], root: dict[str, Any]) 
     }
 
 
+def project_role_operation(root: dict[str, Any]) -> dict[str, Any]:
+    operation = root.get("role_operation")
+    if not isinstance(operation, dict):
+        fail("role_operation must be an object")
+    action = operation.get("action")
+    capability = ROLE_OPERATION_CAPABILITIES.get(action)
+    receipt = operation.get("capability_receipt")
+    forbidden = forbidden_paths(operation)
+    status = "unsupported"
+    provenance = "unavailable"
+    native_metadata: dict[str, Any] = {}
+    reasons: list[str] = []
+    if forbidden:
+        reasons.append("privacy-safe receipt contains forbidden raw content")
+    if capability is None:
+        reasons.append("unknown role operation")
+    if not isinstance(receipt, dict):
+        reasons.append("capability receipt is unavailable")
+    else:
+        status = receipt.get("status", "unsupported")
+        provenance = receipt.get("provenance", "unavailable")
+        metadata = receipt.get("native_metadata", {})
+        if isinstance(metadata, dict):
+            native_metadata = metadata
+        if receipt.get("capability") != capability:
+            reasons.append("capability receipt does not bind the requested operation")
+        if status not in VALID_STATUSES:
+            reasons.append("capability receipt has an unknown status")
+        if provenance not in {"observed", "estimated", "unavailable"}:
+            reasons.append("capability receipt has an unknown provenance")
+    if status in {"unsupported", "not_available", "unknown"} or provenance == "unavailable":
+        reasons.append("capability is unavailable or unsupported")
+        decision = "hold_required"
+    elif reasons:
+        decision = "hold_required"
+    elif status == "degraded":
+        decision = "dry_run_degraded"
+        reasons.append("capability is degraded; no live operation is proposed")
+    else:
+        decision = "dry_run_ready"
+    return {
+        "adapter": "codex",
+        "adapter_plan": {
+            "mode": "dry_run",
+            "adapter_decision": decision,
+            "role_operation": action,
+            "capability": capability or "not_available",
+            "capability_status": status,
+            "provenance": provenance,
+            "tool_call_proposed": "not_available",
+            "native_ids_are_metadata_only": True,
+            "adapter_metadata": native_metadata,
+        },
+        "attention": reasons,
+        "next_action": "Keep the portable Core route unchanged; obtain supported capability evidence before separately authorized execution.",
+        "mutation_performed": False,
+        "dispatch_performed": False,
+        "user_config_mutation_performed": False,
+        "hook_or_custom_agent_mutation_performed": False,
+    }
+
+
 def project(root: dict[str, Any]) -> dict[str, Any]:
+    if "role_operation" in root:
+        return project_role_operation(root)
     portable = require_object(root, "portable_plan")
     dispatch_plan = require_object(portable, "dispatch_plan")
     require_object(portable, "conversation_projection")

--- a/scripts/test_af18_mvp1_control.py
+++ b/scripts/test_af18_mvp1_control.py
@@ -451,6 +451,25 @@ def main() -> int:
         NOW,
     )
     expect("successor-only-one-recovery", exhausted_successor["one_recovery_remaining"] is False, exhausted_successor)
+    second_recovery = planner.role_lifecycle_projection(
+        {"role_lifecycle": {"action": "recover_successor", "conversation": conversation, "successor": successor, "recovery_attempts": 2}},
+        NOW,
+    )
+    expect(
+        "second-recovery-fails-closed",
+        second_recovery["decision"] == "hold_required"
+        and second_recovery["operation_allowed"] is False
+        and second_recovery["predecessor_state"] == "current"
+        and "successor_packet" not in second_recovery
+        and second_recovery["root_budget_tokens"] == 120000
+        and "invalid_recovery_attempts" in second_recovery["stop_conditions"],
+        second_recovery,
+    )
+    boolean_recovery = planner.role_lifecycle_projection(
+        {"role_lifecycle": {"action": "recover_successor", "conversation": conversation, "successor": successor, "recovery_attempts": True}},
+        NOW,
+    )
+    expect("boolean-recovery-fails-closed", "invalid_recovery_attempts" in boolean_recovery["stop_conditions"], boolean_recovery)
 
     incident_base = {
         "event_time": "2026-07-29T03:40:00Z",

--- a/scripts/test_af18_mvp1_control.py
+++ b/scripts/test_af18_mvp1_control.py
@@ -383,6 +383,112 @@ def main() -> int:
         invalid_summary,
     )
 
+    conversation = {
+        "role_conversation_id": "role-conversation-459",
+        "project_id": "project-459",
+        "role": "Implementer",
+        "state": "current",
+        "work_id": "af18-459-460",
+        "issue": 459,
+        "durable_anchor": "https://github.com/farmerhunter/agent-foundry/issues/459",
+        "profile": "normal",
+        "model": "gpt-5.6-terra",
+        "reasoning": "medium",
+        "root_budget_tokens": 120000,
+        "max_age_hours": 24,
+        "max_turns": 12,
+    }
+    lifecycle = {
+        "role_lifecycle": {
+            "action": "onboard_fresh",
+            "onboarding_key": "project-459-implementer",
+            "conversation": conversation,
+            "existing_conversations": [],
+        }
+    }
+    fresh = planner.role_lifecycle_projection(lifecycle, NOW)
+    expect("fresh-onboarding-ready", fresh["decision"] == "ready" and fresh["materialization_required"] is True, fresh)
+    repeated = planner.role_lifecycle_projection(
+        {"role_lifecycle": {**lifecycle["role_lifecycle"], "existing_conversations": [{"project_id": "project-459", "role": "Implementer", "onboarding_key": "project-459-implementer", "role_conversation_id": "existing-role-conversation"}]}},
+        NOW,
+    )
+    expect("fresh-onboarding-idempotent", repeated["idempotent_reuse"] is True and repeated["materialization_required"] is False, repeated)
+    legacy = planner.role_lifecycle_projection(
+        {"role_lifecycle": {"action": "adopt_legacy", "conversation": {**conversation, "legacy": True}, "explicit_adoption": False}},
+        NOW,
+    )
+    expect("legacy-default-historical-reference", legacy["legacy_disposition"] == "historical_reference" and legacy["operation_allowed"] is False, legacy)
+    adopted = planner.role_lifecycle_projection(
+        {"role_lifecycle": {"action": "adopt_legacy", "conversation": {**conversation, "legacy": True}, "explicit_adoption": True, "compactness_preflight": "passed"}},
+        NOW,
+    )
+    expect("legacy-explicit-adoption", adopted["decision"] == "ready" and adopted["legacy_disposition"] == "adoption_planned", adopted)
+    successor = {
+        "context_window_id": "window-459-b",
+        "compact_capsule": {"evidence_refs": ["https://github.com/farmerhunter/agent-foundry/issues/460"]},
+        "issue": 459,
+        "durable_anchor": "https://github.com/farmerhunter/agent-foundry/issues/459",
+        "work_id": "af18-459-460",
+        "root_budget_tokens": 120000,
+        "remaining_budget_tokens": 110000,
+        "max_age_hours": 24,
+        "max_turns": 12,
+        "ready": True,
+    }
+    successor_ready = planner.role_lifecycle_projection(
+        {"role_lifecycle": {"action": "request_successor", "conversation": conversation, "successor": successor, "recovery_attempts": 0}},
+        NOW,
+    )
+    expect("successor-readiness-before-supersede", successor_ready["decision"] == "ready" and successor_ready["predecessor_state"] == "supersede_planned", successor_ready)
+    expect("successor-anchor-budget-continuity", successor_ready["successor_packet"]["root_budget_tokens"] == 120000 and successor_ready["successor_packet"]["durable_anchor"] == conversation["durable_anchor"], successor_ready)
+    failed_successor = planner.role_lifecycle_projection(
+        {"role_lifecycle": {"action": "request_successor", "conversation": conversation, "successor": {**successor, "compact_capsule": {}, "ready": False}, "recovery_attempts": 0}},
+        NOW,
+    )
+    expect("successor-failure-keeps-predecessor", failed_successor["predecessor_state"] == "current" and failed_successor["one_recovery_remaining"] is True, failed_successor)
+    exhausted_successor = planner.role_lifecycle_projection(
+        {"role_lifecycle": {"action": "recover_successor", "conversation": conversation, "successor": {**successor, "ready": False}, "recovery_attempts": 1}},
+        NOW,
+    )
+    expect("successor-only-one-recovery", exhausted_successor["one_recovery_remaining"] is False, exhausted_successor)
+
+    incident_base = {
+        "event_time": "2026-07-29T03:40:00Z",
+        "sequence": 1,
+        "work_id": "af18-459-460",
+        "issue": 459,
+        "durable_anchor": "https://github.com/farmerhunter/agent-foundry/issues/459",
+        "root_budget_tokens": 120000,
+        "remaining_budget_tokens": 110000,
+        "evidence_ref": "issue-460",
+    }
+    expected_incidents = {
+        "stale_no_owner": "hold",
+        "evidence_conflict": "quarantine",
+        "budget_breach": "stop",
+        "unavailable_observation": "hold",
+        "duplicate_dispatch": "reject_allocation",
+        "successor_failure": "hold",
+        "escalation_failure": "hold",
+    }
+    for category, decision in expected_incidents.items():
+        incident = {**incident_base, "category": category}
+        if category == "unavailable_observation":
+            incident["observation"] = {"provenance": "unavailable"}
+        if category == "successor_failure":
+            incident["recovery_attempts"] = 0
+        if category == "escalation_failure":
+            incident.update({"requested_model": "gpt-5.6-terra", "effective_model": "gpt-5.6-terra", "requested_reasoning": "medium", "effective_reasoning": "medium"})
+        projected = planner.incident_projection({"incident": incident}, NOW)
+        expect(f"incident-{category}-material", projected["valid"] is True and projected["decision"] == decision and projected["attention_summary"]["human_attention_required"] is True, projected)
+        expect(f"incident-{category}-privacy-safe-receipt", forbidden_paths(projected["incident_receipt"]) == [], projected)
+    unavailable_with_value = planner.incident_projection({"incident": {**incident_base, "category": "unavailable_observation", "observation": {"provenance": "unavailable", "value": 0}}}, NOW)
+    expect("unavailable-incident-never-zero", "unavailable_observation_must_not_supply_value" in unavailable_with_value["stop_conditions"], unavailable_with_value)
+    silent_escalation = planner.incident_projection({"incident": {**incident_base, "category": "escalation_failure", "requested_model": "gpt-5.6-terra", "effective_model": "gpt-5.5", "requested_reasoning": "medium", "effective_reasoning": "low"}}, NOW)
+    expect("incident-no-silent-model-effort-change", "silent_model_change_forbidden" in silent_escalation["stop_conditions"] and "silent_reasoning_change_forbidden" in silent_escalation["stop_conditions"], silent_escalation)
+    private_incident = planner.incident_projection({"incident": {**incident_base, "category": "evidence_conflict", "prompt": "private"}}, NOW)
+    expect("incident-privacy-holds", "privacy_exposure" in private_incident["stop_conditions"], private_incident)
+
     print("af18 mvp1 control-plane tests passed")
     return 0
 

--- a/scripts/test_codex_route_adapter.py
+++ b/scripts/test_codex_route_adapter.py
@@ -175,6 +175,69 @@ def main() -> int:
     })
     expect("spawn-agent-forged-host-collected-is-unverified", code == 0 and provenance_recovery(output, "unknown") and output["schema_provenance"]["evidence_ref_status"] == "unverified", output, errors)
 
+    for action in ("create", "link", "navigate", "measure"):
+        code, output = run(
+            {
+                "role_operation": {
+                    "action": action,
+                    "capability_receipt": {
+                        "capability": action,
+                        "status": "supported",
+                        "provenance": "observed",
+                        "native_metadata": {"native_thread_id": f"codex-{action}-fixture"},
+                    },
+                }
+            }
+        )
+        expect(
+            f"role-operation-{action}-supported-dry-run",
+            code == 0
+            and output["adapter_plan"]["adapter_decision"] == "dry_run_ready"
+            and output["adapter_plan"]["tool_call_proposed"] == "not_available"
+            and output["adapter_plan"]["native_ids_are_metadata_only"] is True
+            and output["mutation_performed"] is False
+            and output["dispatch_performed"] is False,
+            output,
+            errors,
+        )
+
+    degraded_operation = {
+        "role_operation": {
+            "action": "measure",
+            "capability_receipt": {"capability": "measure", "status": "degraded", "provenance": "estimated"},
+        }
+    }
+    code, output = run(degraded_operation)
+    expect("role-operation-degraded-no-call", code == 0 and output["adapter_plan"]["adapter_decision"] == "dry_run_degraded" and output["adapter_plan"]["tool_call_proposed"] == "not_available", output, errors)
+
+    unsupported_operation = {
+        "role_operation": {
+            "action": "create",
+            "capability_receipt": {"capability": "create", "status": "unsupported", "provenance": "observed"},
+        }
+    }
+    code, output = run(unsupported_operation)
+    expect("role-operation-unsupported-fails-closed", code == 0 and output["adapter_plan"]["adapter_decision"] == "hold_required", output, errors)
+
+    unavailable_operation = {
+        "role_operation": {
+            "action": "navigate",
+            "capability_receipt": {"capability": "navigate", "status": "supported", "provenance": "unavailable"},
+        }
+    }
+    code, output = run(unavailable_operation)
+    expect("role-operation-unavailable-fails-closed", code == 0 and output["adapter_plan"]["adapter_decision"] == "hold_required", output, errors)
+
+    private_operation = {
+        "role_operation": {
+            "action": "link",
+            "prompt": "private",
+            "capability_receipt": {"capability": "link", "status": "supported", "provenance": "observed"},
+        }
+    }
+    code, output = run(private_operation)
+    expect("role-operation-privacy-fails-closed", code == 0 and output["adapter_plan"]["adapter_decision"] == "hold_required", output, errors)
+
     if errors:
         print("\n".join(errors), file=sys.stderr)
         return 1


### PR DESCRIPTION
Implements #459 and #460 on the exact 2086b328 base without runtime activation.\n\nScope is limited to the five contracted control-plane and Codex adapter files. Portable Core adds idempotent fresh onboarding, explicit legacy adoption, compact successor/recovery controls, and privacy-safe incident projections. The Codex adapter adds create/link/navigate/measure capability/provenance dry-run projections with native IDs as metadata only.\n\nNo real Codex/API calls, runtime/config/hooks/Vault/generated/Project mutation, polling, archive/delete, dispatch, or activation.