### PR TITLE
docs: name AF18 bounded collaboration control plane

### DIFF
--- a/docs/roadmap/milestones-af16-af18.md
+++ b/docs/roadmap/milestones-af16-af18.md
@@ -231,7 +231,7 @@ The explicit readiness matrix is:
 
 AF18 completion does not imply trusted runtime metrics, normal policy freeze, native successor activation, Vault migration, production/main release, or V2 local-first orchestration completion. Those belong to AF19 or later independent gates.
 
-## AF-19: Adaptive And Observed Collaboration
+## AF-19: Adaptive and Observed Collaboration
 
 AF-19 is the follow-on milestone for capabilities that exceed AF18's transparent bounded collaboration path. It must not block AF18 adoption by existing multi-agent-collaboration environments.
 

--- a/docs/roadmap/milestones-af16-af18.md
+++ b/docs/roadmap/milestones-af16-af18.md
@@ -59,13 +59,18 @@ Acceptance criteria:
 - Missing or stale generated references fail validation instead of silently dropping authority.
 - Runtime context is reduced without making practice authority ambiguous.
 
-## AF-18: Collaboration Cost-Control And Control Plane
+## AF-18: Bounded Collaboration Control Plane
 
 Goal: make Agent Foundry's multi-agent collaboration cost-aware, bounded, portable, and human-controllable before it becomes an assumed runtime substrate.
 
+The user-facing capability is **Bounded Collaboration**. Internally, AF18 is the
+**Contract-Driven Collaboration Control Plane**: explicit contracts and durable
+receipts make collaboration predictable without implying trusted runtime
+observation that is not available.
+
 AF18's user value is direct: any environment that already applies the multi-agent-collaboration practice should transparently receive bounded, human-controllable collaboration. Users do not opt into an "AF18" product mode or need to understand AF18 internals. GitHub remains the durable authority; active execution contexts should be bounded and replaceable.
 
-AF18's completed user-facing slice is the degraded operational path. It is deliberately honest about unavailable runtime metrics while still enforcing the controls that do not depend on those metrics: bounded Work, ownership, duplicate prevention, hold/disable, logical successor packets, Human summaries, durable terminal handoff, and candidate-only learning capture. This slice becomes part of the existing multi-agent-collaboration practice after Human-approved canonical practice application, adapter publish, and one adopter dogfood/readback. It does not require a separate AF18 opt-in.
+AF18's completed user-facing slice is the bounded collaboration path. It is deliberately honest about unavailable runtime metrics while still enforcing the contract-driven controls that do not depend on those metrics: bounded Work, ownership, duplicate prevention, hold/disable, logical successor packets, Human summaries, durable terminal handoff, and candidate-only learning capture. This slice becomes part of the existing multi-agent-collaboration practice after Human-approved canonical practice application, adapter publish, and one adopter dogfood/readback. It does not require a separate AF18 opt-in.
 
 AF18's design is `Codex-first, portable-core`:
 
