### PR TITLE
AF18 #426-N L2-Q: reference backend conformance harness

### DIFF
--- a/schemas/practice-catalog-authority.schema.yaml
+++ b/schemas/practice-catalog-authority.schema.yaml
@@ -7,3 +7,6 @@ rules:
   - Readouts expose hashes and generations only; never secrets or practice content.
   - Snapshot authority requires a verified receipt, successful backup, no pending rollback, and read/status operations only.
   - Snapshot hash and non-negative generation must match the trusted backend receipt.
+  - Conformance results are reference-only and production_eligibility is always false.
+  - trust_domain is same_process_reference and receipt_binding_level is reference_integrity_only.
+  - Same-process arbitrary code/introspection is out of scope and adversarial forgery resistance is unsupported.

--- a/scripts/practice_catalog_backend_conformance.py
+++ b/scripts/practice_catalog_backend_conformance.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Synthetic backend-neutral conformance harness; never creates durable state."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import practice_catalog_snapshot as catalog
+from practice_catalog_snapshot import PointerStore, PointerStoreCapability, ValidationFailure, issue_capability
+from sqlite_pointer_store import SQLitePointerStore
+
+REQUIRED = ("read_receipt", "cas_success", "cas_conflict", "generation_monotonic")
+def _capability_service():
+    issued: list[PointerStoreCapability] = []
+    def register(capability: PointerStoreCapability) -> None:
+        issued.append(capability)
+    def is_issued(capability: PointerStoreCapability) -> bool:
+        return any(item is capability for item in issued)
+    return register, is_issued
+
+
+_register_capability, _is_issued = _capability_service()
+
+
+def _result(adapter_id: str, capability: str, executed: list[str], skipped: list[str], evidence: list[str], holds: list[str]) -> dict[str, Any]:
+    return {"adapter_id": adapter_id, "adapter_class": "reference", "capability": capability, "trust_domain": "same_process_reference", "receipt_binding_level": "reference_integrity_only", "same_process_arbitrary_code_or_introspection": "out_of_scope", "same_process_adversarial_forgery_resistance": "unsupported", "executed_test_ids": executed, "skipped_test_ids": skipped, "evidence_summary": evidence, "production_eligibility": False, "hold_reasons": holds, "privacy_safe": True}
+
+
+def _read(capability: PointerStoreCapability):
+    if not _is_issued(capability):
+        raise ValidationFailure("unissued capability")
+    backend = catalog._require_store(capability)
+    return catalog._validate_receipt(backend.read(), backend)
+
+
+def _cas(capability: PointerStoreCapability, generation: int, snapshot_hash: str):
+    if not _is_issued(capability):
+        raise ValidationFailure("unissued capability")
+    backend = catalog._require_store(capability)
+    receipt = backend.compare_and_set(generation, snapshot_hash)
+    if receipt is None:
+        return None
+    return catalog._validate_receipt(receipt, backend, "cas")
+
+
+def run_pointer_suite(adapter_id: str, backend: object) -> dict[str, Any]:
+    executed: list[str] = []
+    evidence: list[str] = []
+    try:
+        capability = issue_capability(backend)
+        _register_capability(capability)
+        first = _read(capability)
+        if first.operation != "read" or first.generation != 0:
+            raise ValidationFailure("read receipt mismatch")
+        executed.append("read_receipt")
+        new_hash = "b" * 64
+        committed = _cas(capability, 0, new_hash)
+        if committed is None or committed.generation != 1 or committed.snapshot_hash != new_hash:
+            raise ValidationFailure("CAS receipt mismatch")
+        executed.append("cas_success")
+        if _cas(capability, 0, "c" * 64) is not None:
+            raise ValidationFailure("CAS conflict accepted")
+        executed.append("cas_conflict")
+        reopened = _read(capability)
+        if reopened.generation != 1:
+            raise ValidationFailure("generation regression")
+        executed.append("generation_monotonic")
+        evidence.append("trusted capability and generation/hash receipts verified")
+        return _result(adapter_id, "supported", executed, [], evidence, [])
+    except (ValidationFailure, AttributeError, TypeError) as exc:
+        return _result(adapter_id, "unavailable", executed, [test for test in REQUIRED if test not in executed], evidence, [f"held_backend_unqualified:{exc}"])
+
+
+def run_reference_conformance() -> list[dict[str, Any]]:
+    in_memory = run_pointer_suite("synthetic-memory", PointerStore("a" * 64))
+    with tempfile.TemporaryDirectory(prefix="synthetic-pointer-") as temp:
+        sqlite = SQLitePointerStore(Path(temp) / "pointer.sqlite3", "a" * 64, temp)
+        try:
+            sqlite_result = run_pointer_suite("synthetic-sqlite", sqlite)
+        finally:
+            sqlite.close()
+    blob = _result("synthetic-blob", "unsupported", [], list(REQUIRED), ["SnapshotBlobStore capability not implemented"], ["held_backend_unqualified:blob_capability_unavailable"])
+    return [in_memory, sqlite_result, blob]
+
+
+def qualify_result(result: dict[str, Any]) -> dict[str, Any]:
+    """Return a defensive copy; qualification can never rewrite eligibility true."""
+    qualified = dict(result)
+    qualified["production_eligibility"] = False
+    qualified["trust_domain"] = "same_process_reference"
+    qualified["receipt_binding_level"] = "reference_integrity_only"
+    qualified["same_process_arbitrary_code_or_introspection"] = "out_of_scope"
+    qualified["same_process_adversarial_forgery_resistance"] = "unsupported"
+    if not set(REQUIRED).issubset(set(qualified.get("executed_test_ids", []))) and qualified.get("capability") == "supported":
+        qualified["capability"] = "unavailable"
+        qualified.setdefault("hold_reasons", []).append("held_required_test_missing")
+    return qualified

