### PR TITLE
AF18 #426-J S1-C: add disposable SQLite pointer store

### DIFF
--- a/scripts/sqlite_pointer_store.py
+++ b/scripts/sqlite_pointer_store.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Disposable SQLite pointer capability for synthetic snapshot tests only."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from practice_catalog_snapshot import POINTER_FORMAT, PointerReceipt, ValidationFailure, _valid_hash
+
+
+class SQLitePointerStore:
+    """Store only generation and snapshot_hash under an explicit temp path."""
+
+    def __init__(self, db_path: str | Path, initial_hash: str, disposable_root: str | Path | None = None):
+        path = Path(db_path).expanduser()
+        if disposable_root is None:
+            raise ValidationFailure("caller-supplied disposable root required")
+        root = Path(disposable_root).expanduser()
+        if not root.is_absolute() or not root.exists() or not root.is_dir() or not root.name.startswith("synthetic-pointer-"):
+            raise ValidationFailure("invalid disposable TemporaryDirectory root")
+        root = root.resolve()
+        if not path.is_absolute():
+            raise ValidationFailure("SQLite pointer path must be absolute")
+        resolved = path.resolve()
+        try:
+            resolved.relative_to(root)
+        except ValueError as exc:
+            raise ValidationFailure("SQLite pointer must be under TemporaryDirectory") from exc
+        lowered = str(resolved).lower()
+        if any(token in lowered for token in ("vault", "candidate", "practices", "agent-foundry/config")):
+            raise ValidationFailure("SQLite pointer path resembles persistent or Vault data")
+        if not _valid_hash(initial_hash):
+            raise ValidationFailure("invalid initial pointer hash")
+        self.path = resolved
+        self._connection = sqlite3.connect(str(resolved), timeout=2.0)
+        self._connection.execute("CREATE TABLE IF NOT EXISTS pointer (slot INTEGER PRIMARY KEY CHECK (slot = 1), generation INTEGER NOT NULL, snapshot_hash TEXT NOT NULL)")
+        row = self._connection.execute("SELECT generation, snapshot_hash FROM pointer WHERE slot = 1").fetchone()
+        if row is None:
+            self._connection.execute("INSERT INTO pointer(slot, generation, snapshot_hash) VALUES (1, 0, ?)", (initial_hash,))
+            self._connection.commit()
+        elif not isinstance(row[0], int) or not _valid_hash(row[1]):
+            self._connection.close()
+            raise ValidationFailure("invalid persisted pointer")
+        self.read_calls = 0
+        self.cas_calls = 0
+
+    def read(self) -> PointerReceipt:
+        row = self._connection.execute("SELECT generation, snapshot_hash FROM pointer WHERE slot = 1").fetchone()
+        if row is None:
+            raise ValidationFailure("pointer row missing")
+        self.read_calls += 1
+        generation, snapshot_hash = row
+        return PointerReceipt("read", generation, snapshot_hash, f"read:{generation}:{snapshot_hash[:12]}")
+
+    def compare_and_set(self, expected_generation: int, new_hash: str) -> PointerReceipt | None:
+        if not isinstance(expected_generation, int) or not _valid_hash(new_hash):
+            raise ValidationFailure("invalid CAS input")
+        self.cas_calls += 1
+        self._connection.execute("BEGIN IMMEDIATE")
+        cursor = self._connection.execute(
+            "UPDATE pointer SET generation = generation + 1, snapshot_hash = ? WHERE slot = 1 AND generation = ?",
+            (new_hash, expected_generation),
+        )
+        if cursor.rowcount != 1:
+            self._connection.rollback()
+            return None
+        self._connection.commit()
+        row = self._connection.execute("SELECT generation, snapshot_hash FROM pointer WHERE slot = 1").fetchone()
+        return PointerReceipt("cas", row[0], row[1], f"cas:{row[0]}:{row[1][:12]}")
+
+    def close(self) -> None:
+        self._connection.close()
+
+    def rollback(self, expected_generation: int, prior_hash: str, authorization: str | None) -> dict[str, object]:
+        before = self.read()
+        if not isinstance(authorization, str) or not authorization.strip():
+            return {"state": "held_rollback_authorization_missing", "pointer": before}
+        receipt = self.compare_and_set(expected_generation, prior_hash)
+        if receipt is None:
+            return {"state": "held_cas_conflict", "pointer": self.read()}
+        return {"state": "rolled_back", "pointer": PointerReceipt("rollback", receipt.generation, receipt.snapshot_hash, f"rollback:{receipt.generation}:{receipt.snapshot_hash[:12]}")}
+
+    @staticmethod
+    def retention_receipt(keep_hashes: set[str]) -> dict[str, object]:
+        if not keep_hashes or any(not _valid_hash(value) for value in keep_hashes):
+            raise ValidationFailure("invalid retention set")
+        return {"operation": "retention", "retained_hashes": sorted(keep_hashes), "removed_hashes": [], "disposed_hashes": []}
+
+
+__all__ = ["SQLitePointerStore"]

