### PR TITLE
AF18: bound Codex thread harvest intake capability

### DIFF
--- a/adapters/codex/skills/practice-harvester/SKILL.md
+++ b/adapters/codex/skills/practice-harvester/SKILL.md
@@ -5,6 +5,10 @@ description: Use when the user says "harvest practices", "harvest skills", "harv
 
 # Practice Harvester
 
+## Current Codex thread intake capability
+
+For a Human-named thread, use the supported wrapper capability `list_threads(query=<Human name>)` followed by `read_thread(includeOutputs=false)`. Resolve exactly one result: no match is `unavailable`, ambiguity is `privacy_held`, and cross-thread expansion is forbidden. Internal cursors are not Human UX: use `turnLimit=20`, at most 5 pages/100 summaries. Report `content_fidelity=native_turn_summary`; `complete` requires the lower bound or exhausted older cursor, otherwise `partial`. Raw transcript, prompts, tool output, identities, secrets, native IDs, and cursors are transient and never persisted.
+
 Thread intake is bounded by `thread_harvest_request_v1`: require Human intent and an opaque thread reference, report coverage, and keep raw history transient. Do not expose pagination/cursors, expand to other threads, persist transcript/tool/identity/secret data, or promote candidates.
 
 This skill maintains Agent Foundry, the user's canonical capability system.

--- a/adapters/codex/skills/practice-harvester/references/harvest-workflow.md
+++ b/adapters/codex/skills/practice-harvester/references/harvest-workflow.md
@@ -6,6 +6,8 @@ Locate Agent Foundry before writing canonical records. Prefer explicit roots whe
 
 Follow this route:
 
+Codex adapter intake is bounded to `list_threads(query=<Human name>)` then `read_thread(includeOutputs=false)`. Unique resolution is required; ambiguity is `privacy_held`, no-match or unsupported/error is `unavailable`. Use internal-only cursor bounds (`turnLimit=20`, max 5 pages/100 summaries); report `complete` only when the lower bound or older cursor is exhausted, else `partial`. Never expand cross-thread or persist raw/native IDs.
+
 For a named thread, use the bounded intake contract first: explicit intent, opaque ref, adapter history capability, and coverage state. Intake only returns candidate_hold/deferred/rejected; it performs no filesystem, network, GitHub, Vault, publish, or activation mutation.
 
 ```text

--- a/scripts/test_thread_harvest_contract.py
+++ b/scripts/test_thread_harvest_contract.py
@@ -14,6 +14,14 @@ def main():
     if review({**base,"coverage":"unknown"})["outcome"] != "rejected": errors.append("coverage")
     if review({**base,"output":"proposed"})["outcome"] != "rejected": errors.append("promotion")
     if review({**base,"output":"active"})["outcome"] != "rejected": errors.append("active-promotion")
+    def mock_wrapper(matches, pages=1, older_exhausted=True, include_outputs=False):
+        if include_outputs: return "unavailable"
+        if len(matches) != 1: return "privacy_held" if len(matches) > 1 else "unavailable"
+        return "complete" if older_exhausted and pages <= 5 else "partial"
+    if mock_wrapper(["thread"], include_outputs=False) != "complete": errors.append("unique-complete")
+    if mock_wrapper([]) != "unavailable" or mock_wrapper(["a", "b"]) != "privacy_held": errors.append("resolution")
+    if mock_wrapper(["thread"], pages=6) != "partial" or mock_wrapper(["thread"], older_exhausted=False) != "partial": errors.append("coverage-bounds")
+    if mock_wrapper(["thread"], include_outputs=True) != "unavailable": errors.append("includeOutputs")
     print("thread harvest tests passed." if not errors else f"failed: {errors}")
     return 1 if errors else 0
 if __name__ == "__main__": raise SystemExit(main())


### PR DESCRIPTION
## Scope
- Document the supported Human-named Codex thread wrapper intake and bounded resolution.
- Specify native-turn-summary fidelity, internal cursor/page bounds, and complete/partial/unavailable/privacy_held outcomes.
- Extend the existing contract test with mocked resolution, includeOutputs=false, and coverage-bound checks.

## Constraints
- Exactly three allowlisted files changed.
- No Core schema/script, runtime, Vault, native history, cross-thread expansion, or raw/native identifier persistence changes.

## Verification
- `python3 scripts/test_thread_harvest_contract.py`
- `python3 -m py_compile scripts/test_thread_harvest_contract.py`
- `git diff --check`