### PR TITLE
docs: reframe AF18 degraded path and add AF19 roadmap

### DIFF
--- a/docs/roadmap/milestones-af16-af18.md
+++ b/docs/roadmap/milestones-af16-af18.md
@@ -63,7 +63,9 @@ Acceptance criteria:
 
 Goal: make Agent Foundry's multi-agent collaboration cost-aware, bounded, portable, and human-controllable before it becomes an assumed runtime substrate.
 
-AF18's user value is direct: a user should be able to run multi-agent collaboration without losing control of token growth, branch target, role ownership, duplicate dispatches, successor context, or Human attention. GitHub remains the durable authority; active execution contexts should be bounded and replaceable.
+AF18's user value is direct: any environment that already applies the multi-agent-collaboration practice should transparently receive bounded, human-controllable collaboration. Users do not opt into an "AF18" product mode or need to understand AF18 internals. GitHub remains the durable authority; active execution contexts should be bounded and replaceable.
+
+AF18's completed user-facing slice is the degraded operational path. It is deliberately honest about unavailable runtime metrics while still enforcing the controls that do not depend on those metrics: bounded Work, ownership, duplicate prevention, hold/disable, logical successor packets, Human summaries, durable terminal handoff, and candidate-only learning capture. This slice becomes part of the existing multi-agent-collaboration practice after Human-approved canonical practice application, adapter publish, and one adopter dogfood/readback. It does not require a separate AF18 opt-in.
 
 AF18's design is `Codex-first, portable-core`:
 
