### PR TITLE
feat: add bounded Codex RoleHub runner

### DIFF
--- a/schemas/codex-rolehub-runner.schema.yaml
+++ b/schemas/codex-rolehub-runner.schema.yaml
@@ -1,0 +1,35 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: https://agent-foundry.dev/schemas/codex-rolehub-runner.schema.yaml
+title: AF18 generic Codex RoleHub runner contract
+type: object
+additionalProperties: false
+required: [contract_version, project_id, logical_rolehub_id, operations]
+properties:
+  contract_version: {type: string, const: AF18-codex-rolehub-runner-v1}
+  project_id: {type: string, minLength: 1}
+  logical_rolehub_id: {type: string, minLength: 1}
+  runtime_id: {type: string, minLength: 1}
+  capability_evidence:
+    type: object
+    additionalProperties: false
+    required: [trusted, runtime_id, methods]
+    properties:
+      trusted: {type: boolean, const: true}
+      runtime_id: {type: string, minLength: 1}
+      methods: {type: array, items: {type: string}}
+      cwd: {type: string, minLength: 1}
+  operations:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      additionalProperties: false
+      required: [operation_id, action, idempotency_key, role]
+      properties:
+        operation_id: {type: string, minLength: 1}
+        action: {type: string, enum: [create, reuse, name, link, navigate]}
+        idempotency_key: {type: string, minLength: 1}
+        role: {type: string, enum: [Coordinator, Architect, Implementer, Reviewer, Tester, Harvester]}
+        target_ref: {type: string, minLength: 1}
+        title: {type: string, minLength: 1, maxLength: 200}
+        preimage_digest: {type: [string, 'null'], pattern: '^sha256:'}

--- a/scripts/codex_rolehub_runner.py
+++ b/scripts/codex_rolehub_runner.py
@@ -135,7 +135,7 @@ class CodexRoleHubRunner:
 
     def _failure_receipt(self, plan: dict[str, Any], op: dict[str, Any], status: str, reason: str) -> dict[str, Any]:
         receipt = self._receipt(plan, op, status, {"availability": "unknown", "reason": reason})
-        self.receipts[op["idempotency_key"]] = receipt
+        self.receipts[op["idempotency_key"]] = deepcopy(receipt)
         return receipt
 
     def _operation(self, plan: dict[str, Any], op: dict[str, Any]) -> dict[str, Any]:
@@ -195,7 +195,7 @@ class CodexRoleHubRunner:
             after["previous_title"] = before["title"]
         self._sequence += 1
         receipt = self._receipt(plan, op, "applied", {**after, "created": created, "native_id_held_in_memory": True})
-        self.receipts[key] = receipt
+        self.receipts[key] = deepcopy(receipt)
         if action == "name":
             self.rollback_records[key] = {"fingerprint": receipt["operation_fingerprint"], "previous_title": before.get("title"), "native_id": native_id, "operation_id": op["operation_id"]}
         return receipt
@@ -209,12 +209,20 @@ class CodexRoleHubRunner:
             readback = receipt.get("readback", {})
             previous = readback.get("previous_title") if isinstance(readback, dict) else None
             key = receipt.get("idempotency_key")
+            stored_receipt = self.receipts.get(key)
             stored = self.rollback_records.get(key)
-            if not stored or receipt.get("operation_fingerprint") != stored.get("fingerprint") or previous != stored.get("previous_title"):
+            if not stored_receipt or receipt != stored_receipt or not stored or receipt.get("operation_fingerprint") != stored.get("fingerprint") or previous != stored.get("previous_title"):
                 return {"status": "rollback_incomplete", "reason": "reverse_receipt_mismatch", "reversed_operation_ids": reversed_ids}
             native_id = stored.get("native_id")
             if not isinstance(previous, str) or not native_id:
                 return {"status": "rollback_incomplete", "reason": "reverse_receipt_unavailable", "reversed_operation_ids": reversed_ids}
