### PR TITLE
AF18 #426-G: portable synthetic practice catalog snapshot S0

### DIFF
--- a/schemas/practice-catalog-pointer.schema.yaml
+++ b/schemas/practice-catalog-pointer.schema.yaml
@@ -1,0 +1,18 @@
+# Portable synthetic fixture contract for a practice catalog pointer.
+
+required_fields:
+  format: "Must equal practice_catalog_pointer_v1."
+  generation: "Non-negative integer changed only by a successful CAS."
+  snapshot_hash: "SHA-256 of a validated canonical snapshot manifest."
+
+receipt_fields:
+  operation: "read | cas | rollback | recovery."
+  generation: "Generation observed or committed by the operation."
+  snapshot_hash: "Pointer target observed or committed by the operation."
+  receipt_id: "Opaque deterministic fixture receipt identifier."
+
+rules:
+  - "PointerStore is a capability boundary; this schema does not prove a real backend."
+  - "CAS conflict leaves the pointer unchanged."
+  - "Pinned reads resolve only the received snapshot hash and never fall back to a working tree."
+  - "Rollback requires a caller-supplied Human authorization receipt/reference."

--- a/schemas/practice-catalog-snapshot.schema.yaml
+++ b/schemas/practice-catalog-snapshot.schema.yaml
@@ -1,0 +1,19 @@
+# Portable synthetic fixture contract for practice_catalog_snapshot_v1.
+
+required_fields:
+  format: "Must equal practice_catalog_snapshot_v1."
+  snapshot_id: "Opaque fixture-local identifier; it is not a Vault identifier."
+  manifest: "Canonical JSON manifest object with only fixture record metadata."
+  manifest_sha256: "SHA-256 of the canonical manifest bytes."
+
+manifest_fields:
+  format: "Must equal practice_catalog_snapshot_v1."
+  records: "List of path and sha256 metadata; raw record content is excluded."
+  record.path: "Relative POSIX path; no absolute path or traversal."
+  record.sha256: "Lowercase SHA-256 digest."
+
+rules:
+  - "This schema is for disposable synthetic fixtures only."
+  - "Canonical manifest bytes use UTF-8 JSON with sorted keys and compact separators."
+  - "A snapshot hash is the SHA-256 digest of those canonical manifest bytes."
+  - "No selected Vault, candidate content, runtime, network, or working-tree fallback is implied."

--- a/scripts/check_foundry_roots.py
+++ b/scripts/check_foundry_roots.py
@@ -36,6 +36,16 @@ CORE_LAYOUT_MARKER = ".agent-foundry-core.yaml"
 VAULT_LAYOUT_MARKER = ".agent-foundry-vault.yaml"
 
 
+def validate_synthetic_snapshot_fixture(manifest: object, pointer: object) -> list[str]:
+    """Validate only explicit S0 synthetic metadata; default root checks never call this."""
+    errors: list[str] = []
+    if not isinstance(manifest, dict) or manifest.get("format") != "practice_catalog_snapshot_v1":
+        errors.append("synthetic snapshot fixture has invalid manifest format")
+    if not isinstance(pointer, dict) or pointer.get("format") != "practice_catalog_pointer_v1":
+        errors.append("synthetic snapshot fixture has invalid pointer format")
+    return errors
+
+
 def read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 

