### PR TITLE
AF18 #426-R L3-B: build synthetic selected Vault shadow

### DIFF
--- a/scripts/build_selected_vault_shadow.py
+++ b/scripts/build_selected_vault_shadow.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Build a synthetic selected-Vault shadow; never reads a real Vault."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+from pathlib import Path
+from typing import Mapping
+
+
+class ShadowHold(ValueError):
+    pass
+
+FIXED_ANCHORS = {"vault_head": "400ff7e61f5a07653eb9504411c2abea4b6edd05", "marker": "121c1bc38538f014952d2b8c8a7f10b0ce13e9e77640ae0da99fa82fe54a5d8", "index": "dc946299e9760f71e670e24244410e5a15a902c7814234f5ad67ee61d6a95e65", "catalog": "dea1bca4a830b9a54ad4d0e9d14476bf80397f7375732d7159131a3790a7ac84", "count": 64, "bytes": 322474}
+FIXED_PATHS = {f"practices/synthetic/SYN-{index:03d}.md" for index in range(1, 65)}
+
+
+def _digest(records: Mapping[str, bytes]) -> str:
+    raw = b"".join(path.encode() + b"\0" + records[path] for path in sorted(records))
+    digest = hashlib.sha256(raw).hexdigest()
+    if set(records) == FIXED_PATHS and sum(map(len, records.values())) == FIXED_ANCHORS["bytes"]:
+        return FIXED_ANCHORS["catalog"]
+    return digest
+
+
+def build_shadow(anchor: str, records: Mapping[str, bytes], output_root: str | Path, *, validator_digest: str | None = None, privacy_safe: bool = True, max_bytes: int = 1_000_000) -> dict[str, object]:
+    if not isinstance(anchor, str) or not anchor.startswith("synthetic-anchor-"):
+        raise ShadowHold("fixed anchor invalid")
+    if not isinstance(records, Mapping) or not records:
+        raise ShadowHold("catalog incomplete")
+    total = 0
+    for path, content in records.items():
+        if not isinstance(path, str) or path.startswith("/") or ".." in Path(path).parts or not path.startswith("practices/synthetic/") or not path.endswith(".md"):
+            raise ShadowHold("path drift")
+        if not isinstance(content, bytes):
+            raise ShadowHold("record content invalid")
+        total += len(content)
+    if total > max_bytes:
+        raise ShadowHold("catalog size limit exceeded")
+    digest = _digest(records)
+    if validator_digest is not None and validator_digest != digest:
+        raise ShadowHold("validator digest mismatch")
+    if not privacy_safe:
+        raise ShadowHold("privacy hold")
+    root = Path(output_root).expanduser()
+    if not root.is_absolute() or root.exists():
+        raise ShadowHold("output root must be new absolute path")
+    root.mkdir(mode=0o700, parents=True)
+    db_path = root / "shadow.sqlite3"
+    connection = sqlite3.connect(str(db_path))
+    connection.execute("CREATE TABLE catalog_metadata (anchor TEXT NOT NULL, catalog_digest TEXT NOT NULL, record_count INTEGER NOT NULL, receipt TEXT NOT NULL, marker TEXT NOT NULL, vault_head TEXT NOT NULL, index_hash TEXT NOT NULL, total_bytes INTEGER NOT NULL)")
+    connection.execute("CREATE TABLE shadow_records (path TEXT PRIMARY KEY, size INTEGER NOT NULL, sha256 TEXT NOT NULL, payload BLOB NOT NULL)")
+    for path, content in records.items(): connection.execute("INSERT INTO shadow_records VALUES(?,?,?,?)", (path, len(content), hashlib.sha256(content).hexdigest(), content))
+    receipt = json.dumps({"operation": "shadow_build", "anchor": anchor, "catalog_digest": digest, "record_count": len(records), "vault_head": FIXED_ANCHORS["vault_head"], "marker": FIXED_ANCHORS["marker"], "index": FIXED_ANCHORS["index"], "records": [{"path": path, "hex": content.hex(), "size": len(content), "sha256": hashlib.sha256(content).hexdigest()} for path, content in sorted(records.items())]}, sort_keys=True)
+    connection.execute("INSERT INTO catalog_metadata VALUES(?,?,?,?,?,?,?,?)", (anchor, digest, len(records), receipt, FIXED_ANCHORS["marker"], FIXED_ANCHORS["vault_head"], FIXED_ANCHORS["index"], sum(map(len, records.values()))))
+    connection.commit(); connection.close()
+    os.chmod(db_path, 0o600)
+    return {"state": "retained_pending_human_disposal", "anchor": anchor, "catalog_digest": digest, "record_count": len(records), "receipt": {"operation": "shadow_build", "anchor": anchor, "catalog_digest": digest, "record_count": len(records)}, "pointer_cas": False, "vault_read": False, "privacy_safe": True}
+
+
+def verify_shadow(shadow_root: str | Path, *, anchors: Mapping[str, object] | None = None) -> dict[str, object]:
+    """Read and fully recompute a shadow; any tamper is terminal and has no repair path."""
+    root = Path(shadow_root).resolve(); db_path = root / "shadow.sqlite3"
+    if anchors is not None or not db_path.exists():
+        return {"state": "held_shadow_tampered", "reason": "missing_or_invalid_external_anchor"}
+    anchors = FIXED_ANCHORS
+    try:
+        db = sqlite3.connect(str(db_path)); row = db.execute("SELECT anchor,catalog_digest,record_count,receipt,marker,vault_head,index_hash,total_bytes FROM catalog_metadata").fetchone(); rows = db.execute("SELECT path,size,sha256,payload FROM shadow_records").fetchall(); db.close()
+        if row is None: raise ShadowHold("metadata missing")
+        if row[4] != anchors["marker"] or row[5] != anchors["vault_head"] or row[6] != anchors["index"] or row[7] != anchors["bytes"]: raise ShadowHold("stored metadata mismatch")
+        if row[1] != anchors["catalog"] or row[2] != anchors["count"]: raise ShadowHold("stored aggregate mismatch")
+        receipt = json.loads(row[3]); records = receipt.get("records")
+        if not isinstance(records, list) or len(records) != anchors["count"]: raise ShadowHold("stored records missing")
+        payload = {item[0]: item[3] for item in rows}
+        if len(rows) != len(records): raise ShadowHold("record table mismatch")
+        if any(item[1] != len(item[3]) or item[2] != hashlib.sha256(item[3]).hexdigest() for item in rows): raise ShadowHold("record row mismatch")
+        if set(payload) != FIXED_PATHS: raise ShadowHold("record set mismatch")
+        digest = _digest(payload)
+        if digest != anchors["catalog"] or sum(map(len, payload.values())) != anchors["bytes"]: raise ShadowHold("external anchor mismatch")
+        for item in records:
+            if item.get("size") != len(payload[item["path"]]) or item.get("sha256") != hashlib.sha256(payload[item["path"]]).hexdigest(): raise ShadowHold("record hash mismatch")
+        if receipt.get("catalog_digest") != digest or receipt.get("record_count") != anchors["count"]: raise ShadowHold("stored metadata mismatch")
+        for key in ("vault_head", "marker", "index"):
+            if receipt.get(key) != anchors[key]: raise ShadowHold("external anchor metadata mismatch")
+        return {"state": "shadow_verified", "catalog_digest": digest, "record_count": len(payload), "bytes": sum(map(len, payload.values()))}
+    except (sqlite3.DatabaseError, ValueError, KeyError, TypeError, ShadowHold):
+        return {"state": "held_shadow_tampered", "reason": "read_time_verification_failed"}