@@ -166,7 +171,7 @@ Current canonical path:
 | Privacy-safe telemetry aggregation | [#470](https://github.com/farmerhunter/agent-foundry/issues/470) / [PR #474](https://github.com/farmerhunter/agent-foundry/pull/474) (`6a6a3bc3fdf621d27a4c7b43b8366dbb890a45a4`) | static/read-only | Static privacy-safe telemetry-aggregation only; it does not prove a trusted live telemetry channel or activation. |
 | W10 provisional-policy evidence | [#471](https://github.com/farmerhunter/agent-foundry/issues/471) | local deterministic/reference only | W10 local deterministic/reference-only evidence; it is not trusted live evidence or a formal Harvest. |
 | Provisional-policy no-change hold | [#472](https://github.com/farmerhunter/agent-foundry/issues/472) (CLOSED) | static/read-only | No-change hold retains provisional policy-v0 and forbids parameter divergence or final freeze without a new Human HDC; it does not prove a new policy or activation. |
-| Limited real-mode rollout | [#462](https://github.com/farmerhunter/agent-foundry/issues/462) | AF19 candidate / held | Full trusted-metrics real-mode rollout is no longer an AF18 MVP gate. The degraded controls are usable through the existing collaboration practice; #462 moves to AF19 for trusted observation, calibration, and higher-order rollout evidence. |
+| Limited real-mode rollout | [#462](https://github.com/farmerhunter/agent-foundry/issues/462) | AF19 candidate / held | Full trusted-metrics real-mode rollout is no longer an AF18 MVP gate. The bounded collaboration controls are usable through the existing collaboration practice; #462 moves to AF19 for trusted observation, calibration, and higher-order rollout evidence. |
 | Parent Epic/readiness | #418 / #426 / #427 | AF18 transparent integration | #418 remains the Epic authority; #426 applies the accepted collaboration practice and publishes selected adapters; #427 performs one adopter dogfood/readback. Trusted runtime and production gates move to AF19. |
 
 ### AF18 Next Gated Work
@@ -180,7 +185,7 @@ The remaining AF18 route is deliberately user-facing and transparent:
 
 Trusted runtime observation, P3/P4 evidence, normal-policy calibration/freeze,
 native successor/runtime activation, and main/release are AF19 enhancement
-gates. They must not block the AF18 degraded path.
+gates. They must not block the AF18 bounded collaboration path.
 
 Until these gates are explicitly accepted:
 
@@ -207,7 +212,7 @@ AF18 is complete when:
 - the integration branch contains all accepted AF18 code and docs;
 - MVP-1, MVP-2, and MVP-3 are accepted in order;
 - the historical/reference evidence in #457 and #469-#471 is retained with its non-trusted status;
-- the degraded control path is integrated into the existing multi-agent-collaboration practice;
+- the bounded collaboration control path is integrated into the existing multi-agent-collaboration practice;
 - a Human approves the canonical practice application and the selected adapters are published;
 - one adopter dogfood/readback confirms the transparent default user experience;
 - metrics remain explicitly `unavailable/not_exposed`, with no unsupported cost, model, auto-tuning, or enforcement claims;
@@ -226,9 +231,9 @@ The explicit readiness matrix is:
 
 AF18 completion does not imply trusted runtime metrics, normal policy freeze, native successor activation, Vault migration, production/main release, or V2 local-first orchestration completion. Those belong to AF19 or later independent gates.
 
-## AF-19: Trusted Runtime Evidence And Production Activation
+## AF-19: Adaptive And Observed Collaboration
 
-AF-19 is the follow-on milestone for capabilities that exceed AF18's transparent degraded collaboration path. It must not block AF18 adoption by existing multi-agent-collaboration environments.
+AF-19 is the follow-on milestone for capabilities that exceed AF18's transparent bounded collaboration path. It must not block AF18 adoption by existing multi-agent-collaboration environments.
 
 AF19 scope:
 

--- a/docs/roadmap/milestones-af16-af18.md
+++ b/docs/roadmap/milestones-af16-af18.md
@@ -59,7 +59,7 @@ Acceptance criteria:
 - Missing or stale generated references fail validation instead of silently dropping authority.
 - Runtime context is reduced without making practice authority ambiguous.
 
-## AF-18: Bounded Collaboration Control Plane
+## AF18: Bounded Collaboration Control Plane
 
 Goal: make Agent Foundry's multi-agent collaboration cost-aware, bounded, portable, and human-controllable before it becomes an assumed runtime substrate.
 
@@ -231,7 +231,7 @@ The explicit readiness matrix is:
 
 AF18 completion does not imply trusted runtime metrics, normal policy freeze, native successor activation, Vault migration, production/main release, or V2 local-first orchestration completion. Those belong to AF19 or later independent gates.
 
-## AF-19: Adaptive and Observed Collaboration
+## AF19: Adaptive and Observed Collaboration
 
 AF-19 is the follow-on milestone for capabilities that exceed AF18's transparent bounded collaboration path. It must not block AF18 adoption by existing multi-agent-collaboration environments.
 


### PR DESCRIPTION
## Summary

Renames the AF18 user-facing path from a misleading "degraded" label to **Bounded Collaboration**.

- AF18: **Bounded Collaboration Control Plane**
- internal architecture: **Contract-Driven Collaboration Control Plane**
- AF19: **Adaptive and Observed Collaboration**

The change is documentation-only. It preserves genuine limitation states and all code/schema/receipt identifiers.

## Verification

- `git diff --check`
- focused terminology scan confirms the roadmap has the three approved terms and no remaining `degraded` product wording
- REST readback confirms #418, #426, #427, #458, #462, #493, and #494 no longer use `degraded` in their current title/body status surfaces

## Boundaries

No runtime, policy, Vault, schema, script, adapter, Project-field, `main`, or release change.
