### PR TITLE
AF18 #426-I S1-B: validate pinned synthetic catalogs

### DIFF
--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -12,6 +12,7 @@ import sys
 from pathlib import Path
 
 from foundry_config import CONFIG_PATH, parse_config
+import practice_catalog_snapshot as catalog
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -29,6 +30,29 @@ def configured_vault_root() -> Path:
 
 
 VAULT_ROOT = configured_vault_root()
+
+
+def validate_injected_pinned_catalog(pointer_capability: object, snapshot_capability: object) -> list[str]:
+    """Validate a complete synthetic catalog without touching VAULT_ROOT or disk."""
+    if not isinstance(pointer_capability, catalog.PointerStore):
+        return ["synthetic catalog unknown pointer capability"]
+    before = pointer_capability.read_calls
+    try:
+        view = catalog.pinned_catalog_view(pointer_capability, snapshot_capability)  # type: ignore[arg-type]
+    except catalog.ValidationFailure as exc:
+        return [f"synthetic catalog rejected: {exc}"]
+    errors: list[str] = []
+    if pointer_capability.read_calls - before != 1:
+        errors.append("synthetic catalog pointer resolved more than once")
+    receipt = view.get("receipt")
+    if not isinstance(receipt, catalog.PointerReceipt) or receipt.operation != "read":
+        errors.append("synthetic catalog missing read receipt")
+    if view.get("snapshot_hash") != receipt.snapshot_hash:
+        errors.append("synthetic catalog receipt hash mismatch")
+    records = view.get("records")
+    if not isinstance(records, list) or len(records) < 2:
+        errors.append("synthetic catalog must contain multiple records")
+    return errors
 
 
 def read(path: Path) -> str:

--- a/scripts/practice_catalog_snapshot.py
+++ b/scripts/practice_catalog_snapshot.py
@@ -134,7 +134,7 @@ def _manifest_file_hashes(value: dict[str, Any]) -> dict[str, str]:
     return {record["path"]: record["sha256"] for record in records}
 
 
-def _index_entry(index_text: str, practice_id: str) -> dict[str, str]:
+def _index_entries(index_text: str) -> list[dict[str, str]]:
     current: dict[str, str] | None = None
     entries: list[dict[str, str]] = []
     in_practices = False
@@ -155,26 +155,21 @@ def _index_entry(index_text: str, practice_id: str) -> dict[str, str]:
             current[key] = item.strip().strip('"')
     if current is not None:
         entries.append(current)
-    matches = [entry for entry in entries if entry.get("id") == practice_id]
+    return entries
+
+
+def _index_entry(index_text: str, practice_id: str) -> dict[str, str]:
+    matches = [entry for entry in _index_entries(index_text) if entry.get("id") == practice_id]
     if len(matches) != 1:
         raise ValidationFailure("practice entry missing or duplicated")
-    path = matches[0].get("path")
-    if not _valid_path(path):
-        raise ValidationFailure("practice entry path mismatch")
     return matches[0]
 
 
