### PR TITLE
AF18 #426-M L1: add synthetic catalog authority lifecycle

### DIFF
--- a/schemas/practice-catalog-authority.schema.yaml
+++ b/schemas/practice-catalog-authority.schema.yaml
@@ -1,0 +1,9 @@
+# Synthetic lifecycle authority readout contract.
+format: practice_catalog_authority_v1
+states: [working_tree_authority, snapshot_shadow, snapshot_authority, rollback_pending, held]
+rules:
+  - Default mode is working_tree_authority.
+  - Snapshot authority requires explicit opt-in and a trusted backend.
+  - Readouts expose hashes and generations only; never secrets or practice content.
+  - Snapshot authority requires a verified receipt, successful backup, no pending rollback, and read/status operations only.
+  - Snapshot hash and non-negative generation must match the trusted backend receipt.

--- a/scripts/foundry_config.py
+++ b/scripts/foundry_config.py
@@ -35,6 +35,7 @@ def config_text(repo_root: Path = ROOT, core_root: Path | None = None, vault_roo
     vault_root = (vault_root or repo_root).resolve()
     lines = [
         "schema_version: 1",
+        "authority_mode: working_tree_authority",
         f"repo_root: {quote(repo_root)}",
         f"core_root: {quote(core_root)}",
         f"vault_root: {quote(vault_root)}",
@@ -55,6 +56,7 @@ def config_text(repo_root: Path = ROOT, core_root: Path | None = None, vault_roo
 
 def parse_config(path: Path = CONFIG_PATH) -> dict[str, str | list[str]]:
     data: dict[str, str | list[str]] = {
+        "authority_mode": "working_tree_authority",
         "core_markers": [],
         "vault_markers": [],
         "canonical_markers": [],
@@ -85,6 +87,8 @@ def parse_config(path: Path = CONFIG_PATH) -> dict[str, str | list[str]]:
 def validate(path: Path = CONFIG_PATH) -> list[str]:
     errors: list[str] = []
     data = parse_config(path)
+    if data.get("authority_mode", "working_tree_authority") not in {"working_tree_authority", "snapshot_shadow", "snapshot_authority"}:
+        errors.append("invalid authority_mode")
     repo_root_text = str(data.get("repo_root", ""))
     core_root_text = str(data.get("core_root", ""))
     vault_root_text = str(data.get("vault_root", ""))

--- a/scripts/operation_context.py
+++ b/scripts/operation_context.py
@@ -11,6 +11,7 @@ from typing import Any
 from check_foundry_roots import validate
 from foundry_config import CONFIG_PATH, ROOT, parse_config
 from runtime_manifest import LOCAL_MANIFEST, parse_targets
+from practice_catalog_authority import WORKING_TREE, authority_readout
 
 
 DEFAULT_GENERATED_ROOT = Path.home() / ".agent-foundry" / "generated" / "agent-foundry-adapters"
@@ -225,11 +226,13 @@ def build_context(
     core_root: Path | None = None,
     vault_root: Path | None = None,
     adapter_root: Path | None = None,
+    authority_mode: str | None = None,
 ) -> dict[str, Any]:
     cwd = (cwd or Path.cwd()).expanduser().resolve()
     core_root = (core_root or ROOT).expanduser().resolve()
     vault_root = (vault_root or core_root).expanduser().resolve()
     adapter_root = (adapter_root or default_adapter_root(core_root, vault_root)).expanduser().resolve()
+    configured_authority = authority_mode or str(parse_config(CONFIG_PATH).get("authority_mode", WORKING_TREE))
     context = classify_context(cwd, core_root, vault_root, adapter_root)
     root_errors = validate(core_root, vault_root)
     routes = operation_routes(operation, context, cwd, core_root, vault_root, adapter_root)
@@ -256,6 +259,7 @@ def build_context(
         "core_root": str(core_root),
         "vault_root": str(vault_root),
         "adapter_root": str(adapter_root),
+        "authority": authority_readout(configured_authority),
         "manual_targets": manual_targets(),
         "allowed_reads": routes["allowed_reads"],
         "allowed_writes": routes["allowed_writes"],

--- a/scripts/practice_catalog_authority.py
+++ b/scripts/practice_catalog_authority.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Synthetic lifecycle authority readout; no Vault or backend I/O."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any
+
+WORKING_TREE = "working_tree_authority"
+SNAPSHOT_SHADOW = "snapshot_shadow"
+SNAPSHOT = "snapshot_authority"
+ROLLBACK = "rollback_pending"
+HELD = "held"
+
+
+@dataclass(frozen=True)
+class SyntheticAuthorityBackend:
+    version: str
+    generation: int
+    snapshot_hash: str
+    trusted: bool = True
+
+
+def _hash(value: object) -> str | None:
+    if not isinstance(value, str) or len(value) != 64 or any(c not in "0123456789abcdef" for c in value):
+        return None
+    return value
+
+
+def authority_readout(mode: str = WORKING_TREE, backend: object | None = None, *, vault_dirty: bool = False, marker_drift: bool = False, replica_drift: bool = False, migration: str = "none", backup: str = "not_required", rollback: str = "not_required", receipt: str = "verified", expected_snapshot_hash: str | None = None, operations: tuple[str, ...] = ("read",)) -> dict[str, Any]:
+    if mode == WORKING_TREE:
+        return {"mode": mode, "authority_id": "working-tree", "backend_version": "n/a", "generation": None, "content_hash": None, "replica_drift": False, "migration": migration, "holds": [], "backup_rollback": {"backup": backup, "rollback": rollback}, "operations": list(operations)}
+    holds: list[str] = []
+    if backend is None:
+        holds.append("held_backend_unavailable")
+    elif not isinstance(backend, SyntheticAuthorityBackend) or not backend.trusted or not backend.version or type(backend.generation) is not int or backend.generation < 0 or _hash(backend.snapshot_hash) is None:
+        holds.append("held_backend_untrusted")
+    if vault_dirty:
+        holds.append("dirty_vault")
+    if marker_drift:
+        holds.append("marker_path_hash_drift")
+    if replica_drift:
+        holds.append("replica_drift")
+    if backend is not None and expected_snapshot_hash is not None and backend.snapshot_hash != expected_snapshot_hash:
+        holds.append("snapshot_hash_mismatch")
+    if backend is not None and backup == "failed":
+        holds.append("backup_failed")
+    if backend is not None and rollback == "pending":
+        holds.append("rollback_pending")
+    if backend is not None and receipt != "verified":
+        holds.append("receipt_verification_failed")
+    if any(operation not in {"read", "status"} for operation in operations):
+        holds.append("write_operation_forbidden")
+    if migration not in {"none", "complete"}:
+        holds.append("legacy_or_partial_migration")
+    if mode == SNAPSHOT and not holds:
+        state = SNAPSHOT
+    elif mode == SNAPSHOT_SHADOW and not holds:
+        state = SNAPSHOT_SHADOW
+    else:
+        state = HELD
+    return {"mode": state, "authority_id": "snapshot" if backend else None, "backend_version": getattr(backend, "version", None), "generation": getattr(backend, "generation", None), "content_hash": getattr(backend, "snapshot_hash", None), "replica_drift": replica_drift, "migration": migration, "holds": holds, "backup_rollback": {"backup": backup, "rollback": rollback}, "operations": list(operations)}
+
+
+def synthetic_content_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()

--- a/scripts/test_operation_context.py
+++ b/scripts/test_operation_context.py
@@ -11,6 +11,7 @@ import tempfile
 from pathlib import Path
 
 import operation_context
+from practice_catalog_authority import HELD, WORKING_TREE
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -113,6 +114,11 @@ def write_locator(home: Path, core: Path, vault: Path) -> dict[str, str]:
 
 def main() -> int:
     errors: list[str] = []
+    default_authority = operation_context.build_context("status")["authority"]
+    if default_authority["mode"] != WORKING_TREE:
+        errors.append("default authority changed")
+    if operation_context.build_context("status", authority_mode="snapshot_authority")["authority"]["mode"] != HELD:
+        errors.append("snapshot opt-in did not hold unavailable backend")
     with tempfile.TemporaryDirectory(prefix="agent-foundry-operation-context-") as tmp:
         base = Path(tmp)
         vault = base / "vault"

--- a/scripts/test_practice_catalog_authority.py
+++ b/scripts/test_practice_catalog_authority.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from practice_catalog_authority import *
+
+
+def main() -> int:
+    errors: list[str] = []
+    def ok(name: str, condition: bool) -> None:
+        print(f"{name}: {'ok' if condition else 'FAIL'}")
+        if not condition: errors.append(name)
+    default = authority_readout()
+    ok("default-working-tree", default["mode"] == WORKING_TREE and default["holds"] == [])
+    held = authority_readout(SNAPSHOT)
+    ok("backend-unavailable-held", held["mode"] == HELD and held["holds"] == ["held_backend_unavailable"])
+    backend = SyntheticAuthorityBackend("sqlite-pointer-v1", 3, "a" * 64)
+    ready = authority_readout(SNAPSHOT, backend)
+    ok("trusted-snapshot", ready["mode"] == SNAPSHOT and ready["generation"] == 3 and "Synthetic" not in str(ready))
+    for name, kwargs, hold in [("dirty", {"vault_dirty": True}, "dirty_vault"), ("drift", {"marker_drift": True}, "marker_path_hash_drift"), ("replica", {"replica_drift": True}, "replica_drift"), ("migration", {"migration": "partial"}, "legacy_or_partial_migration")]:
+        result = authority_readout(SNAPSHOT, backend, **kwargs)
+        ok(name, result["mode"] == HELD and hold in result["holds"])
+    for name, kwargs, hold in [("missing-snapshot", {"expected_snapshot_hash": "b" * 64}, "snapshot_hash_mismatch"), ("backup-failure", {"backup": "failed"}, "backup_failed"), ("rollback-pending", {"rollback": "pending"}, "rollback_pending"), ("receipt-failure", {"receipt": "failed"}, "receipt_verification_failed"), ("write-operation", {"operations": ("write",)}, "write_operation_forbidden")]:
+        result = authority_readout(SNAPSHOT, backend, **kwargs)
+        ok(name, result["mode"] == HELD and hold in result["holds"])
+    for value in (-1, True, "1", None):
+        invalid_generation = authority_readout(SNAPSHOT, SyntheticAuthorityBackend("v", value, "a" * 64))
+        ok(f"invalid-generation-{value!r}", invalid_generation["mode"] == HELD and "held_backend_untrusted" in invalid_generation["holds"])
+    forged = authority_readout(SNAPSHOT, object())
+    ok("untrusted-held", forged["mode"] == HELD)
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Scope

Adds a versioned synthetic-only practice catalog authority lifecycle and explicit snapshot opt-in.

- Default working_tree_authority remains unchanged.
- Snapshot opt-in without a trusted backend returns held_backend_unavailable.
- Dirty Vault, marker/path/hash drift, untrusted backend, and partial migration hold fail closed.
- Privacy-safe readouts expose mode, authority ID, backend version, generation, hash, drift, migration, holds, backup/rollback, and operations; no practice content or secrets.
- No backend, Vault, migration, runtime, publication, or network I/O.

## Verification

- python3 scripts/test_practice_catalog_authority.py
- python3 scripts/test_operation_context.py
- python3 -m py_compile scripts/practice_catalog_authority.py scripts/foundry_config.py scripts/operation_context.py scripts/test_practice_catalog_authority.py scripts/test_operation_context.py
- git diff --check

Only the six requested files were modified.