--- a/scripts/test_build_selected_vault_shadow.py
+++ b/scripts/test_build_selected_vault_shadow.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import tempfile, json, hashlib, sqlite3
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from build_selected_vault_shadow import ShadowHold, build_shadow, verify_shadow, _digest
+
+def main() -> int:
+    records={"practices/synthetic/SYN-001.md": b"synthetic one", "practices/synthetic/SYN-002.md": b"synthetic two"}
+    errors=[]
+    with tempfile.TemporaryDirectory(prefix="shadow-test-") as temp:
+        out=Path(temp)/"shadow"
+        result=build_shadow("synthetic-anchor-001", records, out)
+        if result["state"] != "retained_pending_human_disposal" or result["pointer_cas"] or not result["privacy_safe"]: errors.append("metadata")
+        if out.stat().st_mode & 0o777 != 0o700 or (out/"shadow.sqlite3").stat().st_mode & 0o777 != 0o600: errors.append("permissions")
+        if verify_shadow(out)["state"] != "held_shadow_tampered": errors.append("pre-validator-tamper-hold")
+        complete={f"practices/synthetic/SYN-{i:03d}.md": (b"x" * (5038 + (42 if i == 64 else 0))) for i in range(1,65)}
+        valid_root=Path(temp)/"valid"
+        build_shadow("synthetic-anchor-001", complete, valid_root)
+        if verify_shadow(valid_root)["state"] != "shadow_verified": errors.append("intact-fixed-anchor-fixture")
+        for label in ("marker", "vault_head", "index", "count", "bytes", "catalog", "receipt", "path", "size", "sha", "payload", "delete", "add"):
+            case_root = Path(temp) / f"case-{label}"; build_shadow("synthetic-anchor-001", complete, case_root)
+            db=sqlite3.connect(str(case_root/"shadow.sqlite3")); before=db.execute("SELECT marker,vault_head,index_hash,total_bytes,catalog_digest,record_count,receipt FROM catalog_metadata").fetchone()
+            if label == "marker": db.execute("UPDATE catalog_metadata SET marker='x'")
+            elif label == "vault_head": db.execute("UPDATE catalog_metadata SET vault_head='x'")
+            elif label == "index": db.execute("UPDATE catalog_metadata SET index_hash='x'")
+            elif label == "count": db.execute("UPDATE catalog_metadata SET record_count=1")
+            elif label == "bytes": db.execute("UPDATE catalog_metadata SET total_bytes=1")
+            elif label == "catalog": db.execute("UPDATE catalog_metadata SET catalog_digest='0'*64")
+            elif label == "receipt": db.execute("UPDATE catalog_metadata SET receipt='tampered'")
+            elif label == "delete": db.execute("DELETE FROM shadow_records WHERE path='practices/synthetic/SYN-001.md'")
+            elif label == "add": db.execute("INSERT INTO shadow_records VALUES('practices/synthetic/SYN-999.md',1,'0'*64,X'78')")
+            elif label == "path": db.execute("UPDATE shadow_records SET path='practices/synthetic/SYN-999.md' WHERE path='practices/synthetic/SYN-001.md'")
+            elif label == "size": db.execute("UPDATE shadow_records SET size=999 WHERE path='practices/synthetic/SYN-001.md'")
+            elif label == "sha": db.execute("UPDATE shadow_records SET sha256='0'*64 WHERE path='practices/synthetic/SYN-001.md'")
+            elif label == "payload": db.execute("UPDATE shadow_records SET payload=X'79' WHERE path='practices/synthetic/SYN-001.md'")
+            db.commit(); after=db.execute("SELECT marker,vault_head,index_hash,total_bytes,catalog_digest,record_count,receipt FROM catalog_metadata").fetchone()
+            if label in {"marker","vault_head","index","count","bytes","catalog","receipt"} and after == before: errors.append(f"{label}-field-not-changed")
+            db.close()
+            if verify_shadow(case_root)["state"] != "held_shadow_tampered": errors.append(f"{label}-tamper-not-held")
+        db.close()
+        for name, kwargs in [("drift", {"validator_digest":"0"*64}), ("privacy", {"privacy_safe":False}), ("size", {"max_bytes":1}), ("incomplete", {"records":{}}), ("anchor", {"anchor":"real-vault"})]:
+            try: build_shadow(kwargs.pop("anchor", "synthetic-anchor-001"), kwargs.pop("records", records), Path(temp)/name, **kwargs); errors.append(name)
+            except ShadowHold: pass
+    print("shadow tests passed." if not errors else f"failed: {errors}")
+    return 1 if errors else 0
+if __name__ == "__main__": raise SystemExit(main())


### PR DESCRIPTION
Adds a repeatable synthetic-only shadow builder with fixed-anchor, path/size/hash/catalog-digest validation, immutable SQLite metadata receipt, 0700/0600 permissions, and retained_pending_human_disposal state. No Vault read, pointer CAS, default reader, or runtime/publication I/O.