-def injected_snapshot_view(store: PointerStore, snapshots: dict[str, dict[str, Any]], practice_id: str) -> dict[str, Any]:
-    """Read a synthetic practice index and record through one pinned view.
-
-    This is deliberately an injected in-memory capability. It resolves the pointer
-    once, pins the returned receipt/hash, and never falls back to a working tree.
-    """
+def pinned_catalog_view(store: PointerStore, snapshots: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    """Validate the complete synthetic catalog through one pinned in-memory view."""
     store = _require_store(store)
     if not isinstance(snapshots, dict):
         raise ValidationFailure("unknown snapshot-view capability")
-    if not isinstance(practice_id, str) or not practice_id:
-        raise ValidationFailure("invalid practice id")
     receipt = store.read()
     if not isinstance(receipt, PointerReceipt) or receipt.operation != "read":
         raise ValidationFailure("invalid pinned pointer receipt")
@@ -196,18 +191,61 @@ def injected_snapshot_view(store: PointerStore, snapshots: dict[str, dict[str, A
     index_path = "indexes/practice_index.yaml"
     if index_path not in files:
         raise ValidationFailure("practice index missing")
-    entry = _index_entry(files[index_path], practice_id)
-    practice_path = entry["path"]
-    if practice_path not in files or practice_path not in hashes:
-        raise ValidationFailure("practice record missing")
+    entries = _index_entries(files[index_path])
+    if not entries:
+        raise ValidationFailure("practice catalog entries missing")
+    ids: set[str] = set()
+    records: list[dict[str, str]] = []
+    for entry in entries:
+        practice_id = entry.get("id", "")
+        path = entry.get("path")
+        if not practice_id.startswith("SYN-") or practice_id in ids:
+            raise ValidationFailure("synthetic catalog duplicate or non-synthetic id")
+        if not _valid_path(path) or not path.startswith("practices/synthetic/"):
+            raise ValidationFailure("practice entry path mismatch")
+        if path != f"practices/synthetic/{practice_id}.md":
+            raise ValidationFailure("practice entry filename mismatch")
+        if path not in files or path not in hashes:
+            raise ValidationFailure("practice record missing")
+        practice = files[path]
+        lines = practice.splitlines()
+        if not lines or lines[0] != "---":
+            raise ValidationFailure("practice frontmatter missing")
+        end = next((index for index, line in enumerate(lines[1:], 1) if line == "---"), None)
+        if end is None:
+            raise ValidationFailure("practice frontmatter malformed")
+        front_ids = [line.split(":", 1)[1].strip() for line in lines[1:end] if line.startswith("id:")]
+        if len(front_ids) != 1:
+            raise ValidationFailure("practice frontmatter id must be unique")
+        front_id = front_ids[0]
+        if front_id != practice_id:
+            raise ValidationFailure("tampered practice entry")
+        ids.add(practice_id)
+        records.append({"id": practice_id, "path": path, "content": practice})
+    return {"receipt": receipt, "snapshot_hash": receipt.snapshot_hash, "index": files[index_path], "records": records}
+
+
+def injected_snapshot_view(store: PointerStore, snapshots: dict[str, dict[str, Any]], practice_id: str) -> dict[str, Any]:
+    """Read a synthetic practice index and record through one pinned view.
+
+    This is deliberately an injected in-memory capability. It resolves the pointer
+    once, pins the returned receipt/hash, and never falls back to a working tree.
+    """
+    if not isinstance(practice_id, str) or not practice_id:
+        raise ValidationFailure("invalid practice id")
+    view = pinned_catalog_view(store, snapshots)
+    matches = [record for record in view["records"] if record["id"] == practice_id]
+    if len(matches) != 1:
+        raise ValidationFailure("practice entry missing or duplicated")
+    record = matches[0]
     return {
         "practice_id": practice_id,
-        "index_path": index_path,
-        "practice_path": practice_path,
-        "index": files[index_path],
-        "practice": files[practice_path],
-        "receipt": receipt,
-        "snapshot_hash": receipt.snapshot_hash,
+        "index_path": "indexes/practice_index.yaml",
+        "practice_path": record["path"],
+        "index": view["index"],
+        "practice": record["content"],
+        "receipt": view["receipt"],
+        "snapshot_hash": view["snapshot_hash"],
     }
 
 

--- a/scripts/test_check_consistency_snapshot.py
+++ b/scripts/test_check_consistency_snapshot.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Static synthetic-only consumer fixtures for consistency pinned catalogs."""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import check_consistency
+import practice_catalog_snapshot as catalog
+
+
+def main() -> int:
+    files = {
+        "indexes/practice_index.yaml": "schema_version: 1\npractices:\n  - id: SYN-001\n    path: practices/synthetic/SYN-001.md\n  - id: SYN-002\n    path: practices/synthetic/SYN-002.md\n",
+        "practices/synthetic/SYN-001.md": "---\nid: SYN-001\n---\nSynthetic one.\n",
+        "practices/synthetic/SYN-002.md": "---\nid: SYN-002\n---\nSynthetic two.\n",
+    }
+    manifest = {"format": catalog.SNAPSHOT_FORMAT, "records": [{"path": path, "sha256": hashlib.sha256(text.encode()).hexdigest()} for path, text in files.items()]}
+    value = catalog.snapshot("synthetic-consistency", manifest, files)
+    store = catalog.PointerStore(value["manifest_sha256"])
+    errors = check_consistency.validate_injected_pinned_catalog(store, {value["manifest_sha256"]: value})
+    if errors or store.read_calls != 1:
+        print(f"pinned-consistency-consumer: FAIL {errors} read_calls={store.read_calls}")
+        return 1
+    print("pinned-consistency-consumer: ok")
+    if check_consistency.validate_injected_pinned_catalog(object(), {value["manifest_sha256"]: value}):
+        print("unknown-capability: ok")
+    else:
+        print("unknown-capability: FAIL")
+        return 1
+    for label, path, body in [
+        ("non-markdown-path", "practices/synthetic/SYN-001.txt", "---\nid: SYN-001\n---\nSynthetic.\n"),
+        ("body-only-id", "practices/synthetic/SYN-001.md", "body\nid: SYN-001\n"),
+        ("fake-frontmatter-delimiter", "practices/synthetic/SYN-001.md", "---\nid: SYN-001\n---not-a-delimiter\nSynthetic.\n"),
+        ("duplicate-frontmatter-id", "practices/synthetic/SYN-001.md", "---\nid: SYN-001\nid: SYN-999\n---\nSynthetic.\n"),
+    ]:
+        altered_files = dict(files)
+        altered_files.pop("practices/synthetic/SYN-001.md")
+        altered_files[path] = body
+        altered_manifest = {"format": catalog.SNAPSHOT_FORMAT, "records": [{"path": item, "sha256": hashlib.sha256(text.encode()).hexdigest()} for item, text in altered_files.items()]}
+        altered = catalog.snapshot(label, altered_manifest, altered_files)
+        if check_consistency.validate_injected_pinned_catalog(catalog.PointerStore(altered["manifest_sha256"]), {altered["manifest_sha256"]: altered}):
+            print(f"{label}: ok")
+        else:
+            print(f"{label}: FAIL")
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_practice_catalog_snapshot.py
+++ b/scripts/test_practice_catalog_snapshot.py
@@ -108,6 +108,27 @@ def main() -> int:
         errors.append("injected-view-working-tree-fallback: accepted")
     except catalog.ValidationFailure:
         errors += expect("injected-view-working-tree-fallback", True)
+
+    multi_files = {
+        "indexes/practice_index.yaml": "schema_version: 1\npractices:\n  - id: SYN-001\n    path: practices/synthetic/SYN-001.md\n  - id: SYN-002\n    path: practices/synthetic/SYN-002.md\n",
+        "practices/synthetic/SYN-001.md": "---\nid: SYN-001\n---\nSynthetic one.\n",
+        "practices/synthetic/SYN-002.md": "---\nid: SYN-002\n---\nSynthetic two.\n",
+    }
+    multi_manifest = {"format": catalog.SNAPSHOT_FORMAT, "records": [{"path": path, "sha256": hashlib.sha256(text.encode()).hexdigest()} for path, text in multi_files.items()]}
+    multi = catalog.snapshot("synthetic-multi", multi_manifest, multi_files)
+    multi_store = catalog.PointerStore(multi["manifest_sha256"])
+    full = catalog.pinned_catalog_view(multi_store, {multi["manifest_sha256"]: multi})
+    errors += expect("pinned-catalog-multiple", len(full["records"]) == 2 and multi_store.read_calls == 1)
+    for label, mutate in [("duplicate-id", lambda f: f.update({"indexes/practice_index.yaml": f["indexes/practice_index.yaml"].replace("SYN-002", "SYN-001")})), ("tampered-entry", lambda f: f.update({"practices/synthetic/SYN-002.md": "---\nid: SYN-999\n---\nTampered.\n"}))]:
+        altered = dict(multi_files)
+        mutate(altered)
+        altered_value = dict(multi)
+        altered_value["files"] = altered
+        try:
+            catalog.pinned_catalog_view(catalog.PointerStore(multi["manifest_sha256"]), {multi["manifest_sha256"]: altered_value})
+            errors.append(f"{label}: accepted")
+        except catalog.ValidationFailure:
+            errors += expect(label, True)
     if errors:
         print("Practice catalog snapshot tests failed:")
         print("\n".join(f"- {error}" for error in errors))


### PR DESCRIPTION
## Scope

Adds a synthetic-only pinned-catalog validation path within the four-file allowlist.

- Resolves the pointer exactly once with operation=read and pins one receipt/hash.
- Validates the complete synthetic index and multiple SYN-* Markdown records through the same in-memory view.
- Fails closed on duplicate IDs, missing entries, bad hashes, path traversal, manifest/path mismatch, tampered frontmatter, unknown capability, and working-tree fallback.
- Existing CLI, VAULT_ROOT, and working-tree behavior are unchanged; default checks do not invoke the synthetic path.

## Verification

- python3 scripts/test_practice_catalog_snapshot.py
- python3 scripts/test_check_consistency_snapshot.py
- python3 -m py_compile scripts/practice_catalog_snapshot.py scripts/check_consistency.py scripts/test_practice_catalog_snapshot.py scripts/test_check_consistency_snapshot.py
- git diff --check

Fixtures contain only SYN-* identities and no filesystem, Vault, network, runtime, or production I/O.