--- a/scripts/test_practice_catalog_backend_conformance.py
+++ b/scripts/test_practice_catalog_backend_conformance.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from practice_catalog_backend_conformance import qualify_result, run_pointer_suite, run_reference_conformance
+from practice_catalog_snapshot import PointerReceipt, PointerStoreCapability, ValidationFailure, issue_capability
+import practice_catalog_snapshot as catalog
+import practice_catalog_backend_conformance as harness
+from sqlite_pointer_store import SQLitePointerStore
+import tempfile
+from pathlib import Path
+
+def main() -> int:
+    results = run_reference_conformance()
+    errors = []
+    for result in results:
+        print(f"{result['adapter_id']}: {result['capability']}")
+        if result["production_eligibility"] or result["adapter_class"] != "reference" or not result["privacy_safe"]:
+            errors.append(result["adapter_id"])
+        if result["trust_domain"] != "same_process_reference" or result["receipt_binding_level"] != "reference_integrity_only" or result["same_process_adversarial_forgery_resistance"] != "unsupported":
+            errors.append(result["adapter_id"] + ":threat-model")
+        if result["adapter_id"] != "synthetic-blob" and result["capability"] != "supported":
+            errors.append(result["adapter_id"] + ":unsupported")
+        if result["adapter_id"] == "synthetic-blob" and result["capability"] != "unsupported":
+            errors.append("blob:claimed-supported")
+    forged = {"adapter_id": "forged", "adapter_class": "reference", "capability": "supported", "executed_test_ids": [], "production_eligibility": True}
+    rewritten = qualify_result(forged)
+    if rewritten["production_eligibility"] or rewritten["capability"] == "supported":
+        errors.append("qualification-rewrite")
+    class SelfAttesting:
+        _capability_issuer = "sqlite_pointer_store_v1"
+        def read(self): return None
+        def compare_and_set(self, generation, snapshot_hash): return None
+    try:
+        issue_capability(SelfAttesting())
+        errors.append("self-attestation-accepted")
+    except ValidationFailure:
+        pass
+    try:
+        PointerStoreCapability(object())
+        errors.append("forged-capability-accepted")
+    except ValidationFailure:
+        pass
+    with tempfile.TemporaryDirectory(prefix="synthetic-pointer-") as temp:
+        outside = Path(temp).parent / "escape.sqlite3"
+        try:
+            SQLitePointerStore(outside, "a" * 64, temp)
+            errors.append("temp-escape-accepted")
+        except ValidationFailure:
+            pass
+    missing = qualify_result({"adapter_id": "missing", "adapter_class": "reference", "capability": "supported", "executed_test_ids": []})
+    if missing["capability"] != "unavailable" or "held_required_test_missing" not in missing["hold_reasons"]:
+        errors.append("missing-required-test")
+    rewritten_backend = catalog.PointerStore("a" * 64)
+    original = rewritten_backend.read()
+    rewritten_backend.read = lambda: PointerReceipt("read", original.generation, "b" * 64, original.receipt_id, signature=original.signature)  # type: ignore[method-assign]
+    rewritten_result = run_pointer_suite("rewritten-receipt", rewritten_backend)
+    if rewritten_result["capability"] != "unavailable" or not any("held_backend_unqualified" in reason for reason in rewritten_result["hold_reasons"]):
+        errors.append("rewritten-receipt-not-held")
+    forged_capability = PointerStoreCapability.__new__(PointerStoreCapability)
+    object.__setattr__(forged_capability, "backend", catalog.PointerStore("a" * 64))
+    object.__setattr__(forged_capability, "format", "practice_catalog_capability_v1")
+    object.__setattr__(forged_capability, "version", 1)
+    try:
+        from practice_catalog_backend_conformance import _read
+        _read(forged_capability)
+        errors.append("forged-new-capability-accepted")
+    except ValidationFailure:
+        pass
+    real = issue_capability(catalog.PointerStore("a" * 64))
+    clone = PointerStoreCapability.__new__(PointerStoreCapability)
+    for field in ("backend", "format", "version", "_seal"):
+        object.__setattr__(clone, field, getattr(real, field))
+    registry = getattr(harness, "_ISSUED_CAPABILITIES", None)
+    if isinstance(registry, list):
+        registry.append(clone)
+    try:
+        harness._read(clone)
+        errors.append("forged-clone-registry-tamper-accepted")
+    except ValidationFailure:
+        pass
+    if errors:
+        print("errors:", errors)
+    return 1 if errors else 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a backend-neutral synthetic conformance harness for in-memory and disposable SQLite pointer adapters. Results are reference-only with production_eligibility=false, privacy-safe diagnostics, executed/skipped test IDs, and explicit unsupported SnapshotBlobStore capability. No durable, Vault, network, runtime, or publication I/O.