+            try:
+                current = self._readback(native_id)
+            except Exception:
+                return {"status": "rollback_incomplete", "reason": "current_readback_unavailable", "reversed_operation_ids": reversed_ids}
+            expected_readback = stored_receipt.get("readback", {})
+            if not isinstance(expected_readback, dict) or current.get("digest") != expected_readback.get("digest") or current.get("title") != expected_readback.get("title"):
+                return {"status": "rollback_incomplete", "reason": "current_preimage_changed", "reversed_operation_ids": reversed_ids}
             try:
                 self._call("thread/name/set", {"threadId": native_id, "name": previous})
             except Exception:

--- a/scripts/codex_rolehub_runner.py
+++ b/scripts/codex_rolehub_runner.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Bounded, privacy-safe native Codex RoleHub runner.
+
+The runner accepts a JSON-RPC client supplied by the host.  It never starts an
+app-server and deliberately has no shell, filesystem, history, or deletion
+surface.  Native thread ids remain in process memory and receipts contain only
+opaque references and digests.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Callable
+
+try:
+    import yaml
+    from jsonschema import Draft202012Validator
+except Exception:  # pragma: no cover
+    yaml = None
+    Draft202012Validator = None
+
+SCHEMA = Path(__file__).resolve().parents[1] / "schemas" / "codex-rolehub-runner.schema.yaml"
+CONTRACT = "AF18-codex-rolehub-runner-v1"
+ALLOWED_METHODS = {"initialize", "initialized", "thread/list", "thread/read", "thread/start", "thread/name/set"}
+FORBIDDEN_METHODS = {"history", "turn/list", "thread/archive", "thread/delete", "turn/start", "shell", "filesystem", "config", "plugin", "mcp"}
+PRIVATE_KEYS = {"prompt", "body", "message", "messages", "content", "transcript", "turns", "tool_output", "raw_log"}
+
+
+class RunnerHold(Exception):
+    def __init__(self, status: str, reason: str):
+        self.status, self.reason = status, reason
+
+
+def digest(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def scrub(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {k: scrub(v) for k, v in value.items() if k not in PRIVATE_KEYS}
+    if isinstance(value, list):
+        return [scrub(v) for v in value]
+    return value
+
+
+class CodexRoleHubRunner:
+    def __init__(self, rpc: Callable[[str, dict[str, Any] | None], Any], *, runtime_id: str):
+        self.rpc = rpc
+        self.runtime_id = runtime_id
+        self.native_ids: dict[str, str] = {}
+        self.role_native: dict[str, str] = {}
+        self.receipts: dict[str, dict[str, Any]] = {}
+        self._sequence = 0
+
+    def _call(self, method: str, params: dict[str, Any] | None = None) -> Any:
+        if method not in ALLOWED_METHODS:
+            raise RunnerHold("partial_hold", "method_not_allowlisted")
+        result = self.rpc(method, params or {})
+        return scrub(result)
+
+    def _readback(self, native_id: str) -> dict[str, Any]:
+        # includeTurns is explicitly false; the runner never reads transcript history.
+        value = self._call("thread/read", {"threadId": native_id, "includeTurns": False})
+        if not isinstance(value, dict):
+            raise RunnerHold("partial_hold", "readback_not_object")
+        result = {"digest": digest(value), "opaque_ref": "native:" + digest(native_id)[:24]}
+        # Titles are metadata needed for a bounded reverse receipt; no body or turns
+        # are retained.  The native id itself is never put in a durable receipt.
+        if isinstance(value.get("name"), str):
+            result["title"] = value["name"]
+        elif isinstance(value.get("title"), str):
+            result["title"] = value["title"]
+        return result
+
+    def preflight(self) -> dict[str, Any]:
+        try:
+            init = self._call("initialize", {})
+            self._call("initialized", {})
+            listing = self._call("thread/list", {})
+            return {"status": "ready", "runtime_id": self.runtime_id, "methods": sorted(ALLOWED_METHODS), "initialize_digest": digest(init), "thread_list_digest": digest(listing)}
+        except RunnerHold as hold:
+            return {"status": hold.status, "reason": hold.reason}
+        except Exception:
+            return {"status": "partial_hold", "reason": "native_preflight_error"}
+
+    def _validate(self, plan: dict[str, Any]) -> None:
+        if not isinstance(plan, dict) or plan.get("contract_version") != CONTRACT:
+            raise RunnerHold("partial_hold", "schema_drift")
+        if plan.get("runtime_id") and plan["runtime_id"] != self.runtime_id:
+            raise RunnerHold("partial_hold", "foreign_runtime")
+        if Draft202012Validator is None or yaml is None:
+            raise RunnerHold("partial_hold", "schema_validator_unavailable")
+        try:
+            schema = yaml.safe_load(SCHEMA.read_text(encoding="utf-8"))
+            errors = list(Draft202012Validator(schema).iter_errors(plan))
+        except Exception:
+            raise RunnerHold("partial_hold", "schema_validator_error")
+        if errors:
+            raise RunnerHold("partial_hold", "schema_drift")
+        evidence = plan.get("capability_evidence")
+        if not isinstance(evidence, dict) or evidence.get("runtime_id") != self.runtime_id or evidence.get("trusted") is not True:
+            raise RunnerHold("partial_hold", "untrusted_capability_evidence")
+        methods = set(evidence.get("methods", []))
+        if not ALLOWED_METHODS.issubset(methods):
+            raise RunnerHold("partial_hold", "required_method_unavailable")
+        if methods & FORBIDDEN_METHODS:
+            raise RunnerHold("partial_hold", "forbidden_method_observed")
+
+    def apply(self, plan: dict[str, Any]) -> dict[str, Any]:
+        try:
+            self._validate(plan)
+            applied: list[dict[str, Any]] = []
+            for operation in plan["operations"]:
+                applied.append(self._operation(plan, operation))
+            return {"status": "ready", "project_id": plan["project_id"], "logical_rolehub_id": plan["logical_rolehub_id"], "operations": applied}
+        except RunnerHold as hold:
+            return {"status": hold.status, "reason": hold.reason, "operations": []}
+
+    def _operation(self, plan: dict[str, Any], op: dict[str, Any]) -> dict[str, Any]:
+        key = op["idempotency_key"]
+        fingerprint = digest({k: v for k, v in op.items() if k not in {"receipt"}})
+        existing = self.receipts.get(key)
+        if existing:
+            if existing["operation_fingerprint"] != fingerprint:
+                raise RunnerHold("partial_hold", "foreign_idempotency_key")
+            return deepcopy(existing)
+        action = op["action"]
+        if action in {"link", "navigate"}:
+            # Logical receipts only; never claim a native link/navigation.
+            self._sequence += 1
+            receipt = self._receipt(plan, op, "partial_hold", {"availability": "unavailable"})
+            self.receipts[key] = receipt
+            return receipt
+        native_id = self.native_ids.get(key)
+        created = False
+        if action == "create":
+            result = self._call("thread/start", {"cwd": plan.get("capability_evidence", {}).get("cwd", "")})
+            if not isinstance(result, dict):
+                raise RunnerHold("setup_incomplete", "thread_start_no_receipt")
+            native_id = result.get("threadId") or result.get("id")
+            if not isinstance(native_id, str) or not native_id:
+                raise RunnerHold("setup_incomplete", "native_id_unavailable")
+            self.native_ids[key] = native_id
+            self.role_native[op["role"]] = native_id
+            created = True
+        elif action == "reuse":
+            native_id = op.get("target_ref")
+            if not isinstance(native_id, str) or not native_id.startswith("native:"):
+                raise RunnerHold("partial_hold", "foreign_native_reference")
+            native_id = self.native_ids.get(key)
+            if not native_id:
+                raise RunnerHold("partial_hold", "native_reference_not_in_process")
+        elif action == "name":
+            native_id = self.role_native.get(op["role"])
+            if not native_id:
+                raise RunnerHold("partial_hold", "native_reference_not_in_process")
+        if not native_id:
+            raise RunnerHold("partial_hold", "native_id_missing")
+        self.native_ids[key] = native_id
+        before = self._readback(native_id)
+        expected = op.get("preimage_digest")
+        if expected and expected != before["digest"]:
+            raise RunnerHold("partial_hold", "stale_preimage")
+        if action == "name":
+            self._call("thread/name/set", {"threadId": native_id, "name": op.get("title", "")})
+        after = self._readback(native_id)
+        if action == "name" and isinstance(before.get("title"), str):
+            after["previous_title"] = before["title"]
+        self._sequence += 1
+        receipt = self._receipt(plan, op, "applied", {**after, "created": created, "native_id_held_in_memory": True})
+        self.receipts[key] = receipt
+        return receipt
+
+    def rollback(self, receipts: list[dict[str, Any]]) -> dict[str, Any]:
+        """Reverse title changes in reverse sequence; never delete a new thread."""
+        reversed_ids: list[str] = []
+        for receipt in sorted(receipts, key=lambda item: item.get("sequence", 0), reverse=True):
+            if receipt.get("status") != "applied":
+                continue
+            readback = receipt.get("readback", {})
+            previous = readback.get("previous_title") if isinstance(readback, dict) else None
+            key = receipt.get("idempotency_key")
+            native_id = self.native_ids.get(key)
+            if not isinstance(previous, str) or not native_id:
+                return {"status": "rollback_incomplete", "reason": "reverse_receipt_unavailable", "reversed_operation_ids": reversed_ids}
+            try:
+                self._call("thread/name/set", {"threadId": native_id, "name": previous})
+            except Exception:
+                return {"status": "rollback_incomplete", "reason": "reverse_call_failed", "reversed_operation_ids": reversed_ids}
+            reversed_ids.append(receipt.get("operation_id", ""))
+        return {"status": "complete", "reversed_operation_ids": reversed_ids}
+
+    def _receipt(self, plan: dict[str, Any], op: dict[str, Any], status: str, readback: dict[str, Any]) -> dict[str, Any]:
+        return {"operation_id": op["operation_id"], "idempotency_key": op["idempotency_key"], "operation_fingerprint": digest({k: v for k, v in op.items() if k != "receipt"}), "opaque_ref": "receipt:" + digest(op["idempotency_key"])[:24], "project_id": plan["project_id"], "logical_rolehub_id": plan["logical_rolehub_id"], "role": op["role"], "readback": scrub(readback), "sequence": self._sequence, "status": status}

--- a/scripts/codex_rolehub_runner.py
+++ b/scripts/codex_rolehub_runner.py
@@ -52,6 +52,7 @@ class CodexRoleHubRunner:
         self.native_ids: dict[str, str] = {}
         self.role_native: dict[str, str] = {}
         self.receipts: dict[str, dict[str, Any]] = {}
+        self.rollback_records: dict[str, dict[str, Any]] = {}
         self._sequence = 0
 
     def _call(self, method: str, params: dict[str, Any] | None = None) -> Any:
@@ -109,18 +110,33 @@ class CodexRoleHubRunner:
             raise RunnerHold("partial_hold", "forbidden_method_observed")
 
     def apply(self, plan: dict[str, Any]) -> dict[str, Any]:
+        applied: list[dict[str, Any]] = []
         try:
             self._validate(plan)
-            applied: list[dict[str, Any]] = []
             for operation in plan["operations"]:
-                applied.append(self._operation(plan, operation))
+                try:
+                    applied.append(self._operation(plan, operation))
+                except RunnerHold as hold:
+                    if operation.get("action") == "create" and hold.reason in {"native_call_error", "readback_not_object", "native_id_unavailable"}:
+                        applied.append(self._failure_receipt(plan, operation, "setup_incomplete", hold.reason))
+                    raise
+                except Exception:
+                    if operation.get("action") == "create":
+                        applied.append(self._failure_receipt(plan, operation, "setup_incomplete", "native_call_error"))
+                        raise RunnerHold("setup_incomplete", "native_call_error")
+                    raise RunnerHold("partial_hold", "native_call_error")
             return {"status": "ready", "project_id": plan["project_id"], "logical_rolehub_id": plan["logical_rolehub_id"], "operations": applied}
         except RunnerHold as hold:
-            return {"status": hold.status, "reason": hold.reason, "operations": []}
+            return {"status": hold.status, "reason": hold.reason, "operations": applied}
         except Exception:
             # Do not surface host errors, RPC payloads, or exception text in a
             # durable receipt.  The Coordinator can request an independent retry.
-            return {"status": "partial_hold", "reason": "native_call_error", "operations": []}
+            return {"status": "partial_hold", "reason": "native_call_error", "operations": applied}
+
+    def _failure_receipt(self, plan: dict[str, Any], op: dict[str, Any], status: str, reason: str) -> dict[str, Any]:
+        receipt = self._receipt(plan, op, status, {"availability": "unknown", "reason": reason})
+        self.receipts[op["idempotency_key"]] = receipt
+        return receipt
 
     def _operation(self, plan: dict[str, Any], op: dict[str, Any]) -> dict[str, Any]:
         key = op["idempotency_key"]
@@ -180,6 +196,8 @@ class CodexRoleHubRunner:
         self._sequence += 1
         receipt = self._receipt(plan, op, "applied", {**after, "created": created, "native_id_held_in_memory": True})
         self.receipts[key] = receipt
+        if action == "name":
+            self.rollback_records[key] = {"fingerprint": receipt["operation_fingerprint"], "previous_title": before.get("title"), "native_id": native_id, "operation_id": op["operation_id"]}
         return receipt
 
     def rollback(self, receipts: list[dict[str, Any]]) -> dict[str, Any]:
@@ -191,7 +209,10 @@ class CodexRoleHubRunner:
             readback = receipt.get("readback", {})
             previous = readback.get("previous_title") if isinstance(readback, dict) else None
             key = receipt.get("idempotency_key")
-            native_id = self.native_ids.get(key)
+            stored = self.rollback_records.get(key)
+            if not stored or receipt.get("operation_fingerprint") != stored.get("fingerprint") or previous != stored.get("previous_title"):
+                return {"status": "rollback_incomplete", "reason": "reverse_receipt_mismatch", "reversed_operation_ids": reversed_ids}
+            native_id = stored.get("native_id")
             if not isinstance(previous, str) or not native_id:
                 return {"status": "rollback_incomplete", "reason": "reverse_receipt_unavailable", "reversed_operation_ids": reversed_ids}
             try:

--- a/scripts/codex_rolehub_runner.py
+++ b/scripts/codex_rolehub_runner.py
@@ -170,7 +170,9 @@ class CodexRoleHubRunner:
         expected = op.get("preimage_digest")
         if expected and expected != before["digest"]:
             raise RunnerHold("partial_hold", "stale_preimage")
-        if action == "name":
+        if action == "create" and isinstance(op.get("title"), str) and op["title"]:
+            self._call("thread/name/set", {"threadId": native_id, "name": op["title"]})
+        elif action == "name":
             self._call("thread/name/set", {"threadId": native_id, "name": op.get("title", "")})
         after = self._readback(native_id)
         if action == "name" and isinstance(before.get("title"), str):

--- a/scripts/codex_rolehub_runner.py
+++ b/scripts/codex_rolehub_runner.py
@@ -136,7 +136,10 @@ class CodexRoleHubRunner:
         native_id = self.native_ids.get(key)
         created = False
         if action == "create":
-            result = self._call("thread/start", {"cwd": plan.get("capability_evidence", {}).get("cwd", "")})
+            cwd = plan.get("capability_evidence", {}).get("cwd")
+            if not isinstance(cwd, str) or not cwd:
+                raise RunnerHold("partial_hold", "cwd_unproven")
+            result = self._call("thread/start", {"cwd": cwd})
             if not isinstance(result, dict):
                 raise RunnerHold("setup_incomplete", "thread_start_no_receipt")
             native_id = result.get("threadId") or result.get("id")

--- a/scripts/codex_rolehub_runner.py
+++ b/scripts/codex_rolehub_runner.py
@@ -117,6 +117,10 @@ class CodexRoleHubRunner:
             return {"status": "ready", "project_id": plan["project_id"], "logical_rolehub_id": plan["logical_rolehub_id"], "operations": applied}
         except RunnerHold as hold:
             return {"status": hold.status, "reason": hold.reason, "operations": []}
+        except Exception:
+            # Do not surface host errors, RPC payloads, or exception text in a
+            # durable receipt.  The Coordinator can request an independent retry.
+            return {"status": "partial_hold", "reason": "native_call_error", "operations": []}
 
     def _operation(self, plan: dict[str, Any], op: dict[str, Any]) -> dict[str, Any]:
         key = op["idempotency_key"]

--- a/scripts/test_codex_rolehub_runner.py
+++ b/scripts/test_codex_rolehub_runner.py
@@ -73,6 +73,15 @@ class RunnerTests(unittest.TestCase):
         self.assertEqual(runner.apply(without_cwd)["reason"], "cwd_unproven")
         self.assertNotIn("thread/start", [method for method, _ in rpc.calls])
 
+    def test_rpc_error_is_structured_and_private(self):
+        class Broken(FakeRPC):
+            def __call__(self, method, params):
+                if method == "thread/start":
+                    raise RuntimeError("secret prompt payload")
+                return super().__call__(method, params)
+        result = CodexRoleHubRunner(Broken(), runtime_id="rt-1").apply(plan(op()))
+        self.assertEqual(result, {"status": "partial_hold", "reason": "native_call_error", "operations": []})
+
     def test_logical_link_and_navigation_hold(self):
         rpc = FakeRPC(); runner = CodexRoleHubRunner(rpc, runtime_id="rt-1")
         result = runner.apply(plan(op("link", target_ref="github:issue:501"), op("navigate", key="k2")))

--- a/scripts/test_codex_rolehub_runner.py
+++ b/scripts/test_codex_rolehub_runner.py
@@ -60,6 +60,13 @@ class RunnerTests(unittest.TestCase):
         self.assertEqual(first, second)
         self.assertEqual(runner.apply(plan(op(title="other")))["reason"], "foreign_idempotency_key")
 
+    def test_stale_preimage_holds_before_mutation(self):
+        rpc = FakeRPC(); runner = CodexRoleHubRunner(rpc, runtime_id="rt-1")
+        runner.apply(plan(op("create", title="old")))
+        result = runner.apply(plan(op("name", key="k2", title="new", preimage_digest="sha256:stale")))
+        self.assertEqual(result["reason"], "stale_preimage")
+        self.assertEqual(rpc.threads["t1"]["name"], "old")
+
     def test_schema_drift_and_forbidden_rpc(self):
         rpc = FakeRPC(); runner = CodexRoleHubRunner(rpc, runtime_id="rt-1")
         bad = plan(op()); bad["unexpected"] = True

--- a/scripts/test_codex_rolehub_runner.py
+++ b/scripts/test_codex_rolehub_runner.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+import copy
+import unittest
+
+from codex_rolehub_runner import CodexRoleHubRunner
+
+
+class FakeRPC:
+    def __init__(self):
+        self.calls = []
+        self.threads = {}
+        self.next_id = 1
+
+    def __call__(self, method, params):
+        self.calls.append((method, copy.deepcopy(params)))
+        if method == "initialize":
+            return {"protocolVersion": "1", "capabilities": {"thread": True}}
+        if method == "initialized":
+            return {}
+        if method == "thread/list":
+            return {"threads": [{"id": k, "name": v["name"]} for k, v in self.threads.items()]}
+        if method == "thread/start":
+            tid = f"t{self.next_id}"; self.next_id += 1
+            self.threads[tid] = {"name": ""}
+            return {"threadId": tid}
+        if method == "thread/read":
+            tid = params["threadId"]
+            if tid not in self.threads:
+                raise RuntimeError("foreign")
+            return {"id": tid, "name": self.threads[tid]["name"], "turns": [{"message": "secret"}]}
+        if method == "thread/name/set":
+            self.threads[params["threadId"]]["name"] = params["name"]
+            return {"ok": True}
+        raise AssertionError(method)
+
+
+def plan(*ops):
+    return {"contract_version": "AF18-codex-rolehub-runner-v1", "project_id": "tiny-ipa", "logical_rolehub_id": "tiny-ipa:rolehub", "runtime_id": "rt-1", "capability_evidence": {"trusted": True, "runtime_id": "rt-1", "methods": ["initialize", "initialized", "thread/list", "thread/read", "thread/start", "thread/name/set"], "cwd": "/tmp/tiny-ipa"}, "operations": list(ops)}
+
+
+def op(action="create", key="k1", role="Coordinator", **kwargs):
+    item = {"operation_id": key, "action": action, "idempotency_key": key, "role": role}
+    item.update(kwargs)
+    return item
+
+
+class RunnerTests(unittest.TestCase):
+    def test_preflight_and_create_name_readback(self):
+        rpc = FakeRPC(); runner = CodexRoleHubRunner(rpc, runtime_id="rt-1")
+        self.assertEqual(runner.preflight()["status"], "ready")
+        result = runner.apply(plan(op(title="coord")))
+        self.assertEqual(result["status"], "ready")
+        self.assertTrue(all("includeTurns" not in p or p["includeTurns"] is False for m, p in rpc.calls if m == "thread/read"))
+        self.assertTrue(all("secret" not in str(x) for x in result.values()))
+
+    def test_duplicate_and_foreign_idempotency(self):
+        rpc = FakeRPC(); runner = CodexRoleHubRunner(rpc, runtime_id="rt-1")
+        first = runner.apply(plan(op()))
+        second = runner.apply(plan(op()))
+        self.assertEqual(first, second)
+        self.assertEqual(runner.apply(plan(op(title="other")))["reason"], "foreign_idempotency_key")
+
+    def test_schema_drift_and_forbidden_rpc(self):
+        rpc = FakeRPC(); runner = CodexRoleHubRunner(rpc, runtime_id="rt-1")
+        bad = plan(op()); bad["unexpected"] = True
+        self.assertEqual(runner.apply(bad)["reason"], "schema_drift")
+        with self.assertRaises(Exception):
+            runner._call("turn/start", {})
+
+    def test_logical_link_and_navigation_hold(self):
+        rpc = FakeRPC(); runner = CodexRoleHubRunner(rpc, runtime_id="rt-1")
+        result = runner.apply(plan(op("link", target_ref="github:issue:501"), op("navigate", key="k2")))
+        self.assertEqual(result["status"], "ready")
+        self.assertTrue(all(item["status"] == "partial_hold" for item in result["operations"]))
+        self.assertEqual(len(rpc.calls), 0)
+
+    def test_title_rollback(self):
+        rpc = FakeRPC(); runner = CodexRoleHubRunner(rpc, runtime_id="rt-1")
+        runner.apply(plan(op("create", title="new")))
+        receipt = runner.apply(plan(op("name", title="renamed", key="k2")))
+        self.assertEqual(receipt["status"], "ready")
+        self.assertEqual(runner.rollback(receipt["operations"])["status"], "complete")
+        # No delete is attempted when setup cannot be completed.
+        self.assertNotIn("thread/delete", [m for m, _ in rpc.calls])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_codex_rolehub_runner.py
+++ b/scripts/test_codex_rolehub_runner.py
@@ -117,6 +117,17 @@ class RunnerTests(unittest.TestCase):
         self.assertEqual(rollback["status"], "rollback_incomplete")
         self.assertEqual(rpc.threads["t1"]["name"], "new")
 
+    def test_forged_digest_and_external_rename_are_rejected(self):
+        rpc = FakeRPC(); runner = CodexRoleHubRunner(rpc, runtime_id="rt-1")
+        runner.apply(plan(op("create", title="old")))
+        result = runner.apply(plan(op("name", title="new", key="named")))
+        forged = copy.deepcopy(result["operations"][0])
+        forged["readback"]["digest"] = "sha256:forged"
+        self.assertEqual(runner.rollback([forged])["status"], "rollback_incomplete")
+        rpc.threads["t1"]["name"] = "changed-externally"
+        self.assertEqual(runner.rollback([result["operations"][0]])["reason"], "current_preimage_changed")
+        self.assertEqual(rpc.threads["t1"]["name"], "changed-externally")
+
     def test_logical_link_and_navigation_hold(self):
         rpc = FakeRPC(); runner = CodexRoleHubRunner(rpc, runtime_id="rt-1")
         result = runner.apply(plan(op("link", target_ref="github:issue:501"), op("navigate", key="k2")))

--- a/scripts/test_codex_rolehub_runner.py
+++ b/scripts/test_codex_rolehub_runner.py
@@ -87,7 +87,35 @@ class RunnerTests(unittest.TestCase):
                     raise RuntimeError("secret prompt payload")
                 return super().__call__(method, params)
         result = CodexRoleHubRunner(Broken(), runtime_id="rt-1").apply(plan(op()))
-        self.assertEqual(result, {"status": "partial_hold", "reason": "native_call_error", "operations": []})
+        self.assertEqual(result["status"], "setup_incomplete")
+        self.assertEqual(result["operations"][0]["status"], "setup_incomplete")
+
+    def test_new_thread_failure_is_setup_incomplete_with_receipt(self):
+        class Broken(FakeRPC):
+            def __call__(self, method, params):
+                if method == "thread/start":
+                    raise RuntimeError("private native error")
+                return super().__call__(method, params)
+        result = CodexRoleHubRunner(Broken(), runtime_id="rt-1").apply(plan(op()))
+        self.assertEqual(result["status"], "setup_incomplete")
+        self.assertEqual(result["operations"][0]["status"], "setup_incomplete")
+        self.assertNotIn("private", str(result))
+
+    def test_mid_plan_failure_preserves_applied_evidence(self):
+        rpc = FakeRPC(); runner = CodexRoleHubRunner(rpc, runtime_id="rt-1")
+        result = runner.apply(plan(op("create", key="first"), op("name", key="second", role="Reviewer")))
+        self.assertEqual(result["status"], "partial_hold")
+        self.assertEqual(result["operations"][0]["status"], "applied")
+
+    def test_forged_rollback_receipt_is_rejected(self):
+        rpc = FakeRPC(); runner = CodexRoleHubRunner(rpc, runtime_id="rt-1")
+        runner.apply(plan(op("create", title="old")))
+        result = runner.apply(plan(op("name", title="new", key="named")))
+        forged = copy.deepcopy(result["operations"][0])
+        forged["readback"]["previous_title"] = "forged"
+        rollback = runner.rollback([forged])
+        self.assertEqual(rollback["status"], "rollback_incomplete")
+        self.assertEqual(rpc.threads["t1"]["name"], "new")
 
     def test_logical_link_and_navigation_hold(self):
         rpc = FakeRPC(); runner = CodexRoleHubRunner(rpc, runtime_id="rt-1")

--- a/scripts/test_codex_rolehub_runner.py
+++ b/scripts/test_codex_rolehub_runner.py
@@ -67,6 +67,12 @@ class RunnerTests(unittest.TestCase):
         with self.assertRaises(Exception):
             runner._call("turn/start", {})
 
+    def test_no_cwd_fails_closed(self):
+        rpc = FakeRPC(); runner = CodexRoleHubRunner(rpc, runtime_id="rt-1")
+        without_cwd = plan(op()); del without_cwd["capability_evidence"]["cwd"]
+        self.assertEqual(runner.apply(without_cwd)["reason"], "cwd_unproven")
+        self.assertNotIn("thread/start", [method for method, _ in rpc.calls])
+
     def test_logical_link_and_navigation_hold(self):
         rpc = FakeRPC(); runner = CodexRoleHubRunner(rpc, runtime_id="rt-1")
         result = runner.apply(plan(op("link", target_ref="github:issue:501"), op("navigate", key="k2")))


### PR DESCRIPTION
## Summary
Implements the bounded generic Codex RoleHub runner for AF18 #505.

- allowlisted JSON-RPC methods only; no history/turn listing, deletion, shell, filesystem, config, plugin, MCP, or turn/start
- in-memory native IDs and privacy-safe opaque receipts
- create/reuse/idempotence, preimage/readback, title rollback and fail-closed hold states
- fake JSON-RPC tests for duplicate/foreign/stale/privacy/schema drift/no-history/no-cwd/rollback paths

Base: integration branch containing #503 merge d2d59da0652886a8eb0708ca22be7bdf7e668ca6
No tiny-ipa, Vault, runtime, main, or release changes.