--- a/scripts/practice_catalog_snapshot.py
+++ b/scripts/practice_catalog_snapshot.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Portable, synthetic-only reference contract for practice catalog snapshots."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any
+
+
+SNAPSHOT_FORMAT = "practice_catalog_snapshot_v1"
+POINTER_FORMAT = "practice_catalog_pointer_v1"
+
+
+class ValidationFailure(ValueError):
+    pass
+
+
+def canonical_manifest_bytes(manifest: dict[str, Any]) -> bytes:
+    validate_manifest(manifest)
+    return json.dumps(manifest, ensure_ascii=True, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def manifest_hash(manifest: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_manifest_bytes(manifest)).hexdigest()
+
+
+def _valid_path(path: object) -> bool:
+    return isinstance(path, str) and path and not path.startswith("/") and "\\" not in path and all(part not in {"", ".", ".."} for part in path.split("/"))
+
+
+def _valid_hash(value: object) -> bool:
+    return isinstance(value, str) and len(value) == 64 and all(char in "0123456789abcdef" for char in value)
+
+
+def validate_manifest(manifest: object) -> None:
+    if not isinstance(manifest, dict) or manifest.get("format") != SNAPSHOT_FORMAT:
+        raise ValidationFailure("invalid manifest format")
+    records = manifest.get("records")
+    if not isinstance(records, list):
+        raise ValidationFailure("manifest records must be a list")
+    paths: set[str] = set()
+    for record in records:
+        if not isinstance(record, dict) or not _valid_path(record.get("path")) or not _valid_hash(record.get("sha256")):
+            raise ValidationFailure("invalid manifest record")
+        if record["path"] in paths:
+            raise ValidationFailure("duplicate manifest path")
+        paths.add(record["path"])
+
+
+def snapshot(snapshot_id: str, manifest: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(snapshot_id, str) or not snapshot_id:
+        raise ValidationFailure("invalid snapshot id")
+    digest = manifest_hash(manifest)
+    return {"format": SNAPSHOT_FORMAT, "snapshot_id": snapshot_id, "manifest": manifest, "manifest_sha256": digest}
+
+
+def validate_snapshot(value: object) -> None:
+    if not isinstance(value, dict) or value.get("format") != SNAPSHOT_FORMAT:
+        raise ValidationFailure("invalid snapshot format")
+    if not isinstance(value.get("snapshot_id"), str) or not value["snapshot_id"]:
+        raise ValidationFailure("invalid snapshot id")
+    validate_manifest(value.get("manifest"))
+    if value.get("manifest_sha256") != manifest_hash(value["manifest"]):
+        raise ValidationFailure("manifest hash mismatch")
+
+
+@dataclass(frozen=True)
+class PointerReceipt:
+    operation: str
+    generation: int
+    snapshot_hash: str
+    receipt_id: str
+
+
+class PointerStore:
+    """Deterministic fake capability; no filesystem or network behavior."""
+
+    def __init__(self, initial_hash: str):
+        if not _valid_hash(initial_hash):
+            raise ValidationFailure("invalid initial pointer hash")
+        self._generation = 0
+        self._snapshot_hash = initial_hash
+        self.cas_calls = 0
+
+    def _receipt(self, operation: str) -> PointerReceipt:
+        return PointerReceipt(operation, self._generation, self._snapshot_hash, f"{operation}:{self._generation}:{self._snapshot_hash[:12]}")
+
+    def read(self) -> PointerReceipt:
+        return self._receipt("read")
+
+    def compare_and_set(self, expected_generation: int, new_hash: str) -> PointerReceipt | None:
+        self.cas_calls += 1
+        if not isinstance(expected_generation, int) or not _valid_hash(new_hash):
+            raise ValidationFailure("invalid CAS input")
+        if expected_generation != self._generation:
+            return None
+        self._generation += 1
+        self._snapshot_hash = new_hash
+        return self._receipt("cas")
+
+
+def _require_store(store: object) -> PointerStore:
+    if not isinstance(store, PointerStore):
+        raise ValidationFailure("unknown pointer capability")
+    return store
+
+
+def pinned_read(store: PointerStore, snapshots: dict[str, dict[str, Any]]) -> tuple[dict[str, Any], PointerReceipt]:
+    store = _require_store(store)
+    receipt = store.read()
+    value = snapshots.get(receipt.snapshot_hash)
+    if value is None:
+        raise ValidationFailure("pointer target snapshot missing")
+    validate_snapshot(value)
+    if value["manifest_sha256"] != receipt.snapshot_hash:
+        raise ValidationFailure("pointer target hash mismatch")
+    return value, receipt
+
+
+def commit_snapshot(store: PointerStore, snapshots: dict[str, dict[str, Any]], candidate: dict[str, Any], expected_generation: int, interrupt: str | None = None) -> dict[str, Any]:
+    store = _require_store(store)
+    before = store.read()
+    try:
+        validate_snapshot(candidate)
+        candidate_hash = candidate["manifest_sha256"]
+    except ValidationFailure:
+        return {"state": "held_validation_failure", "pointer": before}
+    if interrupt == "before_cas":
+        return {"state": "held_interrupted_before_cas", "pointer": before}
+    receipt = store.compare_and_set(expected_generation, candidate_hash)
+    if receipt is None:
+        return {"state": "held_cas_conflict", "pointer": store.read()}
+    snapshots[candidate_hash] = candidate
+    if interrupt == "after_cas_before_receipt":
+        return {"state": "interrupted_after_cas_before_receipt", "pointer": receipt}
+    return {"state": "committed", "pointer": receipt}
+
+
+def recover_receipt(store: PointerStore, interrupted: dict[str, Any]) -> dict[str, Any]:
+    store = _require_store(store)
+    pointer = interrupted.get("pointer")
+    if interrupted.get("state") != "interrupted_after_cas_before_receipt" or not isinstance(pointer, PointerReceipt):
+        raise ValidationFailure("no recoverable interrupted commit")
+    current = store.read()
+    if current.generation != pointer.generation or current.snapshot_hash != pointer.snapshot_hash:
+        raise ValidationFailure("interrupted pointer no longer current")
+    return {"state": "committed_receipt_recovered", "pointer": PointerReceipt("recovery", current.generation, current.snapshot_hash, f"recovery:{current.generation}:{current.snapshot_hash[:12]}")}
+
+
+def rollback(store: PointerStore, expected_generation: int, prior_hash: str, human_authorization: str | None) -> dict[str, Any]:
+    store = _require_store(store)
+    before = store.read()
+    if not isinstance(human_authorization, str) or not human_authorization.strip():
+        return {"state": "held_rollback_authorization_missing", "pointer": before}
+    receipt = store.compare_and_set(expected_generation, prior_hash)
+    if receipt is None:
+        return {"state": "held_cas_conflict", "pointer": store.read()}
+    return {"state": "rolled_back", "pointer": PointerReceipt("rollback", receipt.generation, receipt.snapshot_hash, f"rollback:{receipt.generation}:{receipt.snapshot_hash[:12]}")}
+
+
+def retain_snapshots(snapshots: dict[str, dict[str, Any]], keep_hashes: set[str]) -> dict[str, Any]:
+    """Return a deterministic synthetic retention receipt without touching a filesystem."""
+    if not keep_hashes or any(not _valid_hash(value) for value in keep_hashes):
+        raise ValidationFailure("invalid retention set")
+    missing = keep_hashes.difference(snapshots)
+    if missing:
+        raise ValidationFailure("retention target snapshot missing")
+    removed = sorted(set(snapshots).difference(keep_hashes))
+    for digest in removed:
+        del snapshots[digest]
+    return {"operation": "retention", "retained_hashes": sorted(keep_hashes), "removed_hashes": removed, "receipt_id": "retention:" + hashlib.sha256("|".join(sorted(keep_hashes)).encode()).hexdigest()[:12]}

--- a/scripts/practice_catalog_snapshot.py
+++ b/scripts/practice_catalog_snapshot.py
@@ -161,13 +161,10 @@ def rollback(store: PointerStore, expected_generation: int, prior_hash: str, hum
 
 
 def retain_snapshots(snapshots: dict[str, dict[str, Any]], keep_hashes: set[str]) -> dict[str, Any]:
-    """Return a deterministic synthetic retention receipt without touching a filesystem."""
+    """Return a receipt only; S0 retention never disposes synthetic snapshots."""
     if not keep_hashes or any(not _valid_hash(value) for value in keep_hashes):
         raise ValidationFailure("invalid retention set")
     missing = keep_hashes.difference(snapshots)
     if missing:
         raise ValidationFailure("retention target snapshot missing")
-    removed = sorted(set(snapshots).difference(keep_hashes))
-    for digest in removed:
-        del snapshots[digest]
-    return {"operation": "retention", "retained_hashes": sorted(keep_hashes), "removed_hashes": removed, "receipt_id": "retention:" + hashlib.sha256("|".join(sorted(keep_hashes)).encode()).hexdigest()[:12]}
+    return {"operation": "retention", "retained_hashes": sorted(keep_hashes), "removed_hashes": [], "disposed_hashes": [], "receipt_id": "retention:" + hashlib.sha256("|".join(sorted(keep_hashes)).encode()).hexdigest()[:12]}

--- a/scripts/practice_catalog_snapshot.py
+++ b/scripts/practice_catalog_snapshot.py
@@ -127,9 +127,9 @@ def commit_snapshot(store: PointerStore, snapshots: dict[str, dict[str, Any]], c
         candidate_hash = candidate["manifest_sha256"]
     except ValidationFailure:
         return {"state": "held_validation_failure", "pointer": before}
+    snapshots[candidate_hash] = candidate
     if interrupt == "before_cas":
         return {"state": "held_interrupted_before_cas", "pointer": before}
-    snapshots[candidate_hash] = candidate
     receipt = store.compare_and_set(expected_generation, candidate_hash)
     if receipt is None:
         return {"state": "held_cas_conflict", "pointer": store.read()}

--- a/scripts/practice_catalog_snapshot.py
+++ b/scripts/practice_catalog_snapshot.py
@@ -129,10 +129,10 @@ def commit_snapshot(store: PointerStore, snapshots: dict[str, dict[str, Any]], c
         return {"state": "held_validation_failure", "pointer": before}
     if interrupt == "before_cas":
         return {"state": "held_interrupted_before_cas", "pointer": before}
+    snapshots[candidate_hash] = candidate
     receipt = store.compare_and_set(expected_generation, candidate_hash)
     if receipt is None:
         return {"state": "held_cas_conflict", "pointer": store.read()}
-    snapshots[candidate_hash] = candidate
     if interrupt == "after_cas_before_receipt":
         return {"state": "interrupted_after_cas_before_receipt", "pointer": receipt}
     return {"state": "committed", "pointer": receipt}

--- a/scripts/test_foundry_roots.py
+++ b/scripts/test_foundry_roots.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+import check_foundry_roots
 CHECK = ROOT / "scripts" / "check_foundry_roots.py"
 CONFIG = ROOT / "scripts" / "foundry_config.py"
 INIT = ROOT / "scripts" / "init_vault.py"
@@ -325,6 +327,16 @@ def expect(name: str, result: subprocess.CompletedProcess[str], should_pass: boo
 
 def main() -> int:
     errors: list[str] = []
+    errors.extend(
+        check_foundry_roots.validate_synthetic_snapshot_fixture(
+            {"format": "practice_catalog_snapshot_v1"},
+            {"format": "practice_catalog_pointer_v1"},
+        )
+    )
+    if check_foundry_roots.validate_synthetic_snapshot_fixture({}, {}):
+        print("synthetic-snapshot-fixture-validation: ok")
+    else:
+        errors.append("synthetic-snapshot-fixture-validation: malformed fixture accepted")
     with tempfile.TemporaryDirectory(prefix="agent-foundry-root-fixtures-") as tmp:
         base = Path(tmp)
 

--- a/scripts/test_practice_catalog_snapshot.py
+++ b/scripts/test_practice_catalog_snapshot.py
@@ -28,7 +28,7 @@ def main() -> int:
     store = catalog.PointerStore(initial["manifest_sha256"])
 
     held = catalog.commit_snapshot(store, snapshots, candidate, 0, "before_cas")
-    errors += expect("held_interrupted_before_cas", held["state"] == "held_interrupted_before_cas" and store.read().generation == 0)
+    errors += expect("held_interrupted_before_cas", held["state"] == "held_interrupted_before_cas" and candidate["manifest_sha256"] in snapshots and store.read().generation == 0 and store.read().snapshot_hash == initial["manifest_sha256"] and store.cas_calls == 0)
 
     conflict = catalog.commit_snapshot(store, snapshots, candidate, 9)
     errors += expect("held_cas_conflict", conflict["state"] == "held_cas_conflict" and store.read().snapshot_hash == initial["manifest_sha256"])

--- a/scripts/test_practice_catalog_snapshot.py
+++ b/scripts/test_practice_catalog_snapshot.py
@@ -35,6 +35,8 @@ def main() -> int:
 
     interrupted = catalog.commit_snapshot(store, snapshots, candidate, 0, "after_cas_before_receipt")
     calls = store.cas_calls
+    pinned_after_cas, after_cas_receipt = catalog.pinned_read(store, snapshots)
+    errors += expect("after_cas_interruption_pinned_read", pinned_after_cas == candidate and after_cas_receipt.snapshot_hash == candidate["manifest_sha256"] and store.cas_calls == calls)
     recovered = catalog.recover_receipt(store, interrupted)
     errors += expect("committed_receipt_recovered", recovered["state"] == "committed_receipt_recovered" and store.read().snapshot_hash == candidate["manifest_sha256"] and store.cas_calls == calls)
 
@@ -48,6 +50,8 @@ def main() -> int:
 
     pinned, receipt = catalog.pinned_read(store, snapshots)
     errors += expect("pinned_read_no_fallback", pinned == candidate and receipt.snapshot_hash == candidate["manifest_sha256"])
+    authorized = catalog.rollback(store, 1, initial["manifest_sha256"], "#426-G human authorization receipt")
+    errors += expect("authorized_rollback_receipt", authorized["state"] == "rolled_back" and authorized["pointer"].operation == "rollback" and store.read().snapshot_hash == initial["manifest_sha256"])
     missing = catalog.PointerStore("f" * 64)
     try:
         catalog.pinned_read(missing, snapshots)
@@ -66,8 +70,8 @@ def main() -> int:
             errors.append(f"{label}: accepted")
         except catalog.ValidationFailure:
             errors += expect(label, True)
-    retention = catalog.retain_snapshots(dict(snapshots), {candidate["manifest_sha256"]})
-    errors += expect("retention_receipt", retention["operation"] == "retention" and retention["retained_hashes"] == [candidate["manifest_sha256"]])
+    retention = catalog.retain_snapshots(snapshots, {initial["manifest_sha256"]})
+    errors += expect("retention_receipt", retention["operation"] == "retention" and retention["retained_hashes"] == [initial["manifest_sha256"]] and candidate["manifest_sha256"] in retention["removed_hashes"])
     if errors:
         print("Practice catalog snapshot tests failed:")
         print("\n".join(f"- {error}" for error in errors))

--- a/scripts/test_practice_catalog_snapshot.py
+++ b/scripts/test_practice_catalog_snapshot.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Focused synthetic fixtures for the S0 practice catalog snapshot contract."""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import practice_catalog_snapshot as catalog
+
+
+def manifest(name: str = "one") -> dict[str, object]:
+    return {"format": catalog.SNAPSHOT_FORMAT, "records": [{"path": f"fixtures/{name}.txt", "sha256": hashlib.sha256(name.encode()).hexdigest()}]}
+
+
+def expect(name: str, condition: bool, detail: object = "") -> list[str]:
+    print(f"{name}: {'ok' if condition else 'FAIL'}")
+    return [] if condition else [f"{name}: {detail}"]
+
+
+def main() -> int:
+    errors: list[str] = []
+    initial = catalog.snapshot("initial", manifest("initial"))
+    candidate = catalog.snapshot("candidate", manifest("candidate"))
+    snapshots = {initial["manifest_sha256"]: initial}
+    store = catalog.PointerStore(initial["manifest_sha256"])
+
+    held = catalog.commit_snapshot(store, snapshots, candidate, 0, "before_cas")
+    errors += expect("held_interrupted_before_cas", held["state"] == "held_interrupted_before_cas" and store.read().generation == 0)
+
+    conflict = catalog.commit_snapshot(store, snapshots, candidate, 9)
+    errors += expect("held_cas_conflict", conflict["state"] == "held_cas_conflict" and store.read().snapshot_hash == initial["manifest_sha256"])
+
+    interrupted = catalog.commit_snapshot(store, snapshots, candidate, 0, "after_cas_before_receipt")
+    calls = store.cas_calls
+    recovered = catalog.recover_receipt(store, interrupted)
+    errors += expect("committed_receipt_recovered", recovered["state"] == "committed_receipt_recovered" and store.read().snapshot_hash == candidate["manifest_sha256"] and store.cas_calls == calls)
+
+    bad = dict(candidate)
+    bad["manifest_sha256"] = "0" * 64
+    invalid = catalog.commit_snapshot(store, snapshots, bad, 1)
+    errors += expect("held_validation_failure", invalid["state"] == "held_validation_failure" and store.read().generation == 1)
+
+    missing_auth = catalog.rollback(store, 1, initial["manifest_sha256"], None)
+    errors += expect("held_rollback_authorization_missing", missing_auth["state"] == "held_rollback_authorization_missing" and store.read().snapshot_hash == candidate["manifest_sha256"])
+
+    pinned, receipt = catalog.pinned_read(store, snapshots)
+    errors += expect("pinned_read_no_fallback", pinned == candidate and receipt.snapshot_hash == candidate["manifest_sha256"])
+    missing = catalog.PointerStore("f" * 64)
+    try:
+        catalog.pinned_read(missing, snapshots)
+        errors.append("missing_pointer_target: accepted")
+    except catalog.ValidationFailure:
+        errors += expect("missing_pointer_target", True)
+    try:
+        catalog.pinned_read(object(), snapshots)  # type: ignore[arg-type]
+        errors.append("unknown_pointer_capability: accepted")
+    except catalog.ValidationFailure:
+        errors += expect("unknown_pointer_capability", True)
+
+    for label, malformed in [("bad_path", {"format": catalog.SNAPSHOT_FORMAT, "records": [{"path": "../escape", "sha256": "a" * 64}]}), ("bad_hash", {"format": catalog.SNAPSHOT_FORMAT, "records": [{"path": "ok", "sha256": "bad"}]})]:
+        try:
+            catalog.snapshot(label, malformed)
+            errors.append(f"{label}: accepted")
+        except catalog.ValidationFailure:
+            errors += expect(label, True)
+    retention = catalog.retain_snapshots(dict(snapshots), {candidate["manifest_sha256"]})
+    errors += expect("retention_receipt", retention["operation"] == "retention" and retention["retained_hashes"] == [candidate["manifest_sha256"]])
+    if errors:
+        print("Practice catalog snapshot tests failed:")
+        print("\n".join(f"- {error}" for error in errors))
+        return 1
+    print("Practice catalog snapshot tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_practice_catalog_snapshot.py
+++ b/scripts/test_practice_catalog_snapshot.py
@@ -71,7 +71,7 @@ def main() -> int:
         except catalog.ValidationFailure:
             errors += expect(label, True)
     retention = catalog.retain_snapshots(snapshots, {initial["manifest_sha256"]})
-    errors += expect("retention_receipt", retention["operation"] == "retention" and retention["retained_hashes"] == [initial["manifest_sha256"]] and candidate["manifest_sha256"] in retention["removed_hashes"])
+    errors += expect("retention_receipt_no_disposal", retention["operation"] == "retention" and retention["retained_hashes"] == [initial["manifest_sha256"]] and not retention["removed_hashes"] and not retention["disposed_hashes"] and initial["manifest_sha256"] in snapshots and candidate["manifest_sha256"] in snapshots)
     if errors:
         print("Practice catalog snapshot tests failed:")
         print("\n".join(f"- {error}" for error in errors))


### PR DESCRIPTION
Implements the bounded #426-G S0 portable synthetic snapshot/pointer contract.

Scope is limited to the approved six-file allowlist. The deterministic fake `PointerStore` provides CAS/read receipts; tests cover interruption, conflict, recovery without rollback or second CAS, validation holds, rollback authorization, pinned no-fallback, capability failure, and retention receipt.

Verification:
- `python3 scripts/test_practice_catalog_snapshot.py`
- `python3 scripts/test_foundry_roots.py`
- `python3 -m py_compile scripts/practice_catalog_snapshot.py scripts/test_practice_catalog_snapshot.py scripts/check_foundry_roots.py scripts/test_foundry_roots.py`
- `git diff --check`

Residual risk: this establishes only an in-memory deterministic synthetic contract. It does not prove a real linearizable PointerStore, Authority S, selected-Vault migration/cutover, or runtime activation.

Next owners: independent Reviewer -> Tester -> Architect. No merge or issue closure requested.