@@ -159,22 +161,26 @@ Current canonical path:
 | Policy freeze HDC | [#458](https://github.com/farmerhunter/agent-foundry/issues/458) | candidate-only | A candidate Human decision path for normal policy and rollback conditions; it does not prove a frozen policy, auto-tuning, or activation. |
 | RoleConversation/adaptor successor | [#459](https://github.com/farmerhunter/agent-foundry/issues/459) / [PR #475](https://github.com/farmerhunter/agent-foundry/pull/475) (`637c422f73bc2d2cba76d64bcbb425aed69f55fe`) | static/read-only | Merged static deterministic dry-run controls; they do not prove a real Codex capability, live UX, or activation. |
 | Recovery/rollback readiness | [#460](https://github.com/farmerhunter/agent-foundry/issues/460) / [PR #475](https://github.com/farmerhunter/agent-foundry/pull/475) (`637c422f73bc2d2cba76d64bcbb425aed69f55fe`) | static/read-only | Merged static deterministic dry-run controls; they do not prove a real Codex capability, live UX, or activation. |
-| LearningSignal harvest contract | [#461](https://github.com/farmerhunter/agent-foundry/issues/461) | candidate-only | Contract preparation only; no candidate exists and this is not a formal Harvest or publication authorization. |
+| LearningSignal harvest contract | [#461](https://github.com/farmerhunter/agent-foundry/issues/461) | accepted Core + durable handoff | Accepted Core identity/index contract plus privacy-safe Work terminal handoff and candidate-only persistence; it is not automatic Harvest or publication authorization. |
 | Provisional policy source/readout | [#469](https://github.com/farmerhunter/agent-foundry/issues/469) / [PR #473](https://github.com/farmerhunter/agent-foundry/pull/473) (`8ab846e19b268281899aa8c4747f50c08b7862ec`) | static/read-only | Static portable policy-source and Human readout only; it does not prove runtime enforcement, final freeze, or activation. |
 | Privacy-safe telemetry aggregation | [#470](https://github.com/farmerhunter/agent-foundry/issues/470) / [PR #474](https://github.com/farmerhunter/agent-foundry/pull/474) (`6a6a3bc3fdf621d27a4c7b43b8366dbb890a45a4`) | static/read-only | Static privacy-safe telemetry-aggregation only; it does not prove a trusted live telemetry channel or activation. |
 | W10 provisional-policy evidence | [#471](https://github.com/farmerhunter/agent-foundry/issues/471) | local deterministic/reference only | W10 local deterministic/reference-only evidence; it is not trusted live evidence or a formal Harvest. |
 | Provisional-policy no-change hold | [#472](https://github.com/farmerhunter/agent-foundry/issues/472) (CLOSED) | static/read-only | No-change hold retains provisional policy-v0 and forbids parameter divergence or final freeze without a new Human HDC; it does not prove a new policy or activation. |
-| Limited real-mode rollout | [#462](https://github.com/farmerhunter/agent-foundry/issues/462) | trusted live evidence required | P3 trusted live evidence and a Human release remain required; it does not prove rollout, activation, or final readiness. |
-| Parent Epic/readiness | #418 / #426 / #427 | Held | Final publish/runtime activation/readiness remain later gates. |
+| Limited real-mode rollout | [#462](https://github.com/farmerhunter/agent-foundry/issues/462) | AF19 candidate / held | Full trusted-metrics real-mode rollout is no longer an AF18 MVP gate. The degraded controls are usable through the existing collaboration practice; #462 moves to AF19 for trusted observation, calibration, and higher-order rollout evidence. |
+| Parent Epic/readiness | #418 / #426 / #427 | AF18 transparent integration | #418 remains the Epic authority; #426 applies the accepted collaboration practice and publishes selected adapters; #427 performs one adopter dogfood/readback. Trusted runtime and production gates move to AF19. |
 
 ### AF18 Next Gated Work
 
-P0, P1, and P2 are preparation only. They must not be described as trusted
-live evidence, normal-policy calibration, formal Harvest, final policy freeze,
-or activation. The gated route is strictly P3 -> P4 -> #426 -> #427 ->
-main/release: P3 requires trusted live evidence, P4 requires its prerequisite
-evidence and a Human release, and #426, #427, and main/release each retain
-their Human gates.
+The remaining AF18 route is deliberately user-facing and transparent:
+
+1. Human approves the canonical collaboration-practice application.
+2. Selected adapters publish that practice to environments that already use
+   multi-agent collaboration; there is no separate AF18 opt-in.
+3. One adopter runs a bounded dogfood and readback through #427.
+
+Trusted runtime observation, P3/P4 evidence, normal-policy calibration/freeze,
+native successor/runtime activation, and main/release are AF19 enhancement
+gates. They must not block the AF18 degraded path.
 
 Until these gates are explicitly accepted:
 
@@ -191,18 +197,44 @@ Older AF18 issues may be closed or superseded only after compact evidence commen
 - #435 is stale as an active implementation route and should not keep `needs:implementer`.
 - #444/#445/#433/#436/#432 need narrow closure/supersession packets before closing.
 - #452 and #454 are complete evidence/design inputs.
-- #426/#427/#418 remain open gates.
+- #426/#427 remain AF18 integration/adopter gates; #418 remains the AF18 Epic
+  authority. AF19 owns the trusted-runtime and production gates.
 
 ### AF18 Acceptance Criteria
 
-AF18 is not complete until:
+AF18 is complete when:
 
 - the integration branch contains all accepted AF18 code and docs;
 - MVP-1, MVP-2, and MVP-3 are accepted in order;
-- post-MVP operational readiness is reconciled through #454 and decomposed into #457 through #462;
-- runtime-owned observation proves availability/provenance/fail-closed behavior;
-- dogfood produces calibration evidence without self-tuning policy;
-- Human reviews and freezes any normal operating policy;
-- final activation/publish/readiness gates are explicitly accepted.
+- the historical/reference evidence in #457 and #469-#471 is retained with its non-trusted status;
+- the degraded control path is integrated into the existing multi-agent-collaboration practice;
+- a Human approves the canonical practice application and the selected adapters are published;
+- one adopter dogfood/readback confirms the transparent default user experience;
+- metrics remain explicitly `unavailable/not_exposed`, with no unsupported cost, model, auto-tuning, or enforcement claims;
+- the AF18 integration branch contains all accepted AF18 code and docs.
 
-AF18 completion does not imply V2 local-first orchestration completion, memory-system implementation, generated adapter publish, runtime activation, or direct-to-main merge.
+The explicit readiness matrix is:
+
+| Record | Milestone | Lifecycle | Roadmap status |
+| --- | --- | --- | --- |
+| #457 | AF-18 | Done | Done |
+| #458 | AF-19 | Active | Blocked |
+| #462 | AF-19 | Active | Blocked |
+| #469-#471 | AF-18 | Done | Done |
+| #493 | AF-19 | Active | Ready |
+| #494 | AF-19 | Active | Blocked |
+
+AF18 completion does not imply trusted runtime metrics, normal policy freeze, native successor activation, Vault migration, production/main release, or V2 local-first orchestration completion. Those belong to AF19 or later independent gates.
+
+## AF-19: Trusted Runtime Evidence And Production Activation
+
+AF-19 is the follow-on milestone for capabilities that exceed AF18's transparent degraded collaboration path. It must not block AF18 adoption by existing multi-agent-collaboration environments.
+
+AF19 scope:
+
+- a trusted runtime-owned producer for context age, token consumption, and effective model/reasoning mapping;
+- calibration evidence and a Human-approved normal policy freeze;
+- native successor/runtime activation and full real-mode rollout evidence for [#462](https://github.com/farmerhunter/agent-foundry/issues/462);
+- production activation, generated publish beyond the AF18 adopter path, and final main/release readiness.
+
+AF19 does not include the deferred selected-Vault SQLite/shadow lane in [#492](https://github.com/farmerhunter/agent-foundry/issues/492); that remains an optional, separately reopened storage-architecture effort.


### PR DESCRIPTION
## Scope
- document transparent default AF18 degraded collaboration
- move trusted runtime/metrics/full rollout/activation to AF19
- keep #492 deferred storage lane outside AF19 critical path
- synchronize explicit AF18/AF19 readiness matrix and #418 current boundary

## Evidence
- exact current head: 13164201802d14cdd5f21fb8572db652d82e79d3
- #418 current boundary readback: https://github.com/farmerhunter/agent-foundry/issues/418#issuecomment-5187040969
- Project Stage field preserves all existing options and adds AF-19 only

No code, Vault, runtime, publish, or main/release mutation.