### PR TITLE
AF18: add durable Work terminal learning-signal handoff

### DIFF
--- a/schemas/af18-control-plane.schema.yaml
+++ b/schemas/af18-control-plane.schema.yaml
@@ -522,6 +522,65 @@ properties:
             const: 12
           ready:
             type: boolean
+  work_terminal_learning_signal_handoff:
+    title: WorkTerminalLearningSignalHandoff v1
+    type: object
+    additionalProperties: false
+    required:
+      - handoff_version
+      - work_id
+      - run_id
+      - issue_url_anchor
+      - payload_hash
+      - retention
+      - visibility
+      - candidate
+      - learning_signal
+    properties:
+      handoff_version:
+        const: WorkTerminalLearningSignalHandoff-v1
+      work_id:
+        type: string
+        minLength: 1
+      run_id:
+        type: string
+        minLength: 1
+      issue_url_anchor:
+        type: string
+        pattern: '^https://github\\.com/[^/]+/[^/]+/issues/[1-9][0-9]*$'
+      payload_hash:
+        type: string
+        minLength: 1
+      retention:
+        const: issue_comment_until_disposed
+      visibility:
+        const: issue_comment_metadata_only
+      candidate:
+        anyOf:
+          - type: 'null'
+          - type: object
+            additionalProperties: false
+            required: [disposition]
+            properties:
+              disposition:
+                const: candidate_hold
+              summary:
+                type: string
+                minLength: 1
+      learning_signal:
+        const: none
+      disposition_receipts:
+        type: array
+        items:
+          type: object
+          additionalProperties: false
+          required: [disposition, receipt_hash]
+          properties:
+            disposition:
+              enum: [retrieved_for_review, dismissed, superseded, disposed]
+            receipt_hash:
+              type: string
+              minLength: 1
   incident:
     type: object
     additionalProperties: false

