### PR TITLE
AF18 #426-K S1-D: version pointer capability boundary

### DIFF
--- a/scripts/check_foundry_roots.py
+++ b/scripts/check_foundry_roots.py
@@ -75,14 +75,16 @@ def validate_injected_snapshot_fixture_view(
 ) -> list[str]:
     """Consume the synthetic injected view; never read roots or a working tree."""
     errors: list[str] = []
-    if not isinstance(pointer_capability, catalog.PointerStore):
+    try:
+        backend = catalog._require_store(pointer_capability)
+    except catalog.ValidationFailure:
         return ["synthetic snapshot view has unknown pointer capability"]
-    before = pointer_capability.read_calls
+    before = getattr(backend, "read_calls", None)
     try:
         result = catalog.injected_snapshot_view(pointer_capability, snapshot_capability, practice_id)  # type: ignore[arg-type]
     except catalog.ValidationFailure as exc:
         return [f"synthetic snapshot view rejected: {exc}"]
-    if pointer_capability.read_calls - before != 1:
+    if before is None or getattr(backend, "read_calls", None) - before != 1:
         errors.append("synthetic snapshot view resolved pointer more than once")
     receipt = result.get("receipt")
     if not isinstance(receipt, catalog.PointerReceipt) or receipt.operation != "read":

--- a/scripts/practice_catalog_snapshot.py
+++ b/scripts/practice_catalog_snapshot.py
@@ -5,12 +5,17 @@ from __future__ import annotations
 
 import hashlib
 import json
+import secrets
+import weakref
 from dataclasses import dataclass
 from typing import Any, Mapping
 
 
 SNAPSHOT_FORMAT = "practice_catalog_snapshot_v1"
 POINTER_FORMAT = "practice_catalog_pointer_v1"
+CAPABILITY_FORMAT = "practice_catalog_capability_v1"
+_CAPABILITY_SEAL = object()
+_RECEIPT_KEYS: weakref.WeakKeyDictionary[object, bytes] = weakref.WeakKeyDictionary()
 
 
 class ValidationFailure(ValueError):
@@ -80,6 +85,53 @@ class PointerReceipt:
     generation: int
     snapshot_hash: str
     receipt_id: str
+    format: str = POINTER_FORMAT
+    version: int = 1
+    signature: str = ""
+
+
+def _register_receipt_backend(backend: object) -> None:
+    _RECEIPT_KEYS[backend] = secrets.token_bytes(32)
+
+
+def _receipt_signature(backend: object, operation: str, generation: int, snapshot_hash: str, receipt_id: str) -> str:
+    key = _RECEIPT_KEYS.get(backend)
+    if key is None:
+        raise ValidationFailure("unregistered receipt producer")
+    return hashlib.sha256(key + f"{operation}|{generation}|{snapshot_hash}|{receipt_id}".encode()).hexdigest()
+
+
+def _make_receipt(backend: object, operation: str, generation: int, snapshot_hash: str, receipt_id: str) -> PointerReceipt:
+    return PointerReceipt(operation, generation, snapshot_hash, receipt_id, signature=_receipt_signature(backend, operation, generation, snapshot_hash, receipt_id))
+
+
+@dataclass(frozen=True, init=False)
+class PointerStoreCapability:
+    backend: object
+    format: str = CAPABILITY_FORMAT
+    version: int = 1
+    _seal: object = _CAPABILITY_SEAL
+
+    def __init__(self, backend: object, *, _seal: object | None = None):
+        if _seal is not _CAPABILITY_SEAL:
+            raise ValidationFailure("capability issuance is private")
+        object.__setattr__(self, "backend", backend)
+        object.__setattr__(self, "format", CAPABILITY_FORMAT)
+        object.__setattr__(self, "version", 1)
+        object.__setattr__(self, "_seal", _CAPABILITY_SEAL)
+
+
+def issue_capability(backend: object) -> PointerStoreCapability:
+    approved = type(backend) is PointerStore
+    if not approved:
+        try:
+            from sqlite_pointer_store import SQLitePointerStore
+            approved = type(backend) is SQLitePointerStore
+        except ImportError:
+            approved = False
+    if not approved:
+        raise ValidationFailure("unknown pointer producer")
+    return PointerStoreCapability(backend, _seal=_CAPABILITY_SEAL)
 
 
 class PointerStore:
@@ -90,11 +142,13 @@ class PointerStore:
             raise ValidationFailure("invalid initial pointer hash")
         self._generation = 0
         self._snapshot_hash = initial_hash
+        _register_receipt_backend(self)
         self.cas_calls = 0
         self.read_calls = 0
 
     def _receipt(self, operation: str) -> PointerReceipt:
-        return PointerReceipt(operation, self._generation, self._snapshot_hash, f"{operation}:{self._generation}:{self._snapshot_hash[:12]}")
+        receipt_id = f"{operation}:{self._generation}:{self._snapshot_hash[:12]}"
+        return _make_receipt(self, operation, self._generation, self._snapshot_hash, receipt_id)
 
     def read(self) -> PointerReceipt:
         self.read_calls += 1
@@ -112,14 +166,24 @@ class PointerStore:
 
 
 def _require_store(store: object) -> PointerStore:
+    if isinstance(store, PointerStoreCapability):
+        if getattr(store, "format", None) != CAPABILITY_FORMAT or getattr(store, "version", None) != 1 or getattr(store, "_seal", None) is not _CAPABILITY_SEAL or not hasattr(store, "backend"):
+            raise ValidationFailure("forged pointer capability")
+        return store.backend  # type: ignore[return-value]
     if not isinstance(store, PointerStore):
         raise ValidationFailure("unknown pointer capability")
     return store
 
 
+def _validate_receipt(receipt: object, backend: object, operation: str = "read") -> PointerReceipt:
+    if not isinstance(receipt, PointerReceipt) or receipt.format != POINTER_FORMAT or receipt.version != 1 or receipt.operation != operation or not isinstance(receipt.generation, int) or receipt.generation < 0 or not _valid_hash(receipt.snapshot_hash) or receipt.signature != _receipt_signature(backend, receipt.operation, receipt.generation, receipt.snapshot_hash, receipt.receipt_id):
+        raise ValidationFailure("forged or invalid pointer receipt")
+    return receipt
+
+
 def pinned_read(store: PointerStore, snapshots: dict[str, dict[str, Any]]) -> tuple[dict[str, Any], PointerReceipt]:
     store = _require_store(store)
-    receipt = store.read()
+    receipt = _validate_receipt(store.read(), store)
     value = snapshots.get(receipt.snapshot_hash)
     if value is None:
         raise ValidationFailure("pointer target snapshot missing")
