### PR TITLE
AF18 #426-H S1-A: validate pinned synthetic snapshot views

### DIFF
--- a/scripts/check_foundry_roots.py
+++ b/scripts/check_foundry_roots.py
@@ -13,6 +13,7 @@ import sys
 from pathlib import Path
 
 from foundry_config import CORE_MARKERS, ROOT, VAULT_MARKERS
+import practice_catalog_snapshot as catalog
 
 
 PRACTICE_STATUSES = {
@@ -36,13 +37,64 @@ CORE_LAYOUT_MARKER = ".agent-foundry-core.yaml"
 VAULT_LAYOUT_MARKER = ".agent-foundry-vault.yaml"
 
 
-def validate_synthetic_snapshot_fixture(manifest: object, pointer: object) -> list[str]:
+def validate_synthetic_snapshot_fixture(
+    manifest: object,
+    pointer: object,
+    files: object | None = None,
+    practice_id: object | None = None,
+) -> list[str]:
     """Validate only explicit S0 synthetic metadata; default root checks never call this."""
     errors: list[str] = []
     if not isinstance(manifest, dict) or manifest.get("format") != "practice_catalog_snapshot_v1":
         errors.append("synthetic snapshot fixture has invalid manifest format")
     if not isinstance(pointer, dict) or pointer.get("format") != "practice_catalog_pointer_v1":
         errors.append("synthetic snapshot fixture has invalid pointer format")
+    if files is None:
+        return errors
+    if not isinstance(files, dict) or any(not isinstance(path, str) or not isinstance(content, str) for path, content in files.items()):
+        errors.append("synthetic snapshot fixture has invalid files")
+        return errors
+    if not isinstance(practice_id, str) or not practice_id.startswith("SYN-"):
+        errors.append("synthetic snapshot fixture practice id must be synthetic")
+    records = manifest.get("records", []) if isinstance(manifest, dict) else []
+    paths = {record.get("path") for record in records if isinstance(record, dict)}
+    if set(files) != paths:
+        errors.append("synthetic snapshot fixture manifest/path mismatch")
+    if "indexes/practice_index.yaml" not in files:
+        errors.append("synthetic snapshot fixture practice index missing")
+    if isinstance(practice_id, str) and practice_id and isinstance(files.get("indexes/practice_index.yaml"), str):
+        if f"id: {practice_id}" not in files["indexes/practice_index.yaml"]:
+            errors.append("synthetic snapshot fixture practice entry missing")
+    return errors
+
+
+def validate_injected_snapshot_fixture_view(
+    pointer_capability: object,
+    snapshot_capability: object,
+    practice_id: object,
+) -> list[str]:
+    """Consume the synthetic injected view; never read roots or a working tree."""
+    errors: list[str] = []
+    if not isinstance(pointer_capability, catalog.PointerStore):
+        return ["synthetic snapshot view has unknown pointer capability"]
+    before = pointer_capability.read_calls
+    try:
+        result = catalog.injected_snapshot_view(pointer_capability, snapshot_capability, practice_id)  # type: ignore[arg-type]
+    except catalog.ValidationFailure as exc:
+        return [f"synthetic snapshot view rejected: {exc}"]
+    if pointer_capability.read_calls - before != 1:
+        errors.append("synthetic snapshot view resolved pointer more than once")
+    receipt = result.get("receipt")
+    if not isinstance(receipt, catalog.PointerReceipt) or receipt.operation != "read":
+        errors.append("synthetic snapshot view missing read receipt")
+    if result.get("snapshot_hash") != receipt.snapshot_hash:
+        errors.append("synthetic snapshot view receipt hash mismatch")
+    if result.get("index_path") != "indexes/practice_index.yaml" or not result.get("index"):
+        errors.append("synthetic snapshot view index missing")
+    if result.get("practice_id") != practice_id or result.get("practice_path") not in result.get("index", ""):
+        errors.append("synthetic snapshot view entry mismatch")
+    if not result.get("practice"):
+        errors.append("synthetic snapshot view practice record missing")
     return errors
 
 

--- a/scripts/practice_catalog_snapshot.py
+++ b/scripts/practice_catalog_snapshot.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Mapping
 
 
 SNAPSHOT_FORMAT = "practice_catalog_snapshot_v1"
@@ -49,11 +49,16 @@ def validate_manifest(manifest: object) -> None:
         paths.add(record["path"])
 
 
-def snapshot(snapshot_id: str, manifest: dict[str, Any]) -> dict[str, Any]:
+def snapshot(snapshot_id: str, manifest: dict[str, Any], files: Mapping[str, str] | None = None) -> dict[str, Any]:
     if not isinstance(snapshot_id, str) or not snapshot_id:
         raise ValidationFailure("invalid snapshot id")
     digest = manifest_hash(manifest)
-    return {"format": SNAPSHOT_FORMAT, "snapshot_id": snapshot_id, "manifest": manifest, "manifest_sha256": digest}
+    value: dict[str, Any] = {"format": SNAPSHOT_FORMAT, "snapshot_id": snapshot_id, "manifest": manifest, "manifest_sha256": digest}
+    if files is not None:
+        if not isinstance(files, Mapping) or any(not _valid_path(path) or not isinstance(content, str) for path, content in files.items()):
+            raise ValidationFailure("invalid snapshot files")
+        value["files"] = dict(files)
+    return value
 
 
 def validate_snapshot(value: object) -> None:
@@ -64,6 +69,9 @@ def validate_snapshot(value: object) -> None:
     validate_manifest(value.get("manifest"))
     if value.get("manifest_sha256") != manifest_hash(value["manifest"]):
         raise ValidationFailure("manifest hash mismatch")
+    files = value.get("files")
+    if files is not None and (not isinstance(files, dict) or any(not _valid_path(path) or not isinstance(content, str) for path, content in files.items())):
+        raise ValidationFailure("invalid snapshot files")
 
 
 @dataclass(frozen=True)
@@ -83,11 +91,13 @@ class PointerStore:
         self._generation = 0
         self._snapshot_hash = initial_hash
         self.cas_calls = 0
+        self.read_calls = 0
 
     def _receipt(self, operation: str) -> PointerReceipt:
         return PointerReceipt(operation, self._generation, self._snapshot_hash, f"{operation}:{self._generation}:{self._snapshot_hash[:12]}")
 
     def read(self) -> PointerReceipt:
+        self.read_calls += 1
         return self._receipt("read")
 
     def compare_and_set(self, expected_generation: int, new_hash: str) -> PointerReceipt | None:
@@ -117,6 +127,91 @@ def pinned_read(store: PointerStore, snapshots: dict[str, dict[str, Any]]) -> tu
     if value["manifest_sha256"] != receipt.snapshot_hash:
         raise ValidationFailure("pointer target hash mismatch")
     return value, receipt
+
+
+def _manifest_file_hashes(value: dict[str, Any]) -> dict[str, str]:
+    records = value["manifest"]["records"]
+    return {record["path"]: record["sha256"] for record in records}
+
+
+def _index_entry(index_text: str, practice_id: str) -> dict[str, str]:
+    current: dict[str, str] | None = None
+    entries: list[dict[str, str]] = []
+    in_practices = False
+    for line in index_text.splitlines():
+        if line.startswith("practices:"):
+            in_practices = True
+            continue
+        if in_practices and line and not line.startswith(" "):
+            in_practices = False
+        if not in_practices:
+            continue
+        if line.startswith("  - id: "):
+            if current is not None:
+                entries.append(current)
+            current = {"id": line.split(":", 1)[1].strip().strip('"')}
+        elif current is not None and line.startswith("    ") and ":" in line:
+            key, item = line.strip().split(":", 1)
+            current[key] = item.strip().strip('"')
+    if current is not None:
+        entries.append(current)
+    matches = [entry for entry in entries if entry.get("id") == practice_id]
+    if len(matches) != 1:
+        raise ValidationFailure("practice entry missing or duplicated")
+    path = matches[0].get("path")
+    if not _valid_path(path):
+        raise ValidationFailure("practice entry path mismatch")
+    return matches[0]
+
+
+def injected_snapshot_view(store: PointerStore, snapshots: dict[str, dict[str, Any]], practice_id: str) -> dict[str, Any]:
+    """Read a synthetic practice index and record through one pinned view.
+
+    This is deliberately an injected in-memory capability. It resolves the pointer
+    once, pins the returned receipt/hash, and never falls back to a working tree.
+    """
+    store = _require_store(store)
+    if not isinstance(snapshots, dict):
+        raise ValidationFailure("unknown snapshot-view capability")
+    if not isinstance(practice_id, str) or not practice_id:
+        raise ValidationFailure("invalid practice id")
+    receipt = store.read()
+    if not isinstance(receipt, PointerReceipt) or receipt.operation != "read":
+        raise ValidationFailure("invalid pinned pointer receipt")
+    value = snapshots.get(receipt.snapshot_hash)
+    if value is None:
+        raise ValidationFailure("pointer target snapshot missing")
+    validate_snapshot(value)
+    if value["manifest_sha256"] != receipt.snapshot_hash:
+        raise ValidationFailure("snapshot receipt hash mismatch")
+    files = value.get("files")
+    if not isinstance(files, dict):
+        raise ValidationFailure("snapshot view files missing")
+    hashes = _manifest_file_hashes(value)
+    if set(files) != set(hashes):
+        raise ValidationFailure("manifest and snapshot paths mismatch")
+    for path, content in files.items():
+        if hashlib.sha256(content.encode("utf-8")).hexdigest() != hashes[path]:
+            raise ValidationFailure("snapshot file hash mismatch")
+    index_path = "indexes/practice_index.yaml"
+    if index_path not in files:
+        raise ValidationFailure("practice index missing")
+    entry = _index_entry(files[index_path], practice_id)
+    practice_path = entry["path"]
+    if practice_path not in files or practice_path not in hashes:
+        raise ValidationFailure("practice record missing")
+    return {
+        "practice_id": practice_id,
+        "index_path": index_path,
+        "practice_path": practice_path,
+        "index": files[index_path],
+        "practice": files[practice_path],
+        "receipt": receipt,
+        "snapshot_hash": receipt.snapshot_hash,
+    }
+
+
+validate_injected_snapshot_view = injected_snapshot_view
 
 
 def commit_snapshot(store: PointerStore, snapshots: dict[str, dict[str, Any]], candidate: dict[str, Any], expected_generation: int, interrupt: str | None = None) -> dict[str, Any]:

--- a/scripts/test_foundry_roots.py
+++ b/scripts/test_foundry_roots.py
@@ -13,6 +13,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 import check_foundry_roots
+import practice_catalog_snapshot as catalog
 CHECK = ROOT / "scripts" / "check_foundry_roots.py"
 CONFIG = ROOT / "scripts" / "foundry_config.py"
 INIT = ROOT / "scripts" / "init_vault.py"
@@ -337,6 +338,40 @@ def main() -> int:
         print("synthetic-snapshot-fixture-validation: ok")
     else:
         errors.append("synthetic-snapshot-fixture-validation: malformed fixture accepted")
+    synthetic_files = {
+        "indexes/practice_index.yaml": "schema_version: 1\npractices:\n  - id: SYN-001\n    path: practices/synthetic/SYN-001.md\n",
+        "practices/synthetic/SYN-001.md": "---\nid: SYN-001\n---\nSynthetic only.\n",
+    }
+    synthetic_manifest = {
+        "format": "practice_catalog_snapshot_v1",
+        "records": [{"path": path, "sha256": hashlib.sha256(text.encode()).hexdigest()} for path, text in synthetic_files.items()],
+    }
+    synthetic_snapshot = catalog.snapshot("synthetic-root-view", synthetic_manifest, synthetic_files)
+    synthetic_store = catalog.PointerStore(synthetic_snapshot["manifest_sha256"])
+    view_errors = check_foundry_roots.validate_injected_snapshot_fixture_view(
+        synthetic_store,
+        {synthetic_snapshot["manifest_sha256"]: synthetic_snapshot},
+        "SYN-001",
+    )
+    if not view_errors and synthetic_store.read_calls == 1:
+        print("synthetic-injected-view-consumer: ok")
+    else:
+        errors.append(f"synthetic-injected-view-consumer: {view_errors}, read_calls={synthetic_store.read_calls}")
+    errors.extend(
+        check_foundry_roots.validate_synthetic_snapshot_fixture(
+            synthetic_manifest,
+            {"format": "practice_catalog_pointer_v1", "snapshot_hash": "a" * 64},
+            synthetic_files,
+            "SYN-001",
+        )
+    )
+    missing_entry_errors = check_foundry_roots.validate_synthetic_snapshot_fixture(
+        synthetic_manifest, {}, synthetic_files, "SYN-MISSING"
+    )
+    if missing_entry_errors:
+        print("synthetic-snapshot-missing-entry: ok")
+    else:
+        errors.append("synthetic-snapshot-missing-entry: malformed fixture accepted")
     with tempfile.TemporaryDirectory(prefix="agent-foundry-root-fixtures-") as tmp:
         base = Path(tmp)
 

--- a/scripts/test_practice_catalog_snapshot.py
+++ b/scripts/test_practice_catalog_snapshot.py
@@ -72,6 +72,42 @@ def main() -> int:
             errors += expect(label, True)
     retention = catalog.retain_snapshots(snapshots, {initial["manifest_sha256"]})
     errors += expect("retention_receipt_no_disposal", retention["operation"] == "retention" and retention["retained_hashes"] == [initial["manifest_sha256"]] and not retention["removed_hashes"] and not retention["disposed_hashes"] and initial["manifest_sha256"] in snapshots and candidate["manifest_sha256"] in snapshots)
+
+    practice_text = "---\nid: SYN-001\n---\nSynthetic only.\n"
+    index_text = "schema_version: 1\n\npractices:\n  - id: SYN-001\n    path: practices/synthetic/SYN-001.md\n"
+    files = {
+        "indexes/practice_index.yaml": index_text,
+        "practices/synthetic/SYN-001.md": practice_text,
+    }
+    view_manifest = {
+        "format": catalog.SNAPSHOT_FORMAT,
+        "records": [
+            {"path": path, "sha256": hashlib.sha256(text.encode()).hexdigest()}
+            for path, text in files.items()
+        ],
+    }
+    view = catalog.snapshot("synthetic-view", view_manifest, files)
+    view_store = catalog.PointerStore(view["manifest_sha256"])
+    view_result = catalog.injected_snapshot_view(view_store, {view["manifest_sha256"]: view}, "SYN-001")
+    errors += expect("injected-view-pins-once", view_result["snapshot_hash"] == view["manifest_sha256"] and view_store.read_calls == 1 and view_result["practice"] == practice_text)
+    for label, bad_store, bad_snapshots, bad_id in [
+        ("injected-view-unknown-capability", object(), {view["manifest_sha256"]: view}, "SYN-001"),
+        ("injected-view-missing-entry", view_store, {view["manifest_sha256"]: view}, "UNKNOWN"),
+    ]:
+        try:
+            catalog.injected_snapshot_view(bad_store, bad_snapshots, bad_id)  # type: ignore[arg-type]
+            errors.append(f"{label}: accepted")
+        except catalog.ValidationFailure:
+            errors += expect(label, True)
+    bad_files = dict(files)
+    bad_files["practices/synthetic/SYN-001.md"] = "working-tree fallback"
+    bad_view = dict(view)
+    bad_view["files"] = bad_files
+    try:
+        catalog.injected_snapshot_view(catalog.PointerStore(view["manifest_sha256"]), {view["manifest_sha256"]: bad_view}, "SYN-001")
+        errors.append("injected-view-working-tree-fallback: accepted")
+    except catalog.ValidationFailure:
+        errors += expect("injected-view-working-tree-fallback", True)
     if errors:
         print("Practice catalog snapshot tests failed:")
         print("\n".join(f"- {error}" for error in errors))


### PR DESCRIPTION
## Scope

Implements the bounded S1-A synthetic-only injected snapshot-view validation path in exactly four scripts.

- Resolves the pointer exactly once and pins one receipt/snapshot hash.
- Reads practice index and markdown through the same in-memory snapshot view.
- Fails closed on unknown capability, missing target/entry, manifest/hash/path mismatch, missing files, and working-tree fallback.
- Preserves default root/CLI behavior.

## Verification

- python3 scripts/test_practice_catalog_snapshot.py
- python3 scripts/test_foundry_roots.py
- python3 -m py_compile scripts/practice_catalog_snapshot.py scripts/check_foundry_roots.py scripts/test_practice_catalog_snapshot.py scripts/test_foundry_roots.py
- git diff --check

No Vault, schema, workflow, config, network, runtime, or production data was touched.