--- a/scripts/test_sqlite_pointer_store.py
+++ b/scripts/test_sqlite_pointer_store.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Synthetic-only SQLite pointer adapter fixtures."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+sys_path = Path(__file__).resolve().parent
+import sys
+sys.path.insert(0, str(sys_path))
+from practice_catalog_snapshot import ValidationFailure
+from sqlite_pointer_store import SQLitePointerStore
+
+
+def expect(name: str, condition: bool, errors: list[str]) -> None:
+    print(f"{name}: {'ok' if condition else 'FAIL'}")
+    if not condition:
+        errors.append(name)
+
+
+def main() -> int:
+    errors: list[str] = []
+    first_hash = "a" * 64
+    second_hash = "b" * 64
+    with tempfile.TemporaryDirectory(prefix="synthetic-pointer-") as temp:
+        db = Path(temp) / "pointer.sqlite3"
+        try:
+            SQLitePointerStore(Path(temp).parent / "candidate-vault" / "pointer.sqlite3", first_hash, Path(temp))
+            errors.append("persistent-path-rejected: accepted")
+        except ValidationFailure:
+            expect("persistent-path-rejected", True, errors)
+        with tempfile.TemporaryDirectory(prefix="ordinary-s1c-review-") as generic_temp:
+            generic_root = Path(generic_temp)
+            try:
+                SQLitePointerStore(generic_root / "pointer.sqlite3", first_hash, generic_root)
+                errors.append("generic-temp-root-rejected: accepted")
+            except ValidationFailure:
+                expect("generic-temp-root-rejected", True, errors)
+        one = SQLitePointerStore(db, first_hash, Path(temp))
+        two = SQLitePointerStore(db, first_hash, Path(temp))
+        receipt = one.read()
+        expect("read-receipt", receipt.operation == "read" and receipt.generation == 0 and receipt.snapshot_hash == first_hash, errors)
+        committed = one.compare_and_set(receipt.generation, second_hash)
+        expect("first-cas", committed is not None and committed.snapshot_hash == second_hash, errors)
+        conflict = two.compare_and_set(0, first_hash)
+        expect("failed-cas-leaves-new-pointer", conflict is None and two.read().snapshot_hash == second_hash, errors)
+        one.close()
+        two.close()
+        reopened = SQLitePointerStore(db, first_hash, Path(temp))
+        expect("reopen-reads-committed-pointer", reopened.read().snapshot_hash == second_hash and reopened.read().generation == 1, errors)
+        lost_receipt = reopened.compare_and_set(1, first_hash)
+        reopened.close()
+        recovered = SQLitePointerStore(db, first_hash, Path(temp))
+        expect("cas-before-receipt-recovery", lost_receipt is not None and recovered.read().snapshot_hash == first_hash, errors)
+        held = recovered.rollback(2, second_hash, None)
+        expect("rollback-requires-authorization", held["state"] == "held_rollback_authorization_missing", errors)
+        rolled = recovered.rollback(2, second_hash, "synthetic authorization reference")
+        expect("authorized-rollback", rolled["state"] == "rolled_back" and recovered.read().snapshot_hash == second_hash, errors)
+        retention = recovered.retention_receipt({second_hash})
+        expect("retention-receipt-only", retention["removed_hashes"] == [] and retention["disposed_hashes"] == [] and db.exists(), errors)
+        recovered.close()
+    if errors:
+        print("SQLite pointer store tests failed:")
+        print("\n".join(f"- {error}" for error in errors))
+        return 1
+    print("SQLite pointer store tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Scope

Adds a disposable SQLite PointerStore adapter for synthetic snapshot pointer state.

- Stores only generation and snapshot_hash.
- Requires an explicit absolute path under TemporaryDirectory and rejects Vault/candidate/persistent-looking paths.
- Covers independent-connection CAS conflicts, read receipts, reopen/restart, CAS-before-receipt recovery, rollback authorization, and receipt-only retention.
- No Vault, network, GitHub, runtime, default reader, or CLI I/O.

## Verification

- python3 scripts/test_sqlite_pointer_store.py
- python3 scripts/test_practice_catalog_snapshot.py
- python3 -m py_compile scripts/practice_catalog_snapshot.py scripts/sqlite_pointer_store.py scripts/test_sqlite_pointer_store.py scripts/test_practice_catalog_snapshot.py
- git diff --check

Fixtures use only synthetic hashes.