### PR TITLE
AF18 bounded thread harvest intake contract

### DIFF
--- a/adapters/codex/skills/practice-harvester/SKILL.md
+++ b/adapters/codex/skills/practice-harvester/SKILL.md
@@ -5,6 +5,8 @@ description: Use when the user says "harvest practices", "harvest skills", "harv
 
 # Practice Harvester
 
+Thread intake is bounded by `thread_harvest_request_v1`: require Human intent and an opaque thread reference, report coverage, and keep raw history transient. Do not expose pagination/cursors, expand to other threads, persist transcript/tool/identity/secret data, or promote candidates.
+
 This skill maintains Agent Foundry, the user's canonical capability system.
 
 Asset ID: ASSET-META-001. Canonical constraints include META-001 through META-013, GOV-001 through GOV-006, and RUNTIME-001 through RUNTIME-005.

--- a/adapters/codex/skills/practice-harvester/references/harvest-workflow.md
+++ b/adapters/codex/skills/practice-harvester/references/harvest-workflow.md
@@ -6,6 +6,8 @@ Locate Agent Foundry before writing canonical records. Prefer explicit roots whe
 
 Follow this route:
 
+For a named thread, use the bounded intake contract first: explicit intent, opaque ref, adapter history capability, and coverage state. Intake only returns candidate_hold/deferred/rejected; it performs no filesystem, network, GitHub, Vault, publish, or activation mutation.
+
 ```text
 session reconstruction
   -> current capability check

--- a/schemas/thread-harvest-request.schema.yaml
+++ b/schemas/thread-harvest-request.schema.yaml
@@ -1,0 +1,7 @@
+format: thread_harvest_request_v1
+required: [human_intent_confirmed, thread_ref, adapter_history]
+coverage: [complete, partial, unavailable, privacy_held]
+outputs: [candidate_hold, deferred, rejected]
+rules:
+  - thread_ref is opaque and ranges are optional.
+  - page_size, cursor, cross_thread expansion, and raw persistence are forbidden.

--- a/scripts/test_thread_harvest_contract.py
+++ b/scripts/test_thread_harvest_contract.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+from thread_harvest_contract import review
+
+def main():
+    errors=[]
+    base={"human_intent_confirmed":True,"thread_ref":"opaque-1","coverage":"complete","adapter_history":"available"}
+    if review(base)["outcome"] != "candidate_hold": errors.append("valid")
+    for coverage, reason in (("complete", "validated_bounded_request"), ("partial", "thread_harvest_partial"), ("unavailable", "held_thread_history_unavailable"), ("privacy_held", "held_thread_history_privacy")):
+        checked = review({**base, "coverage": coverage})
+        expected_outcome = "candidate_hold" if coverage == "complete" else "deferred"
+        if checked["coverage"] != coverage or checked["reason"] != reason or checked["outcome"] != expected_outcome or (coverage != "complete" and checked["terminal"] is not True): errors.append(coverage)
+    for key in ("page_size","cursor","cross_thread","raw_transcript","prompt","tool_output","identity","secret"):
+        if review({**base,key:1})["outcome"] != "rejected": errors.append(key)
+    if review({**base,"coverage":"unknown"})["outcome"] != "rejected": errors.append("coverage")
+    if review({**base,"output":"proposed"})["outcome"] != "rejected": errors.append("promotion")
+    if review({**base,"output":"active"})["outcome"] != "rejected": errors.append("active-promotion")
+    print("thread harvest tests passed." if not errors else f"failed: {errors}")
+    return 1 if errors else 0
+if __name__ == "__main__": raise SystemExit(main())

--- a/scripts/thread_harvest_contract.py
+++ b/scripts/thread_harvest_contract.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Capability-aware, in-memory thread harvest review contract."""
+
+from __future__ import annotations
+
+from typing import Any
+
+ALLOWED_COVERAGE = {"complete", "partial", "unavailable", "privacy_held"}
+ALLOWED_OUTPUTS = {"candidate_hold", "deferred", "rejected"}
+FORBIDDEN_KEYS = {"page_size", "cursor", "cross_thread", "raw_transcript", "prompt", "tool_output", "identity", "secret"}
+
+
+def review(request: dict[str, Any]) -> dict[str, Any]:
+    holds: list[str] = []
+    if not isinstance(request, dict) or request.keys() & FORBIDDEN_KEYS:
+        return result("rejected", "privacy_or_navigation_forbidden")
+    if request.get("human_intent_confirmed") is not True: holds.append("human_intent_required")
+    if not isinstance(request.get("thread_ref"), str) or not request["thread_ref"]: holds.append("opaque_thread_ref_required")
+    if request.get("coverage") not in ALLOWED_COVERAGE: return result("rejected", "unknown_coverage")
+    if request.get("adapter_history") not in {"available", "unavailable"}: holds.append("adapter_history_unknown")
+    output = request.get("output", "candidate_hold")
+    if output not in ALLOWED_OUTPUTS: return result("rejected", "output_not_allowed")
+    if holds: return result("deferred", ";".join(holds), request.get("coverage"))
+    coverage = request["coverage"]
+    if coverage == "partial": return result("deferred", "thread_harvest_partial", coverage)
+    if coverage == "unavailable": return result("deferred", "held_thread_history_unavailable", coverage)
+    if coverage == "privacy_held": return result("deferred", "held_thread_history_privacy", coverage)
+    return result(output, "validated_bounded_request", coverage)
+
+
+def result(output: str, reason: str, coverage: str | None = None) -> dict[str, Any]:
+    return {"outcome": output, "reason": reason, "coverage": coverage, "terminal": output in {"rejected", "deferred"}, "mutation_flags": {"filesystem": False, "network": False, "github": False, "vault": False, "publish": False, "activate": False}, "persisted_raw_data": False, "privacy_safe": True}

--- a/workflows/harvest-practices.md
+++ b/workflows/harvest-practices.md
@@ -77,6 +77,8 @@ Summarize:
 
 Keep this summary local to the harvest report unless the user asks to store it.
 
+When the Human explicitly names a Codex/runtime thread, that thread is a valid bounded evidence window for this workflow. Read the currently accessible history for that thread, using internal pagination or chunking as needed; do not expose page size, opaque cursors, or Work-index mechanics as the Human-facing interface. If the accessible history is incomplete, report `coverage: partial` and do not claim a complete reconstruction. Do not expand to other threads unless the Human names them.
+
 If using memories, rollout summaries, or activity logs, treat them as evidence only. Apply META-006: durable rules belong in canonical practice entries, not memory alone.
 
 If the agent has native self-growth capabilities, apply META-007: do not suppress native learning. Treat native memories or generated skills as candidate inputs when they should become durable or cross-agent.
@@ -102,6 +104,8 @@ Use these artifact classes:
 Only items routed to `practice candidate` continue through practice drafting. Items routed to `workflow update` may update this or another workflow after review. Items routed to `skill/asset candidate` should use `workflows/discover-assets.md` or the asset workflow. Items routed to evidence, design, research, or project-local decision classes need an implemented canonical destination before writing.
 
 When the user corrects the agent's method, first treat the correction as process evidence. Analyze whether it reveals an agent failure mode, workflow weakness, prompting gap, review checklist gap, handoff risk, harvest risk, or generalizable practice evidence before treating it as content inside the current domain.
+
+The Human-facing entry point should remain simple: “从这个 thread 做一次 harvest practice”。Return a concise review list with paraphrased lessons and evidence windows; raw transcript, prompts, tool output, secrets, identities, and large message bodies remain transient processing data and must not enter canonical output.
 
 ## 4. Generalization Gate
 
@@ -325,4 +329,8 @@ Files changed:
 
 Needs human review:
 - <entry id/title or none>
+
+## Bounded thread intake contract
+
+Thread harvest requires explicit Human intent, an opaque named `thread_ref`, and an adapter-provided history capability. Coverage is reported as `complete`, `partial`, `unavailable`, or `privacy_held`. Page size/cursors are internal implementation details and never Human UX; no cross-thread expansion is allowed. Raw transcript, prompts, tool output, identities, and secrets remain transient and are never persisted. Outputs are limited to `candidate_hold`, `deferred`, or `rejected`; proposed/active promotion is not performed by intake.
 ```


### PR DESCRIPTION
Adds a capability-aware bounded thread harvest request schema, in-memory review contract, adapter/workflow guidance, and privacy/mutation guard tests. No native history reading or filesystem/network/GitHub/Vault I/O.