@@ -170,9 +234,7 @@ def pinned_catalog_view(store: PointerStore, snapshots: dict[str, dict[str, Any]
     store = _require_store(store)
     if not isinstance(snapshots, dict):
         raise ValidationFailure("unknown snapshot-view capability")
-    receipt = store.read()
-    if not isinstance(receipt, PointerReceipt) or receipt.operation != "read":
-        raise ValidationFailure("invalid pinned pointer receipt")
+    receipt = _validate_receipt(store.read(), store)
     value = snapshots.get(receipt.snapshot_hash)
     if value is None:
         raise ValidationFailure("pointer target snapshot missing")

--- a/scripts/sqlite_pointer_store.py
+++ b/scripts/sqlite_pointer_store.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-from practice_catalog_snapshot import POINTER_FORMAT, PointerReceipt, ValidationFailure, _valid_hash
+from practice_catalog_snapshot import POINTER_FORMAT, PointerReceipt, PointerStoreCapability, ValidationFailure, _make_receipt, _register_receipt_backend, _valid_hash
 
 
 class SQLitePointerStore:
@@ -33,6 +33,7 @@ class SQLitePointerStore:
         if not _valid_hash(initial_hash):
             raise ValidationFailure("invalid initial pointer hash")
         self.path = resolved
+        _register_receipt_backend(self)
         self._connection = sqlite3.connect(str(resolved), timeout=2.0)
         self._connection.execute("CREATE TABLE IF NOT EXISTS pointer (slot INTEGER PRIMARY KEY CHECK (slot = 1), generation INTEGER NOT NULL, snapshot_hash TEXT NOT NULL)")
         row = self._connection.execute("SELECT generation, snapshot_hash FROM pointer WHERE slot = 1").fetchone()
@@ -51,7 +52,8 @@ class SQLitePointerStore:
             raise ValidationFailure("pointer row missing")
         self.read_calls += 1
         generation, snapshot_hash = row
-        return PointerReceipt("read", generation, snapshot_hash, f"read:{generation}:{snapshot_hash[:12]}")
+        receipt_id = f"read:{generation}:{snapshot_hash[:12]}"
+        return _make_receipt(self, "read", generation, snapshot_hash, receipt_id)
 
     def compare_and_set(self, expected_generation: int, new_hash: str) -> PointerReceipt | None:
         if not isinstance(expected_generation, int) or not _valid_hash(new_hash):
@@ -67,10 +69,15 @@ class SQLitePointerStore:
             return None
         self._connection.commit()
         row = self._connection.execute("SELECT generation, snapshot_hash FROM pointer WHERE slot = 1").fetchone()
-        return PointerReceipt("cas", row[0], row[1], f"cas:{row[0]}:{row[1][:12]}")
+        receipt_id = f"cas:{row[0]}:{row[1][:12]}"
+        return _make_receipt(self, "cas", row[0], row[1], receipt_id)
 
     def close(self) -> None:
         self._connection.close()
+
+    def as_capability(self) -> PointerStoreCapability:
+        from practice_catalog_snapshot import issue_capability
+        return issue_capability(self)
 
     def rollback(self, expected_generation: int, prior_hash: str, authorization: str | None) -> dict[str, object]:
         before = self.read()

--- a/scripts/test_foundry_roots.py
+++ b/scripts/test_foundry_roots.py
@@ -349,7 +349,7 @@ def main() -> int:
     synthetic_snapshot = catalog.snapshot("synthetic-root-view", synthetic_manifest, synthetic_files)
     synthetic_store = catalog.PointerStore(synthetic_snapshot["manifest_sha256"])
     view_errors = check_foundry_roots.validate_injected_snapshot_fixture_view(
-        synthetic_store,
+        catalog.issue_capability(synthetic_store),
         {synthetic_snapshot["manifest_sha256"]: synthetic_snapshot},
         "SYN-001",
     )

--- a/scripts/test_practice_catalog_snapshot.py
+++ b/scripts/test_practice_catalog_snapshot.py
@@ -119,6 +119,54 @@ def main() -> int:
     multi_store = catalog.PointerStore(multi["manifest_sha256"])
     full = catalog.pinned_catalog_view(multi_store, {multi["manifest_sha256"]: multi})
     errors += expect("pinned-catalog-multiple", len(full["records"]) == 2 and multi_store.read_calls == 1)
+    try:
+        catalog.pinned_catalog_view(catalog.PointerStoreCapability.__new__(catalog.PointerStoreCapability), {multi["manifest_sha256"]: multi})  # type: ignore[arg-type]
+        errors.append("forged-capability: accepted")
+    except catalog.ValidationFailure:
+        errors += expect("forged-capability", True)
+    class ForgedBackend:
+        _capability_issuer = "sqlite_pointer_store_v1"
+
+        def read(self):
+            return None
+        def compare_and_set(self, expected_generation: int, new_hash: str):
+            return None
+    try:
+        catalog.issue_capability(ForgedBackend())
+        errors.append("forged-readable-backend: accepted")
+    except catalog.ValidationFailure:
+        errors += expect("forged-readable-backend", True)
+    class ForgedStore(catalog.PointerStore):
+        def read(self):
+            return catalog.PointerReceipt("read", 0, multi["manifest_sha256"], "forged")
+    try:
+        catalog.issue_capability(ForgedStore(multi["manifest_sha256"]))
+        errors.append("forged-subclass: accepted")
+    except catalog.ValidationFailure:
+        errors += expect("forged-subclass", True)
+    monkeypatched = catalog.PointerStore(multi["manifest_sha256"])
+    monkeypatched.read = lambda: catalog.PointerReceipt("read", 0, multi["manifest_sha256"], "forged-valid")  # type: ignore[method-assign]
+    try:
+        catalog.pinned_catalog_view(catalog.issue_capability(monkeypatched), {multi["manifest_sha256"]: multi})
+        errors.append("monkeypatched-receipt: accepted")
+    except catalog.ValidationFailure:
+        errors += expect("monkeypatched-receipt", True)
+    captured_store = catalog.PointerStore(multi["manifest_sha256"])
+    captured = captured_store.read()
+    captured_store.read = lambda: catalog.PointerReceipt("read", captured.generation, "c" * 64, captured.receipt_id, signature=captured.signature)  # type: ignore[method-assign]
+    try:
+        catalog.pinned_catalog_view(catalog.issue_capability(captured_store), {multi["manifest_sha256"]: multi})
+        errors.append("captured-receipt-rewrite: accepted")
+    except catalog.ValidationFailure:
+        errors += expect("captured-receipt-rewrite", True)
+    non_read_store = catalog.PointerStore(multi["manifest_sha256"])
+    non_read = non_read_store.compare_and_set(0, "d" * 64)
+    non_read_store.read = lambda: non_read  # type: ignore[method-assign]
+    try:
+        catalog.pinned_catalog_view(catalog.issue_capability(non_read_store), {multi["manifest_sha256"]: multi})
+        errors.append("signed-non-read-receipt: accepted")
+    except catalog.ValidationFailure:
+        errors += expect("signed-non-read-receipt", True)
     for label, mutate in [("duplicate-id", lambda f: f.update({"indexes/practice_index.yaml": f["indexes/practice_index.yaml"].replace("SYN-002", "SYN-001")})), ("tampered-entry", lambda f: f.update({"practices/synthetic/SYN-002.md": "---\nid: SYN-999\n---\nTampered.\n"}))]:
         altered = dict(multi_files)
         mutate(altered)

--- a/scripts/test_sqlite_pointer_store.py
+++ b/scripts/test_sqlite_pointer_store.py
@@ -10,6 +10,7 @@ sys_path = Path(__file__).resolve().parent
 import sys
 sys.path.insert(0, str(sys_path))
 from practice_catalog_snapshot import ValidationFailure
+import practice_catalog_snapshot as catalog
 from sqlite_pointer_store import SQLitePointerStore
 
 
@@ -39,6 +40,8 @@ def main() -> int:
                 expect("generic-temp-root-rejected", True, errors)
         one = SQLitePointerStore(db, first_hash, Path(temp))
         two = SQLitePointerStore(db, first_hash, Path(temp))
+        capability = one.as_capability()
+        expect("versioned-capability", capability.format == catalog.CAPABILITY_FORMAT and capability.version == 1 and capability.backend is one, errors)
         receipt = one.read()
         expect("read-receipt", receipt.operation == "read" and receipt.generation == 0 and receipt.snapshot_hash == first_hash, errors)
         committed = one.compare_and_set(receipt.generation, second_hash)


### PR DESCRIPTION
## Scope

Adds a versioned PointerStoreCapability and receipt validation boundary across the synthetic snapshot, SQLite adapter, and root fixture consumer.

- Exactly one validated operation=read receipt pins generation and snapshot_hash.
- SQLite exposes a caller-owned capability; synthetic snapshot content remains in memory only.
- Forged capability/receipt, non-read receipt, invalid generation/hash, missing snapshot, and fallback paths fail closed.
- Existing CLI/root behavior is unchanged.

## Verification

- python3 scripts/test_sqlite_pointer_store.py
- python3 scripts/test_practice_catalog_snapshot.py
- python3 scripts/test_foundry_roots.py
- python3 -m py_compile scripts/practice_catalog_snapshot.py scripts/sqlite_pointer_store.py scripts/check_foundry_roots.py scripts/test_practice_catalog_snapshot.py scripts/test_sqlite_pointer_store.py scripts/test_foundry_roots.py
- git diff --check

No snapshot persistence, Vault, candidate, network, runtime, or publication I/O.