### PR TITLE
feat: add AF18 LearningSignal index core

### DIFF
--- a/schemas/af18-learning-signal-index.schema.yaml
+++ b/schemas/af18-learning-signal-index.schema.yaml
@@ -1,0 +1,44 @@
+# Static, in-memory-only contract for the AF18 LearningSignal candidate index.
+schema_version: 1
+title: AF18 LearningSignal candidate index
+identity_algorithm: af18-learning-signal-identity-v1
+candidate_fields:
+  - candidate_key
+  - state
+  - source_work_anchor
+  - source_role
+  - lesson_type
+  - summary
+  - applicability
+  - evidence_anchors
+  - residual_limits
+  - privacy_status
+  - explicit_exclusions
+required_values:
+  state: candidate_hold
+  privacy_status: pass_metadata_only
+identity:
+  source_work_anchor: non-empty opaque ASCII source-Work identity
+  evidence_anchors: non-empty HTTPS references, bytewise sorted and deduplicated
+  candidate_key: "af18-ls-v1- plus lowercase SHA-256 of compact sorted UTF-8 JSON identity payload"
+  payload_fields: [identity_algorithm, source_work_identity, evidence_anchors]
+index:
+  storage: in-memory only
+  ordering: stable candidate_key bytewise ascending
+  default_projection: [count, routing_state, next_cursor]
+  page_projection: [references, next_cursor]
+  reference: "af18-ls-ref-v1- plus SHA-256 of candidate_key; no detail lookup exists"
+  cursor:
+    version: af18-learning-signal-cursor-v1
+    integrity: process-local random-secret HMAC-SHA-256
+    payload: [cursor_version, batch_fingerprint, identity_algorithm, page_size, last_ordered_reference]
+    page_size: integer 1..25
+    invalid: held_cursor_invalid
+forbidden:
+  - external approval or acceptance inference
+  - unknown fields, source content, prompt, transcript, tool history, raw model output, logs, user data, identity linkage, or secrets
+  - selected-Vault paths, practice or asset identifiers, publish or activation intent, Harvester routing, native identifiers, or #426 claims
+  - persistence, network or GitHub I/O, Vault, Harvester, publication, activation, runtime, or adapter integration
+boundaries:
+  - candidate_hold is evidence intake only, not formal Harvest or canonical practice activation
+  - invalid candidate batches and cursor inputs hold without candidate or history enumeration

--- a/scripts/af18_learning_signal_index.py
+++ b/scripts/af18_learning_signal_index.py
@@ -34,6 +34,7 @@ FORBIDDEN_REFERENCE_MARKERS = (
     "native_id", "native%2did", "native%5fid", "content=", "/content/", "raw-content",
     "raw_content", "transcript", "prompt", "secret",
 )
+MAX_REFERENCE_NORMALIZATION_ROUNDS = 4
 
 
 class CandidateError(ValueError):
@@ -60,8 +61,18 @@ def canonical_anchors(value: Any) -> list[str]:
 
 
 def is_safe_reference(value: str) -> bool:
-    normalized = unquote(value).lower()
-    return not any(marker in normalized for marker in FORBIDDEN_REFERENCE_MARKERS)
+    normalized = value
+    try:
+        for _ in range(MAX_REFERENCE_NORMALIZATION_ROUNDS):
+            decoded = unquote(normalized, errors="strict")
+            if decoded == normalized:
+                if "%" in normalized:
+                    return False
+                return not any(marker in normalized.lower() for marker in FORBIDDEN_REFERENCE_MARKERS)
+            normalized = decoded
+    except UnicodeDecodeError:
+        return False
+    return False
 
 
 def candidate_key(source_work_identity: str, evidence_anchors: list[str]) -> str:

--- a/scripts/af18_learning_signal_index.py
+++ b/scripts/af18_learning_signal_index.py
@@ -33,7 +33,8 @@ FORBIDDEN_MARKERS = (
 FORBIDDEN_REFERENCE_MARKERS = (
     "selected-vault", "selected_vault", "vault/private", "/private/", "native-id",
     "native_id", "native%2did", "native%5fid", "content=", "/content/", "raw-content",
-    "raw_content", "transcript", "prompt", "secret",
+    "raw_content", "transcript", "prompt", "secret", "harvester", "practice_id",
+    "practice-id", "asset_id", "asset-id", "#426", "publish", "activation",
 )
 MAX_REFERENCE_NORMALIZATION_ROUNDS = 4
 

--- a/scripts/af18_learning_signal_index.py
+++ b/scripts/af18_learning_signal_index.py
@@ -7,6 +7,7 @@ import argparse
 import hashlib
 import hmac
 import json
+import re
 import secrets
 import sys
 from urllib.parse import unquote
@@ -68,7 +69,8 @@ def is_safe_reference(value: str) -> bool:
             if decoded == normalized:
                 if "%" in normalized:
                     return False
-                return not any(marker in normalized.lower() for marker in FORBIDDEN_REFERENCE_MARKERS)
+                marker_value = re.sub(r"[\\\\/]+", "/", normalized).lower()
+                return not any(marker in marker_value for marker in FORBIDDEN_REFERENCE_MARKERS)
             normalized = decoded
     except UnicodeDecodeError:
         return False

--- a/scripts/af18_learning_signal_index.py
+++ b/scripts/af18_learning_signal_index.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Static AF18 LearningSignal validation and in-memory opaque index projection."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import secrets
+import sys
+from pathlib import Path
+from typing import Any
+
+
+IDENTITY_ALGORITHM = "af18-learning-signal-identity-v1"
+CURSOR_VERSION = "af18-learning-signal-cursor-v1"
+KEY_PREFIX = "af18-ls-v1-"
+REFERENCE_PREFIX = "af18-ls-ref-v1-"
+CURSOR_PREFIX = "af18-ls-cur-v1-"
+REQUIRED_FIELDS = {
+    "candidate_key", "state", "source_work_anchor", "source_role", "lesson_type",
+    "summary", "applicability", "evidence_anchors", "residual_limits",
+    "privacy_status", "explicit_exclusions",
+}
+FORBIDDEN_MARKERS = (
+    "selected-vault", "vault/", "practice_id", "asset_id", "publish", "activation",
+    "harvester", "#426", "formal harvest", "prompt", "transcript", "tool history",
+    "raw model", "raw content", "secret", "native id", "identity linkage",
+)
+
+
+class CandidateError(ValueError):
+    pass
+
+
+def canonical_json(value: dict[str, Any]) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+
+
+def is_opaque_ascii(value: Any) -> bool:
+    return isinstance(value, str) and bool(value) and value.isascii() and all(32 <= ord(char) < 127 for char in value)
+
+
+def canonical_anchors(value: Any) -> list[str]:
+    if not isinstance(value, list) or not value:
+        raise CandidateError("held_candidate_invalid")
+    if any(not isinstance(anchor, str) or not anchor or not anchor.startswith("https://") for anchor in value):
+        raise CandidateError("held_candidate_invalid")
+    normalized = sorted(value)
+    if len(set(normalized)) != len(normalized):
+        raise CandidateError("held_candidate_invalid")
+    return normalized
+
+
+def candidate_key(source_work_identity: str, evidence_anchors: list[str]) -> str:
+    payload = {
+        "identity_algorithm": IDENTITY_ALGORITHM,
+        "source_work_identity": source_work_identity,
+        "evidence_anchors": evidence_anchors,
+    }
+    return KEY_PREFIX + hashlib.sha256(canonical_json(payload)).hexdigest()
+
+
+def has_forbidden_content(record: dict[str, Any]) -> bool:
+    values = (record[key] for key in ("source_role", "lesson_type", "summary", "applicability"))
+    return any(marker in value.lower() for value in values if isinstance(value, str) for marker in FORBIDDEN_MARKERS)
+
+
+def validate_candidate(record: Any) -> dict[str, Any]:
+    if not isinstance(record, dict) or set(record) != REQUIRED_FIELDS:
+        raise CandidateError("held_candidate_invalid")
+    if record.get("state") != "candidate_hold" or record.get("privacy_status") != "pass_metadata_only":
+        raise CandidateError("held_candidate_invalid")
+    if not is_opaque_ascii(record.get("source_work_anchor")):
+        raise CandidateError("held_candidate_invalid")
+    anchors = canonical_anchors(record.get("evidence_anchors"))
+    if any(not isinstance(record[name], str) or not record[name].strip() for name in REQUIRED_FIELDS - {"evidence_anchors"}):
+        raise CandidateError("held_candidate_invalid")
+    if has_forbidden_content(record):
+        raise CandidateError("held_candidate_invalid")
+    if not hmac.compare_digest(record["candidate_key"], candidate_key(record["source_work_anchor"], anchors)):
+        raise CandidateError("held_candidate_invalid")
+    return record
+
+
+def opaque_reference(key: str) -> str:
+    return REFERENCE_PREFIX + hashlib.sha256(key.encode("ascii")).hexdigest()
+
+
+class LearningSignalIndex:
+    """A process-local index; instances intentionally cannot resume each other."""
+
+    def __init__(self, records: Any) -> None:
+        if not isinstance(records, list):
+            raise CandidateError("held_candidate_invalid")
+        validated = [validate_candidate(record) for record in records]
+        keys = [record["candidate_key"] for record in validated]
+        if len(keys) != len(set(keys)):
+            raise CandidateError("held_duplicate_candidate")
+        self._records = sorted(validated, key=lambda record: record["candidate_key"])
+        self._references = [opaque_reference(record["candidate_key"]) for record in self._records]
+        self._batch_fingerprint = hashlib.sha256(canonical_json({"identity_algorithm": IDENTITY_ALGORITHM, "candidate_keys": [record["candidate_key"] for record in self._records]})).hexdigest()
+        self._secret = secrets.token_bytes(32)
+        self._cursors: dict[str, tuple[bytes, str]] = {}
+
+    @staticmethod
+    def _valid_page_size(page_size: Any) -> bool:
+        return isinstance(page_size, int) and not isinstance(page_size, bool) and 1 <= page_size <= 25
+
+    def _cursor_payload(self, page_size: int, last_reference: str) -> bytes:
+        return canonical_json({
+            "cursor_version": CURSOR_VERSION,
+            "batch_fingerprint": self._batch_fingerprint,
+            "identity_algorithm": IDENTITY_ALGORITHM,
+            "page_size": page_size,
+            "last_ordered_reference": last_reference,
+        })
+
+    def _issue_cursor(self, page_size: int, last_reference: str) -> str:
+        payload = self._cursor_payload(page_size, last_reference)
+        tag = hmac.new(self._secret, payload, hashlib.sha256).hexdigest()
+        nonce = secrets.token_urlsafe(18)
+        token = f"{CURSOR_PREFIX}{nonce}.{tag}"
+        self._cursors[token] = (payload, tag)
+        return token
+
+    def _read_cursor(self, cursor: Any, page_size: Any) -> int | None:
+        if not self._valid_page_size(page_size) or not isinstance(cursor, str):
+            return None
+        stored = self._cursors.get(cursor)
+        if stored is None or not cursor.startswith(CURSOR_PREFIX) or cursor.count(".") != 1:
+            return None
+        payload, stored_tag = stored
+        given_tag = cursor.rsplit(".", 1)[1]
+        expected_tag = hmac.new(self._secret, payload, hashlib.sha256).hexdigest()
+        if not hmac.compare_digest(given_tag, stored_tag) or not hmac.compare_digest(stored_tag, expected_tag):
+            return None
+        try:
+            decoded = json.loads(payload)
+        except json.JSONDecodeError:
+            return None
+        if decoded != {
+            "cursor_version": CURSOR_VERSION,
+            "batch_fingerprint": self._batch_fingerprint,
+            "identity_algorithm": IDENTITY_ALGORITHM,
+            "page_size": page_size,
+            "last_ordered_reference": decoded.get("last_ordered_reference"),
+        }:
+            return None
+        last = decoded["last_ordered_reference"]
+        if last == "":
+            return 0
+        if last not in self._references:
+            return None
+        return self._references.index(last) + 1
+
+    def default_projection(self, page_size: Any = 25) -> dict[str, Any]:
+        if not self._valid_page_size(page_size):
+            return {"routing_state": "held_cursor_invalid"}
+        cursor = self._issue_cursor(page_size, "") if self._references else None
+        return {"count": len(self._references), "routing_state": "candidate_hold", "next_cursor": cursor}
+
+    def page(self, cursor: Any, page_size: Any) -> dict[str, Any]:
+        start = self._read_cursor(cursor, page_size)
+        if start is None:
+            return {"routing_state": "held_cursor_invalid"}
+        references = self._references[start:start + page_size]
+        next_cursor = self._issue_cursor(page_size, references[-1]) if start + page_size < len(self._references) else None
+        return {"references": references, "next_cursor": next_cursor}
+
+
+def hold_from(error: CandidateError) -> dict[str, str]:
+    return {"routing_state": str(error)}
+
+
+def load_batch(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise CandidateError("held_candidate_invalid") from error
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate static LearningSignal records and render an in-memory opaque index projection.")
+    parser.add_argument("--batch-json", type=Path, required=True)
+    parser.add_argument("--mode", choices=("default", "page"), default="default")
+    parser.add_argument("--cursor")
+    parser.add_argument("--page-size", type=int)
+    args = parser.parse_args()
+    try:
+        index = LearningSignalIndex(load_batch(args.batch_json))
+        if args.mode == "default":
+            output: dict[str, Any] = index.default_projection(args.page_size if args.page_size is not None else 25)
+        else:
+            output = index.page(args.cursor, args.page_size)
+        print(json.dumps(output, sort_keys=True))
+        return 0
+    except CandidateError as error:
+        print(json.dumps(hold_from(error), sort_keys=True))
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/af18_learning_signal_index.py
+++ b/scripts/af18_learning_signal_index.py
@@ -35,6 +35,10 @@ FORBIDDEN_REFERENCE_MARKERS = (
     "native_id", "native%2did", "native%5fid", "content=", "/content/", "raw-content",
     "raw_content", "transcript", "prompt", "secret", "harvester", "practice_id",
     "practice-id", "asset_id", "asset-id", "#426", "publish", "activation",
+    "native id", "nativeid", "native identifier", "nativeidentifier", "native-identifier",
+    "native_identifier", "identity linkage", "identity-linkage", "identity_linkage",
+    "user identity", "user-identity", "user_identity", "real-user-data", "real_user_data",
+    "real user data",
 )
 MAX_REFERENCE_NORMALIZATION_ROUNDS = 4
 

--- a/scripts/af18_learning_signal_index.py
+++ b/scripts/af18_learning_signal_index.py
@@ -67,9 +67,11 @@ def is_safe_reference(value: str) -> bool:
         for _ in range(MAX_REFERENCE_NORMALIZATION_ROUNDS):
             decoded = unquote(normalized, errors="strict")
             if decoded == normalized:
-                if "%" in normalized:
+                if "%" in normalized or not normalized.isascii():
                     return False
                 marker_value = re.sub(r"[\\\\/]+", "/", normalized).lower()
+                if marker_value in {".", ".."} or re.search(r"/(?:\.{1,2})(?:[/?#]|$)", marker_value):
+                    return False
                 return not any(marker in marker_value for marker in FORBIDDEN_REFERENCE_MARKERS)
             normalized = decoded
     except UnicodeDecodeError:

--- a/scripts/af18_learning_signal_index.py
+++ b/scripts/af18_learning_signal_index.py
@@ -9,6 +9,7 @@ import hmac
 import json
 import secrets
 import sys
+from urllib.parse import unquote
 from pathlib import Path
 from typing import Any
 
@@ -28,6 +29,11 @@ FORBIDDEN_MARKERS = (
     "harvester", "#426", "formal harvest", "prompt", "transcript", "tool history",
     "raw model", "raw content", "secret", "native id", "identity linkage",
 )
+FORBIDDEN_REFERENCE_MARKERS = (
+    "selected-vault", "selected_vault", "vault/private", "/private/", "native-id",
+    "native_id", "native%2did", "native%5fid", "content=", "/content/", "raw-content",
+    "raw_content", "transcript", "prompt", "secret",
+)
 
 
 class CandidateError(ValueError):
@@ -45,12 +51,17 @@ def is_opaque_ascii(value: Any) -> bool:
 def canonical_anchors(value: Any) -> list[str]:
     if not isinstance(value, list) or not value:
         raise CandidateError("held_candidate_invalid")
-    if any(not isinstance(anchor, str) or not anchor or not anchor.startswith("https://") for anchor in value):
+    if any(not isinstance(anchor, str) or not anchor or not anchor.startswith("https://") or not is_safe_reference(anchor) for anchor in value):
         raise CandidateError("held_candidate_invalid")
     normalized = sorted(value)
     if len(set(normalized)) != len(normalized):
         raise CandidateError("held_candidate_invalid")
     return normalized
+
+
+def is_safe_reference(value: str) -> bool:
+    normalized = unquote(value).lower()
+    return not any(marker in normalized for marker in FORBIDDEN_REFERENCE_MARKERS)
 
 
 def candidate_key(source_work_identity: str, evidence_anchors: list[str]) -> str:
@@ -73,6 +84,8 @@ def validate_candidate(record: Any) -> dict[str, Any]:
     if record.get("state") != "candidate_hold" or record.get("privacy_status") != "pass_metadata_only":
         raise CandidateError("held_candidate_invalid")
     if not is_opaque_ascii(record.get("source_work_anchor")):
+        raise CandidateError("held_candidate_invalid")
+    if not is_safe_reference(record["source_work_anchor"]):
         raise CandidateError("held_candidate_invalid")
     anchors = canonical_anchors(record.get("evidence_anchors"))
     if any(not isinstance(record[name], str) or not record[name].strip() for name in REQUIRED_FIELDS - {"evidence_anchors"}):

--- a/scripts/test_af18_learning_signal_index.py
+++ b/scripts/test_af18_learning_signal_index.py
@@ -106,6 +106,12 @@ def main() -> int:
     safe_source = record("safe-opaque-id_123")
     safe_anchor = record("safe-query-fragment", ["https://example.test/evidence/a?view=compact#receipt"])
     errors += expect("safe-opaque-and-https-remain-valid", module.validate_candidate(safe_source) == safe_source and module.validate_candidate(safe_anchor) == safe_anchor, (safe_source, safe_anchor))
+    intent_markers = ("harvester", "practice_id", "asset_id", "%23426", "publish", "activation")
+    intent_sources = [record(marker) for marker in intent_markers]
+    intent_anchors = [record(f"work-intent-path-{number}", [f"https://example.test/evidence/{marker}"]) for number, marker in enumerate(intent_markers)]
+    intent_anchors += [record(f"work-intent-query-{number}", [f"https://example.test/evidence/safe?intent={marker}"]) for number, marker in enumerate(intent_markers)]
+    intent_anchors += [record(f"work-intent-fragment-{number}", [f"https://example.test/evidence/safe#{marker}"]) for number, marker in enumerate(intent_markers)]
+    errors += expect("intent-and-identifier-source-and-anchor-hold", all(held(module.validate_candidate, item) for item in intent_sources + intent_anchors), (intent_sources, intent_anchors))
     errors += expect("duplicate-batch-holds", held(module.LearningSignalIndex, [one, copy.deepcopy(one)]), one)
     cursor = default["next_cursor"]
     tampered = cursor[:-1] + ("0" if cursor[-1] != "0" else "1")
@@ -150,6 +156,8 @@ def main() -> int:
         private_cases += tuple((f"backslash-anchor-{number}", item) for number, item in enumerate(backslash_anchors))
         private_cases += tuple((f"guarded-source-{number}", item) for number, item in enumerate(guarded_sources))
         private_cases += tuple((f"guarded-anchor-{number}", item) for number, item in enumerate(guarded_anchors))
+        private_cases += tuple((f"intent-source-{number}", item) for number, item in enumerate(intent_sources))
+        private_cases += tuple((f"intent-anchor-{number}", item) for number, item in enumerate(intent_anchors))
         for name, item in private_cases:
             path = Path(raw) / f"{name}.json"
             path.write_text(json.dumps([item]), encoding="utf-8")

--- a/scripts/test_af18_learning_signal_index.py
+++ b/scripts/test_af18_learning_signal_index.py
@@ -85,6 +85,13 @@ def main() -> int:
     selected_vault_anchor = record("work-8", ["https://example.test/selected-vault/private/path"])
     native_id_anchor = record("work-9", ["https://example.test/evidence/native-id/123"])
     errors += expect("source-and-anchor-private-boundaries-hold", all(held(module.validate_candidate, item) for item in (selected_vault_source, private_vault_source, selected_vault_anchor, native_id_anchor)), (selected_vault_source, private_vault_source, selected_vault_anchor, native_id_anchor))
+    double_encoded_markers = ("selected%252Dvault%252Fprivate", "vault%252Fprivate", "content%253Draw", "native%252Did")
+    double_encoded_sources = [record(marker) for marker in double_encoded_markers]
+    double_encoded_anchors = [record(f"work-double-{number}", [f"https://example.test/evidence/{marker}"]) for number, marker in enumerate(double_encoded_markers)]
+    errors += expect("double-encoded-source-and-anchor-hold", all(held(module.validate_candidate, item) for item in double_encoded_sources + double_encoded_anchors), (double_encoded_sources, double_encoded_anchors))
+    malformed_encoded_sources = [record("bad%FF"), record("residual%GZ")]
+    malformed_encoded_anchors = [record(f"work-malformed-{number}", [f"https://example.test/evidence/{marker}"]) for number, marker in enumerate(("bad%FF", "residual%GZ"))]
+    errors += expect("decode-error-and-residual-encoding-hold", all(held(module.validate_candidate, item) for item in malformed_encoded_sources + malformed_encoded_anchors), (malformed_encoded_sources, malformed_encoded_anchors))
     errors += expect("duplicate-batch-holds", held(module.LearningSignalIndex, [one, copy.deepcopy(one)]), one)
     cursor = default["next_cursor"]
     tampered = cursor[:-1] + ("0" if cursor[-1] != "0" else "1")
@@ -120,7 +127,12 @@ def main() -> int:
         invalid_path.write_text(json.dumps([unknown]), encoding="utf-8")
         invalid = subprocess.run([sys.executable, str(SCRIPT), "--batch-json", str(invalid_path)], text=True, capture_output=True)
         private_paths = []
-        for name, item in (("selected-source", selected_vault_source), ("private-source", private_vault_source), ("selected-anchor", selected_vault_anchor), ("native-anchor", native_id_anchor)):
+        private_cases = (("selected-source", selected_vault_source), ("private-source", private_vault_source), ("selected-anchor", selected_vault_anchor), ("native-anchor", native_id_anchor))
+        private_cases += tuple((f"double-source-{number}", item) for number, item in enumerate(double_encoded_sources))
+        private_cases += tuple((f"double-anchor-{number}", item) for number, item in enumerate(double_encoded_anchors))
+        private_cases += tuple((f"malformed-source-{number}", item) for number, item in enumerate(malformed_encoded_sources))
+        private_cases += tuple((f"malformed-anchor-{number}", item) for number, item in enumerate(malformed_encoded_anchors))
+        for name, item in private_cases:
             path = Path(raw) / f"{name}.json"
             path.write_text(json.dumps([item]), encoding="utf-8")
             private_paths.append(path)

--- a/scripts/test_af18_learning_signal_index.py
+++ b/scripts/test_af18_learning_signal_index.py
@@ -97,6 +97,15 @@ def main() -> int:
     backslash_anchors = [record(f"work-backslash-{number}", [f"https://example.test/evidence/{marker}"]) for number, marker in enumerate(backslash_markers)]
     backslash_anchors += [record("work-backslash-query", ["https://example.test/evidence/safe?path=vault%5Cprivate"]), record("work-backslash-fragment", ["https://example.test/evidence/safe#vault%5Cprivate"])]
     errors += expect("backslash-source-and-anchor-hold", all(held(module.validate_candidate, item) for item in backslash_sources + backslash_anchors), (backslash_sources, backslash_anchors))
+    dot_segment_markers = ("vault/./private", "vault/%2e/private")
+    unicode_markers = ("vault%EF%BC%8Fprivate", "selected%EF%BC%8Dvault", "native%EF%BC%8Did", "vault／private", "selected－vault")
+    guarded_sources = [record(marker) for marker in dot_segment_markers + unicode_markers]
+    guarded_anchors = [record(f"work-guarded-{number}", [f"https://example.test/evidence/{marker}"]) for number, marker in enumerate(dot_segment_markers + unicode_markers)]
+    guarded_anchors += [record("work-dot-query", ["https://example.test/evidence/safe?path=vault/%2e/private"]), record("work-dot-fragment", ["https://example.test/evidence/safe#vault/./private"])]
+    errors += expect("dot-and-unicode-source-and-anchor-hold", all(held(module.validate_candidate, item) for item in guarded_sources + guarded_anchors), (guarded_sources, guarded_anchors))
+    safe_source = record("safe-opaque-id_123")
+    safe_anchor = record("safe-query-fragment", ["https://example.test/evidence/a?view=compact#receipt"])
+    errors += expect("safe-opaque-and-https-remain-valid", module.validate_candidate(safe_source) == safe_source and module.validate_candidate(safe_anchor) == safe_anchor, (safe_source, safe_anchor))
     errors += expect("duplicate-batch-holds", held(module.LearningSignalIndex, [one, copy.deepcopy(one)]), one)
     cursor = default["next_cursor"]
     tampered = cursor[:-1] + ("0" if cursor[-1] != "0" else "1")
@@ -139,6 +148,8 @@ def main() -> int:
         private_cases += tuple((f"malformed-anchor-{number}", item) for number, item in enumerate(malformed_encoded_anchors))
         private_cases += tuple((f"backslash-source-{number}", item) for number, item in enumerate(backslash_sources))
         private_cases += tuple((f"backslash-anchor-{number}", item) for number, item in enumerate(backslash_anchors))
+        private_cases += tuple((f"guarded-source-{number}", item) for number, item in enumerate(guarded_sources))
+        private_cases += tuple((f"guarded-anchor-{number}", item) for number, item in enumerate(guarded_anchors))
         for name, item in private_cases:
             path = Path(raw) / f"{name}.json"
             path.write_text(json.dumps([item]), encoding="utf-8")

--- a/scripts/test_af18_learning_signal_index.py
+++ b/scripts/test_af18_learning_signal_index.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Offline regressions for the AF18 static LearningSignal candidate index."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import hmac
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "af18_learning_signal_index.py"
+SCHEMA = ROOT / "schemas" / "af18-learning-signal-index.schema.yaml"
+SPEC = importlib.util.spec_from_file_location("learning_signal_index", SCRIPT)
+module = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(module)
+
+
+def expect(name: str, condition: bool, detail: object) -> list[str]:
+    if condition:
+        print(f"{name}: ok")
+        return []
+    return [f"{name}: {detail}"]
+
+
+def record(identity: str, anchors: list[str] | None = None) -> dict:
+    anchors = anchors or ["https://example.test/evidence/a", "https://example.test/evidence/b"]
+    return {
+        "candidate_key": module.candidate_key(identity, anchors),
+        "state": "candidate_hold",
+        "source_work_anchor": identity,
+        "source_role": "bounded role",
+        "lesson_type": "validated_workflow",
+        "summary": "compact static evidence intake",
+        "applicability": "future bounded offline work",
+        "evidence_anchors": anchors,
+        "residual_limits": "no formal Harvest or activation",
+        "privacy_status": "pass_metadata_only",
+        "explicit_exclusions": "no persistent storage",
+    }
+
+
+def held(callable_: object, *args: object) -> bool:
+    try:
+        callable_(*args)  # type: ignore[operator]
+    except module.CandidateError:
+        return True
+    return False
+
+
+def main() -> int:
+    errors: list[str] = []
+    one, two = record("work-2"), record("work-1")
+    index = module.LearningSignalIndex([one, two])
+    default = index.default_projection()
+    errors += expect("default-minimal", set(default) == {"count", "routing_state", "next_cursor"} and default["count"] == 2 and default["routing_state"] == "candidate_hold" and "summary" not in json.dumps(default), default)
+    page_cursor = index.default_projection(1)["next_cursor"]
+    page_one = index.page(page_cursor, 1)
+    page_two = index.page(page_one["next_cursor"], 1)
+    expected_refs = [module.opaque_reference(item["candidate_key"]) for item in sorted([one, two], key=lambda item: item["candidate_key"])]
+    errors += expect("opaque-stable-pages", page_one["references"] + page_two["references"] == expected_refs and all("work" not in ref and "https" not in ref for ref in expected_refs), (page_one, page_two))
+    reversed_anchors = record("work-3", ["https://example.test/evidence/b", "https://example.test/evidence/a"])
+    reversed_anchors["candidate_key"] = module.candidate_key("work-3", sorted(reversed_anchors["evidence_anchors"]))
+    errors += expect("anchor-order-normalizes", module.validate_candidate(reversed_anchors)["candidate_key"] == reversed_anchors["candidate_key"], reversed_anchors)
+    duplicate_anchors = record("work-4", ["https://example.test/evidence/a", "https://example.test/evidence/a"])
+    duplicate_anchors["candidate_key"] = module.candidate_key("work-4", duplicate_anchors["evidence_anchors"])
+    errors += expect("anchor-duplicate-holds", held(module.validate_candidate, duplicate_anchors), duplicate_anchors)
+    mismatch = record("work-5")
+    mismatch["candidate_key"] = "af18-ls-v1-" + "0" * 64
+    errors += expect("key-mismatch-holds", held(module.validate_candidate, mismatch), mismatch)
+    unknown = record("work-6")
+    unknown["unexpected"] = "x"
+    forbidden = record("work-7")
+    forbidden["summary"] = "publish activation intent"
+    errors += expect("unknown-and-forbidden-hold", held(module.validate_candidate, unknown) and held(module.validate_candidate, forbidden), (unknown, forbidden))
+    errors += expect("duplicate-batch-holds", held(module.LearningSignalIndex, [one, copy.deepcopy(one)]), one)
+    cursor = default["next_cursor"]
+    tampered = cursor[:-1] + ("0" if cursor[-1] != "0" else "1")
+    errors += expect("cursor-tamper-holds", index.page(tampered, 1) == {"routing_state": "held_cursor_invalid"}, tampered)
+    errors += expect("cursor-missing-holds", index.page(None, 1) == {"routing_state": "held_cursor_invalid"}, None)
+    errors += expect("page-bounds-hold", all(index.page(cursor, size) == {"routing_state": "held_cursor_invalid"} for size in (0, -1, 1.5, 26, True, None)), cursor)
+    errors += expect("page-size-mismatch-holds", index.page(cursor, 2) == {"routing_state": "held_cursor_invalid"}, cursor)
+    restarted = module.LearningSignalIndex([one, two])
+    errors += expect("restart-holds", restarted.page(cursor, 25) == {"routing_state": "held_cursor_invalid"}, cursor)
+    changed = module.LearningSignalIndex([one])
+    errors += expect("batch-change-holds", changed.page(cursor, 25) == {"routing_state": "held_cursor_invalid"}, cursor)
+    payload, _ = index._cursors[cursor]
+    changed_payload = json.loads(payload)
+    changed_payload["cursor_version"] = "wrong"
+    version_payload = module.canonical_json(changed_payload)
+    version_tag = hmac.new(index._secret, version_payload, hashlib.sha256).hexdigest()
+    version_cursor = module.CURSOR_PREFIX + "version." + version_tag
+    index._cursors[version_cursor] = (version_payload, version_tag)
+    changed_payload["cursor_version"] = module.CURSOR_VERSION
+    changed_payload["last_ordered_reference"] = "af18-ls-ref-v1-" + "0" * 64
+    order_payload = module.canonical_json(changed_payload)
+    order_tag = hmac.new(index._secret, order_payload, hashlib.sha256).hexdigest()
+    order_cursor = module.CURSOR_PREFIX + "order." + order_tag
+    index._cursors[order_cursor] = (order_payload, order_tag)
+    errors += expect("version-and-order-holds", index.page(version_cursor, 25) == {"routing_state": "held_cursor_invalid"} and index.page(order_cursor, 25) == {"routing_state": "held_cursor_invalid"}, (version_cursor, order_cursor))
+    schema = SCHEMA.read_text(encoding="utf-8")
+    errors += expect("schema-contract", all(value in schema for value in (module.IDENTITY_ALGORITHM, "HMAC-SHA-256", "1..25", "pass_metadata_only", "no detail lookup")), schema)
+    with tempfile.TemporaryDirectory() as raw:
+        batch_path = Path(raw) / "batch.json"
+        batch_path.write_text(json.dumps([one, two]), encoding="utf-8")
+        valid = subprocess.run([sys.executable, str(SCRIPT), "--batch-json", str(batch_path)], text=True, capture_output=True)
+        invalid_path = Path(raw) / "invalid.json"
+        invalid_path.write_text(json.dumps([unknown]), encoding="utf-8")
+        invalid = subprocess.run([sys.executable, str(SCRIPT), "--batch-json", str(invalid_path)], text=True, capture_output=True)
+        valid_output = json.loads(valid.stdout)
+        invalid_output = json.loads(invalid.stdout)
+        errors += expect("cli-static-input-only", valid.returncode == 0 and invalid.returncode == 0 and set(valid_output) == {"count", "routing_state", "next_cursor"} and invalid_output == {"routing_state": "held_candidate_invalid"} and not any(word in valid.stderr.lower() + invalid.stderr.lower() for word in ("github", "vault", "harvester", "network")), (valid, invalid))
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+    print("af18 learning-signal index tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_af18_learning_signal_index.py
+++ b/scripts/test_af18_learning_signal_index.py
@@ -92,6 +92,11 @@ def main() -> int:
     malformed_encoded_sources = [record("bad%FF"), record("residual%GZ")]
     malformed_encoded_anchors = [record(f"work-malformed-{number}", [f"https://example.test/evidence/{marker}"]) for number, marker in enumerate(("bad%FF", "residual%GZ"))]
     errors += expect("decode-error-and-residual-encoding-hold", all(held(module.validate_candidate, item) for item in malformed_encoded_sources + malformed_encoded_anchors), (malformed_encoded_sources, malformed_encoded_anchors))
+    backslash_markers = ("vault\\private", "selected-vault\\private", "vault%5Cprivate", "vault/%5Cprivate")
+    backslash_sources = [record(marker) for marker in backslash_markers]
+    backslash_anchors = [record(f"work-backslash-{number}", [f"https://example.test/evidence/{marker}"]) for number, marker in enumerate(backslash_markers)]
+    backslash_anchors += [record("work-backslash-query", ["https://example.test/evidence/safe?path=vault%5Cprivate"]), record("work-backslash-fragment", ["https://example.test/evidence/safe#vault%5Cprivate"])]
+    errors += expect("backslash-source-and-anchor-hold", all(held(module.validate_candidate, item) for item in backslash_sources + backslash_anchors), (backslash_sources, backslash_anchors))
     errors += expect("duplicate-batch-holds", held(module.LearningSignalIndex, [one, copy.deepcopy(one)]), one)
     cursor = default["next_cursor"]
     tampered = cursor[:-1] + ("0" if cursor[-1] != "0" else "1")
@@ -132,6 +137,8 @@ def main() -> int:
         private_cases += tuple((f"double-anchor-{number}", item) for number, item in enumerate(double_encoded_anchors))
         private_cases += tuple((f"malformed-source-{number}", item) for number, item in enumerate(malformed_encoded_sources))
         private_cases += tuple((f"malformed-anchor-{number}", item) for number, item in enumerate(malformed_encoded_anchors))
+        private_cases += tuple((f"backslash-source-{number}", item) for number, item in enumerate(backslash_sources))
+        private_cases += tuple((f"backslash-anchor-{number}", item) for number, item in enumerate(backslash_anchors))
         for name, item in private_cases:
             path = Path(raw) / f"{name}.json"
             path.write_text(json.dumps([item]), encoding="utf-8")

--- a/scripts/test_af18_learning_signal_index.py
+++ b/scripts/test_af18_learning_signal_index.py
@@ -80,6 +80,11 @@ def main() -> int:
     forbidden = record("work-7")
     forbidden["summary"] = "publish activation intent"
     errors += expect("unknown-and-forbidden-hold", held(module.validate_candidate, unknown) and held(module.validate_candidate, forbidden), (unknown, forbidden))
+    selected_vault_source = record("selected-vault/private/path")
+    private_vault_source = record("vault/private/path")
+    selected_vault_anchor = record("work-8", ["https://example.test/selected-vault/private/path"])
+    native_id_anchor = record("work-9", ["https://example.test/evidence/native-id/123"])
+    errors += expect("source-and-anchor-private-boundaries-hold", all(held(module.validate_candidate, item) for item in (selected_vault_source, private_vault_source, selected_vault_anchor, native_id_anchor)), (selected_vault_source, private_vault_source, selected_vault_anchor, native_id_anchor))
     errors += expect("duplicate-batch-holds", held(module.LearningSignalIndex, [one, copy.deepcopy(one)]), one)
     cursor = default["next_cursor"]
     tampered = cursor[:-1] + ("0" if cursor[-1] != "0" else "1")
@@ -114,9 +119,15 @@ def main() -> int:
         invalid_path = Path(raw) / "invalid.json"
         invalid_path.write_text(json.dumps([unknown]), encoding="utf-8")
         invalid = subprocess.run([sys.executable, str(SCRIPT), "--batch-json", str(invalid_path)], text=True, capture_output=True)
+        private_paths = []
+        for name, item in (("selected-source", selected_vault_source), ("private-source", private_vault_source), ("selected-anchor", selected_vault_anchor), ("native-anchor", native_id_anchor)):
+            path = Path(raw) / f"{name}.json"
+            path.write_text(json.dumps([item]), encoding="utf-8")
+            private_paths.append(path)
+        private_outputs = [subprocess.run([sys.executable, str(SCRIPT), "--batch-json", str(path)], text=True, capture_output=True) for path in private_paths]
         valid_output = json.loads(valid.stdout)
         invalid_output = json.loads(invalid.stdout)
-        errors += expect("cli-static-input-only", valid.returncode == 0 and invalid.returncode == 0 and set(valid_output) == {"count", "routing_state", "next_cursor"} and invalid_output == {"routing_state": "held_candidate_invalid"} and not any(word in valid.stderr.lower() + invalid.stderr.lower() for word in ("github", "vault", "harvester", "network")), (valid, invalid))
+        errors += expect("cli-static-input-only", valid.returncode == 0 and invalid.returncode == 0 and set(valid_output) == {"count", "routing_state", "next_cursor"} and invalid_output == {"routing_state": "held_candidate_invalid"} and all(result.returncode == 0 and json.loads(result.stdout) == {"routing_state": "held_candidate_invalid"} for result in private_outputs) and not any(word in valid.stderr.lower() + invalid.stderr.lower() for word in ("github", "vault", "harvester", "network")), (valid, invalid, private_outputs))
     if errors:
         print("\n".join(errors), file=sys.stderr)
         return 1

--- a/scripts/test_af18_learning_signal_index.py
+++ b/scripts/test_af18_learning_signal_index.py
@@ -11,6 +11,7 @@ import json
 import subprocess
 import sys
 import tempfile
+from urllib.parse import quote
 from pathlib import Path
 
 
@@ -112,6 +113,14 @@ def main() -> int:
     intent_anchors += [record(f"work-intent-query-{number}", [f"https://example.test/evidence/safe?intent={marker}"]) for number, marker in enumerate(intent_markers)]
     intent_anchors += [record(f"work-intent-fragment-{number}", [f"https://example.test/evidence/safe#{marker}"]) for number, marker in enumerate(intent_markers)]
     errors += expect("intent-and-identifier-source-and-anchor-hold", all(held(module.validate_candidate, item) for item in intent_sources + intent_anchors), (intent_sources, intent_anchors))
+    sensitive_markers = ("native id", "native identifier", "identity linkage", "user identity", "real-user-data")
+    encoded_sensitive_markers = tuple(quote(marker, safe="") for marker in sensitive_markers)
+    double_encoded_sensitive_markers = tuple(quote(marker, safe="") for marker in encoded_sensitive_markers)
+    sensitive_sources = [record(marker) for marker in sensitive_markers + encoded_sensitive_markers + double_encoded_sensitive_markers]
+    sensitive_anchors = [record(f"work-sensitive-path-{number}", [f"https://example.test/evidence/{marker}"]) for number, marker in enumerate(sensitive_markers)]
+    sensitive_anchors += [record(f"work-sensitive-query-{number}", [f"https://example.test/evidence/safe?identity={marker}"]) for number, marker in enumerate(encoded_sensitive_markers)]
+    sensitive_anchors += [record(f"work-sensitive-fragment-{number}", [f"https://example.test/evidence/safe#{marker}"]) for number, marker in enumerate(double_encoded_sensitive_markers)]
+    errors += expect("native-identity-user-data-source-and-anchor-hold", all(held(module.validate_candidate, item) for item in sensitive_sources + sensitive_anchors), (sensitive_sources, sensitive_anchors))
     errors += expect("duplicate-batch-holds", held(module.LearningSignalIndex, [one, copy.deepcopy(one)]), one)
     cursor = default["next_cursor"]
     tampered = cursor[:-1] + ("0" if cursor[-1] != "0" else "1")
@@ -158,6 +167,8 @@ def main() -> int:
         private_cases += tuple((f"guarded-anchor-{number}", item) for number, item in enumerate(guarded_anchors))
         private_cases += tuple((f"intent-source-{number}", item) for number, item in enumerate(intent_sources))
         private_cases += tuple((f"intent-anchor-{number}", item) for number, item in enumerate(intent_anchors))
+        private_cases += tuple((f"sensitive-source-{number}", item) for number, item in enumerate(sensitive_sources))
+        private_cases += tuple((f"sensitive-anchor-{number}", item) for number, item in enumerate(sensitive_anchors))
         for name, item in private_cases:
             path = Path(raw) / f"{name}.json"
             path.write_text(json.dumps([item]), encoding="utf-8")


### PR DESCRIPTION
Implements the approved #461 static Core-only LearningSignal candidate-index contract.\n\nValidation:\n- python3 scripts/test_af18_learning_signal_index.py\n- direct CLI holds for unknown field, key mismatch, duplicate batch, tampered cursor, page bounds, and restart\n- git diff --check\n\nBoundaries: caller-supplied static input only; no GitHub approval inference, persistence, network/GitHub/Vault/Harvester I/O, candidate formation, publication, activation, or runtime/adapter integration.\n\nResidual risk: this is only an in-memory intake/query primitive; it does not establish durable evidence approval, formal Harvest, canonical practice activation, or #426 release.