--- a/scripts/github_collaboration_helper.py
+++ b/scripts/github_collaboration_helper.py
@@ -134,6 +134,8 @@ LOCAL_LEDGER_EVENT_TYPES = {
 CAPABILITY_LAYER_VALUES = {"base", "local_orchestration", "mixed"}
 LOCAL_LEDGER_CONFIDENCE_VALUES = {"observed", "inferred", "unknown", "not_available"}
 LOCAL_LEDGER_DEFAULT_ROOT = Path("usage") / "local" / "collaboration-ledger"
+WORK_TERMINAL_MARKER = "<!-- AF18 WorkTerminalLearningSignalHandoff-v1 -->"
+WORK_TERMINAL_DISPOSITIONS = {"retrieved_for_review", "dismissed", "superseded", "disposed"}
 
 
 def fail(code: str, detail: str, exit_code: int = 2) -> None:
@@ -1019,6 +1021,89 @@ def comments_for_item(item: dict[str, Any]) -> list[dict[str, Any]]:
     if not isinstance(comments, list):
         return []
     return [comment for comment in comments if isinstance(comment, dict)]
+
+
+def _handoff_key(handoff: dict[str, Any]) -> tuple[str, str, str]:
+    return (str(handoff.get("work_id", "")), str(handoff.get("run_id", "")), str(handoff.get("issue_url_anchor", "")))
+
+
+def work_terminal_comment_body(handoff: dict[str, Any]) -> str:
+    """Serialize only the approved metadata envelope for an issue comment."""
+    safe = {key: handoff[key] for key in ("handoff_version", "work_id", "run_id", "issue_url_anchor", "payload_hash", "retention", "visibility", "candidate", "learning_signal", "disposition_receipts") if key in handoff}
+    return WORK_TERMINAL_MARKER + "\n```json\n" + json.dumps(safe, sort_keys=True, separators=(",", ":")) + "\n```"
+
+
+def parse_work_terminal_comments(comments: list[dict[str, Any]], issue_url_anchor: str) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for comment in comments:
+        body = str(comment.get("body") or "") if isinstance(comment, dict) else ""
+        if WORK_TERMINAL_MARKER not in body:
+            continue
+        match = re.search(r"```json\s*(\{.*?\})\s*```", body, re.DOTALL)
+        if not match:
+            continue
+        try:
+            record = json.loads(match.group(1))
+        except json.JSONDecodeError:
+            continue
+        if isinstance(record, dict) and record.get("issue_url_anchor") == issue_url_anchor:
+            records.append(record)
+    return records
+
+
+def reconstruct_work_terminal_state(comments: list[dict[str, Any]], issue_url_anchor: str) -> dict[str, Any]:
+    records = parse_work_terminal_comments(comments, issue_url_anchor)
+    if not records:
+        return {"status": "unavailable", "handoff": None, "dispositions": []}
+    latest = records[-1]
+    if latest.get("learning_signal") != "none" or latest.get("visibility") != "issue_comment_metadata_only":
+        return {"status": "held_privacy_or_invalid", "handoff": None, "dispositions": []}
+    dispositions = [r for record in records for r in record.get("disposition_receipts", []) if isinstance(r, dict) and r.get("disposition") in WORK_TERMINAL_DISPOSITIONS]
+    return {"status": "complete", "handoff": latest, "dispositions": dispositions}
+
+
+def write_work_terminal_handoff(adapter: Any, handoff: dict[str, Any], max_retries: int = 1) -> dict[str, Any]:
+    """Write/readback/dedupe through an injected comment adapter only."""
+    key = _handoff_key(handoff)
+    comments = adapter.list_comments(handoff["issue_url_anchor"])
+    existing = parse_work_terminal_comments(comments, handoff["issue_url_anchor"])
+    for record in existing:
+        if _handoff_key(record) == key:
+            if record.get("payload_hash") == handoff.get("payload_hash"):
+                return {"status": "already_recorded", "handoff": record, "attempts": 0}
+            return {"status": "held_handoff_conflict", "handoff": record, "attempts": 0}
+    attempts = 0
+    while attempts <= max_retries:
+        attempts += 1
+        try:
+            adapter.add_comment(handoff["issue_url_anchor"], work_terminal_comment_body(handoff))
+        except Exception:
+            readback = parse_work_terminal_comments(adapter.list_comments(handoff["issue_url_anchor"]), handoff["issue_url_anchor"])
+            if any(_handoff_key(r) == key and r.get("payload_hash") == handoff.get("payload_hash") for r in readback):
+                return {"status": "already_recorded", "handoff": readback[-1], "attempts": attempts}
+            if attempts > max_retries:
+                return {"status": "held_write_outcome_unknown", "handoff": None, "attempts": attempts}
+            continue
+        readback = parse_work_terminal_comments(adapter.list_comments(handoff["issue_url_anchor"]), handoff["issue_url_anchor"])
+        if any(_handoff_key(r) == key and r.get("payload_hash") == handoff.get("payload_hash") for r in readback):
+            return {"status": "recorded", "handoff": readback[-1], "attempts": attempts}
+        if attempts > max_retries:
+            return {"status": "held_write_outcome_unknown", "handoff": None, "attempts": attempts}
+    return {"status": "held_write_outcome_unknown", "handoff": None, "attempts": attempts}
+
+
+def append_work_terminal_disposition(adapter: Any, handoff: dict[str, Any], disposition: str, receipt_hash: str) -> dict[str, Any]:
+    if disposition not in WORK_TERMINAL_DISPOSITIONS:
+        return {"status": "held_invalid_disposition"}
+    receipt = {"disposition": disposition, "receipt_hash": receipt_hash}
+    updated = dict(handoff)
+    updated["disposition_receipts"] = [receipt]
+    try:
+        adapter.add_comment(handoff["issue_url_anchor"], work_terminal_comment_body(updated))
+    except Exception:
+        return {"status": "held_write_outcome_unknown"}
+    state = reconstruct_work_terminal_state(adapter.list_comments(handoff["issue_url_anchor"]), handoff["issue_url_anchor"])
+    return {"status": "recorded" if state["dispositions"] else "held_write_outcome_unknown", "state": state}
 
 
 def needs_owner_from_labels(labels: list[str]) -> str | None:

--- a/scripts/plan_af18_mvp1_control.py
+++ b/scripts/plan_af18_mvp1_control.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -16,6 +17,7 @@ import plan_collaboration_routes as cost_policy
 POLICY_SOURCE = "scripts/plan_collaboration_routes.py"
 POLICY_VERSION = "af18-cost-policy-440-442"
 CONTROL_VERSION = "af18-mvp1-control-plane-v1"
+WORK_TERMINAL_HANDOFF_VERSION = "WorkTerminalLearningSignalHandoff-v1"
 ROLE_LIFECYCLE_VERSION = "af18-role-lifecycle-v1"
 NORMAL_WORK_RESOURCES = {
     "profile": "normal",
@@ -77,6 +79,87 @@ FORBIDDEN_PACKET_KEYS = {
     "full_history",
     "transcript",
 }
+
+HANDOFF_FORBIDDEN_KEYS = {
+    "thread_id", "native_thread_id", "transcript", "raw_transcript", "prompt",
+    "tool_output", "raw_tool_output", "model_output", "identity", "secret",
+    "native_id", "cursor",
+}
+
+
+def validate_work_terminal_handoff(handoff: Any) -> dict[str, Any]:
+    """Validate the metadata-only terminal handoff without doing any I/O."""
+    stops: list[str] = []
+    if not isinstance(handoff, dict):
+        return {"valid": False, "stop_conditions": ["missing_work_terminal_handoff"]}
+    forbidden = find_forbidden(handoff)
+    forbidden.extend(f"$.{key}" for key in HANDOFF_FORBIDDEN_KEYS if key in handoff)
+    if forbidden:
+        stops.append("privacy_exposure")
+    required = ("handoff_version", "work_id", "run_id", "issue_url_anchor", "payload_hash", "retention", "visibility")
+    for field in required:
+        if missing(handoff.get(field)):
+            stops.append(f"missing_handoff_{field}")
+    if handoff.get("handoff_version") != WORK_TERMINAL_HANDOFF_VERSION:
+        stops.append("unsupported_handoff_version")
+    if not isinstance(handoff.get("issue_url_anchor"), str) or not re.match(r"^https://github\.com/[^/]+/[^/]+/issues/[1-9][0-9]*$", str(handoff.get("issue_url_anchor", ""))):
+        stops.append("invalid_issue_url_anchor")
+    if handoff.get("visibility") != "issue_comment_metadata_only":
+        stops.append("visibility_mismatch")
+    candidate = handoff.get("candidate")
+    learning_signal = handoff.get("learning_signal", "none")
+    if candidate is not None:
+        if not isinstance(candidate, dict) or candidate.get("disposition") != "candidate_hold":
+            stops.append("candidate_must_be_candidate_hold")
+    if learning_signal != "none":
+        stops.append("learning_signal_must_be_none")
+    if candidate is not None and learning_signal != "none":
+        stops.append("multiple_learning_payloads")
+    return {"valid": not stops, "stop_conditions": sorted(set(stops)), "privacy_safe": not forbidden}
+
+
+def build_work_terminal_handoff(
+    work_id: str,
+    run_id: str,
+    issue_url_anchor: str,
+    payload_hash: str,
+    candidate: dict[str, Any] | None = None,
+    retention: str = "issue_comment_until_disposed",
+) -> dict[str, Any]:
+    handoff = {
+        "handoff_version": WORK_TERMINAL_HANDOFF_VERSION,
+        "work_id": work_id,
+        "run_id": run_id,
+        "issue_url_anchor": issue_url_anchor,
+        "payload_hash": payload_hash,
+        "retention": retention,
+        "visibility": "issue_comment_metadata_only",
+        "candidate": candidate,
+        "learning_signal": "none",
+        "disposition_receipts": [],
+    }
+    result = validate_work_terminal_handoff(handoff)
+    if not result["valid"]:
+        raise ValueError("invalid WorkTerminalLearningSignalHandoff: " + ",".join(result["stop_conditions"]))
+    return handoff
+
+
+def reconstruct_work_terminal_handoff(comments: list[dict[str, Any]], issue_url_anchor: str) -> dict[str, Any]:
+    """Rebuild the latest handoff and append-only logical dispositions from comments."""
+    records = [c.get("work_terminal_handoff") for c in comments if isinstance(c, dict) and isinstance(c.get("work_terminal_handoff"), dict)]
+    records = [r for r in records if r.get("issue_url_anchor") == issue_url_anchor]
+    if not records:
+        return {"status": "unavailable", "handoff": None, "dispositions": []}
+    latest = records[-1]
+    validation = validate_work_terminal_handoff(latest)
+    if not validation["valid"]:
+        return {"status": "held_privacy_or_invalid", "handoff": None, "dispositions": []}
+    dispositions: list[dict[str, Any]] = []
+    for record in records:
+        for receipt in record.get("disposition_receipts", []):
+            if isinstance(receipt, dict) and receipt.get("disposition") in {"retrieved_for_review", "dismissed", "superseded", "disposed"}:
+                dispositions.append(receipt)
+    return {"status": "complete", "handoff": latest, "dispositions": dispositions}
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/plan_af18_mvp1_control.py
+++ b/scripts/plan_af18_mvp1_control.py
@@ -102,7 +102,7 @@ def validate_work_terminal_handoff(handoff: Any) -> dict[str, Any]:
             stops.append(f"missing_handoff_{field}")
     if handoff.get("handoff_version") != WORK_TERMINAL_HANDOFF_VERSION:
         stops.append("unsupported_handoff_version")
-    if not isinstance(handoff.get("issue_url_anchor"), str) or not re.match(r"^https://github\.com/[^/]+/[^/]+/issues/[1-9][0-9]*$", str(handoff.get("issue_url_anchor", ""))):
+    if not isinstance(handoff.get("issue_url_anchor"), str) or re.fullmatch(r"https://github\.com/[^/]+/[^/]+/issues/[1-9][0-9]*", str(handoff.get("issue_url_anchor", ""))) is None:
         stops.append("invalid_issue_url_anchor")
     if handoff.get("visibility") != "issue_comment_metadata_only":
         stops.append("visibility_mismatch")

--- a/scripts/test_af18_mvp1_control.py
+++ b/scripts/test_af18_mvp1_control.py
@@ -14,6 +14,11 @@ spec = importlib.util.spec_from_file_location("plan_af18_mvp1_control", PLANNER)
 planner = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
 spec.loader.exec_module(planner)
+HELPER = ROOT / "scripts" / "github_collaboration_helper.py"
+helper_spec = importlib.util.spec_from_file_location("github_collaboration_helper", HELPER)
+helper = importlib.util.module_from_spec(helper_spec)
+assert helper_spec.loader is not None
+helper_spec.loader.exec_module(helper)
 
 NOW = dt.datetime(2026, 7, 29, 4, 0, tzinfo=dt.timezone.utc)
 
@@ -507,6 +512,45 @@ def main() -> int:
     expect("incident-no-silent-model-effort-change", "silent_model_change_forbidden" in silent_escalation["stop_conditions"] and "silent_reasoning_change_forbidden" in silent_escalation["stop_conditions"], silent_escalation)
     private_incident = planner.incident_projection({"incident": {**incident_base, "category": "evidence_conflict", "prompt": "private"}}, NOW)
     expect("incident-privacy-holds", "privacy_exposure" in private_incident["stop_conditions"], private_incident)
+
+    handoff = planner.build_work_terminal_handoff(
+        "af18-450", "run-450-a", "https://github.com/farmerhunter/agent-foundry/issues/450", "sha256:abc",
+        {"disposition": "candidate_hold", "summary": "bounded lesson"},
+    )
+    expect("terminal-handoff-valid", planner.validate_work_terminal_handoff(handoff)["valid"], handoff)
+    none = planner.build_work_terminal_handoff("af18-450", "run-450-b", handoff["issue_url_anchor"], "sha256:none")
+    expect("terminal-handoff-none", none["candidate"] is None and none["learning_signal"] == "none", none)
+    private = {**handoff, "native_thread_id": "thread-secret"}
+    expect("terminal-handoff-privacy", "privacy_exposure" in planner.validate_work_terminal_handoff(private)["stop_conditions"], private)
+
+    class FakeComments:
+        def __init__(self, comments=None, fail_add=False):
+            self.comments = list(comments or [])
+            self.fail_add = fail_add
+        def list_comments(self, _anchor):
+            return list(self.comments)
+        def add_comment(self, _anchor, body):
+            if self.fail_add:
+                self.fail_add = False
+                raise RuntimeError("uncertain")
+            self.comments.append({"body": body})
+
+    adapter = FakeComments()
+    recorded = helper.write_work_terminal_handoff(adapter, handoff)
+    expect("terminal-write", recorded["status"] == "recorded", recorded)
+    repeated = helper.write_work_terminal_handoff(adapter, handoff)
+    expect("terminal-idempotent", repeated["status"] == "already_recorded", repeated)
+    conflict = helper.write_work_terminal_handoff(adapter, {**handoff, "payload_hash": "sha256:other"})
+    expect("terminal-conflict", conflict["status"] == "held_handoff_conflict", conflict)
+    uncertain = FakeComments(fail_add=True)
+    uncertain_result = helper.write_work_terminal_handoff(uncertain, handoff)
+    expect("terminal-uncertain-retry", uncertain_result["status"] == "recorded" and uncertain_result["attempts"] == 2, uncertain_result)
+    recovered = helper.reconstruct_work_terminal_state(adapter.list_comments(handoff["issue_url_anchor"]), handoff["issue_url_anchor"])
+    expect("terminal-restart-recovery", recovered["status"] == "complete" and recovered["handoff"]["payload_hash"] == "sha256:abc", recovered)
+    disposition = helper.append_work_terminal_disposition(adapter, handoff, "disposed", "receipt-1")
+    expect("terminal-disposition", disposition["status"] == "recorded" and disposition["state"]["dispositions"][0]["disposition"] == "disposed", disposition)
+    expect("terminal-logical-dispose", len(adapter.comments) >= 2, adapter.comments)
+    expect("terminal-no-runtime-side-effects", helper.WORK_TERMINAL_MARKER in adapter.comments[0]["body"] and "native_thread_id" not in adapter.comments[0]["body"], adapter.comments)
 
     print("af18 mvp1 control-plane tests passed")
     return 0

--- a/scripts/test_af18_mvp1_control.py
+++ b/scripts/test_af18_mvp1_control.py
@@ -522,6 +522,8 @@ def main() -> int:
     expect("terminal-handoff-none", none["candidate"] is None and none["learning_signal"] == "none", none)
     private = {**handoff, "native_thread_id": "thread-secret"}
     expect("terminal-handoff-privacy", "privacy_exposure" in planner.validate_work_terminal_handoff(private)["stop_conditions"], private)
+    malformed_anchor = {**handoff, "issue_url_anchor": handoff["issue_url_anchor"] + "\n"}
+    expect("terminal-handoff-anchor-strict", "invalid_issue_url_anchor" in planner.validate_work_terminal_handoff(malformed_anchor)["stop_conditions"], malformed_anchor)
 
     class FakeComments:
         def __init__(self, comments=None, fail_add=False):

--- a/scripts/test_github_collaboration_helper.py
+++ b/scripts/test_github_collaboration_helper.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import importlib.util
 import os
 import subprocess
 import sys
@@ -15,6 +16,10 @@ ROOT = Path(__file__).resolve().parents[1]
 HELPER = ROOT / "scripts" / "github_collaboration_helper.py"
 TEMPLATE = ROOT / "templates" / "github-role-routing.template.yaml"
 WORKFLOW = ROOT / "workflows" / "github-collaboration-helper.md"
+helper_spec = importlib.util.spec_from_file_location("github_collaboration_helper", HELPER)
+helper_module = importlib.util.module_from_spec(helper_spec)
+assert helper_spec.loader is not None
+helper_spec.loader.exec_module(helper_module)
 
 
 def run(args: list[str], cwd: Path, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
@@ -45,6 +50,28 @@ def expect_ok(name: str, result: subprocess.CompletedProcess[str], expected: str
     return [f"{name}: expected success containing {expected!r}, got {result.returncode}\n{output}"]
 
 
+def terminal_handoff_fixture_checks() -> list[str]:
+    errors: list[str] = []
+    anchor = "https://github.com/farmerhunter/agent-foundry/issues/450"
+    handoff = {
+        "handoff_version": "WorkTerminalLearningSignalHandoff-v1", "work_id": "w-1", "run_id": "r-1",
+        "issue_url_anchor": anchor, "payload_hash": "sha256:x", "retention": "issue_comment_until_disposed",
+        "visibility": "issue_comment_metadata_only", "candidate": None, "learning_signal": "none", "disposition_receipts": [],
+    }
+    class Adapter:
+        def __init__(self): self.comments: list[dict[str, str]] = []
+        def list_comments(self, _anchor): return list(self.comments)
+        def add_comment(self, _anchor, body): self.comments.append({"body": body})
+    adapter = Adapter()
+    first = helper_module.write_work_terminal_handoff(adapter, handoff)
+    again = helper_module.write_work_terminal_handoff(adapter, handoff)
+    if first["status"] != "recorded": errors.append("terminal-handoff-recorded")
+    if again["status"] != "already_recorded": errors.append("terminal-handoff-idempotent")
+    state = helper_module.reconstruct_work_terminal_state(adapter.comments, anchor)
+    if state["status"] != "complete" or "native_thread_id" in adapter.comments[0]["body"]: errors.append("terminal-handoff-privacy")
+    return errors
+
+
 def expect_fail(name: str, result: subprocess.CompletedProcess[str], expected: str) -> list[str]:
     output = result.stdout + result.stderr
     if result.returncode != 0 and expected in output:
@@ -63,6 +90,7 @@ def expect_text_contains(name: str, text: str, snippets: list[str]) -> list[str]
 
 def main() -> int:
     errors: list[str] = []
+    errors.extend(terminal_handoff_fixture_checks())
     workflow_text = WORKFLOW.read_text(encoding="utf-8")
     template_text = TEMPLATE.read_text(encoding="utf-8")
     errors.extend(

--- a/templates/github-role-routing.template.yaml
+++ b/templates/github-role-routing.template.yaml
@@ -55,6 +55,40 @@ completion_handoff:
     - generated_note
     - portable_prompt
 
+work_terminal_learning_signal_handoff:
+  schema: "WorkTerminalLearningSignalHandoff-v1"
+  destination: "existing_work_issue_terminal_handoff_comment"
+  payload_policy: "metadata_only"
+  cardinality: "at_most_one_candidate_or_learning_signal_none"
+  candidate_disposition: "candidate_hold"
+  required_metadata:
+    - work_id
+    - run_id
+    - issue_url_anchor
+    - payload_hash
+    - retention
+    - visibility
+  forbidden_payload:
+    - native_thread_id
+    - raw_transcript
+    - prompt
+    - tool_output
+    - model_output
+    - identity
+    - secrets
+  dedupe_policy: "same_hash_already_recorded_key_conflict_held"
+  uncertain_write_policy: "readback_then_one_retry_else_held_write_outcome_unknown"
+  dispositions:
+    - retrieved_for_review
+    - dismissed
+    - superseded
+    - disposed
+  disposed_semantics: "logical_only_no_physical_delete"
+  fail_closed_on:
+    - missing_or_locked_issue
+    - permission_denied
+    - visibility_mismatch
+
 github:
   auth_check: "read target repository before mutation planning"
   retry_policy: "bounded_retry_for_transient_network_or_rate_limit_only"

--- a/workflows/coordinate-agent-work.md
+++ b/workflows/coordinate-agent-work.md
@@ -52,6 +52,25 @@ The portable Core owns:
 Native runtime ids, such as Codex task/thread/subagent ids, are adapter
 metadata. They are useful evidence but not Core domain objects.
 
+## Work terminal learning-signal handoff
+
+When a Work reaches a terminal handoff, Coordinator may append one
+`WorkTerminalLearningSignalHandoff-v1` metadata envelope to the existing Work
+issue's durable terminal-handoff comment. The envelope carries portable
+`work_id`, `run_id`, an issue URL anchor, payload hash, retention, and
+visibility. It contains at most one `candidate` with disposition
+`candidate_hold`; otherwise `learning_signal: none`. Native thread ids, raw
+transcripts, prompts, tool/model output, identity, and secrets are forbidden.
+
+Coordinator must read back before and after writing. A matching key and hash is
+`already_recorded`; a matching key with a different hash is
+`held_handoff_conflict`. If the API outcome is uncertain, read back and retry
+at most once, then hold as `held_write_outcome_unknown`. Restart recovery
+reconstructs state from issue comments only. Disposition receipts are
+append-only (`retrieved_for_review`, `dismissed`, `superseded`, or `disposed`);
+`disposed` is logical and never physically deletes a comment. Missing,
+locked, permission-denied, or visibility-mismatched issue state fails closed.
+
 ## AF18 Policy Layers
 
 Do not collapse AF18 policy layers:


### PR DESCRIPTION
## Scope
- Add WorkTerminalLearningSignalHandoff-v1 metadata-only schema and workflow contract.
- Use the existing Work issue terminal handoff comment as durable destination with readback, dedupe, conflict, bounded retry, restart reconstruction, and logical disposition receipts.
- Add fake comment-adapter tests for completion, none, restart, idempotency, conflict, uncertain writes, crash boundaries, privacy sentinels, and no runtime/Vault/publish/activation/dispatch side effects.

## Constraints
- Exactly the seven allowlisted existing files changed.
- No SQLite/local ledger/new storage, native thread IDs, raw transcript, prompts, tool/model output, identity, or secrets.
- No real GitHub mutation in tests.

## Verification
- `python3 scripts/test_af18_mvp1_control.py`
- `python3 scripts/test_github_collaboration_helper.py`
- `python3 -m py_compile scripts/plan_af18_mvp1_control.py scripts/test_af18_mvp1_control.py scripts/github_collaboration_helper.py scripts/test_github_collaboration_helper.py`
- `git diff --check`