### PR TITLE
fix: decode nested Codex thread responses

### DIFF
--- a/scripts/codex_rolehub_runner.py
+++ b/scripts/codex_rolehub_runner.py
@@ -50,6 +50,7 @@ class CodexRoleHubRunner:
         self.rpc = rpc
         self.runtime_id = runtime_id
         self.native_ids: dict[str, str] = {}
+        self.native_cwds: dict[str, str] = {}
         self.role_native: dict[str, str] = {}
         self.receipts: dict[str, dict[str, Any]] = {}
         self.rollback_records: dict[str, dict[str, Any]] = {}
@@ -64,16 +65,33 @@ class CodexRoleHubRunner:
     def _readback(self, native_id: str) -> dict[str, Any]:
         # includeTurns is explicitly false; the runner never reads transcript history.
         value = self._call("thread/read", {"threadId": native_id, "includeTurns": False})
-        if not isinstance(value, dict):
-            raise RunnerHold("partial_hold", "readback_not_object")
-        result = {"digest": digest(value), "opaque_ref": "native:" + digest(native_id)[:24]}
+        metadata = self._decode_thread(value, expected_id=native_id, expected_cwd=self.native_cwds.get(native_id), reason_prefix="readback")
+        result = {"digest": digest(metadata), "opaque_ref": "native:" + digest(native_id)[:24]}
         # Titles are metadata needed for a bounded reverse receipt; no body or turns
         # are retained.  The native id itself is never put in a durable receipt.
-        if isinstance(value.get("name"), str):
-            result["title"] = value["name"]
-        elif isinstance(value.get("title"), str):
-            result["title"] = value["title"]
+        result["title"] = metadata["name"]
         return result
+
+    def _decode_thread(
+        self,
+        value: Any,
+        *,
+        expected_id: str | None = None,
+        expected_cwd: str | None = None,
+        reason_prefix: str,
+    ) -> dict[str, str]:
+        """Decode app-server 0.133.0 nested Thread*Response metadata only."""
+        if not isinstance(value, dict) or not isinstance(value.get("thread"), dict):
+            raise RunnerHold("setup_incomplete", reason_prefix + "_malformed")
+        thread = value["thread"]
+        thread_id, cwd, name = thread.get("id"), thread.get("cwd"), thread.get("name")
+        if not all(isinstance(item, str) and item for item in (thread_id, cwd)) or not isinstance(name, str):
+            raise RunnerHold("setup_incomplete", reason_prefix + "_missing_metadata")
+        if expected_id is not None and thread_id != expected_id:
+            raise RunnerHold("partial_hold", reason_prefix + "_foreign_id")
+        if expected_cwd is not None and cwd != expected_cwd:
+            raise RunnerHold("partial_hold", reason_prefix + "_foreign_cwd")
+        return {"id": thread_id, "cwd": cwd, "name": name}
 
     def preflight(self) -> dict[str, Any]:
         try:
@@ -117,7 +135,7 @@ class CodexRoleHubRunner:
                 try:
                     applied.append(self._operation(plan, operation))
                 except RunnerHold as hold:
-                    if operation.get("action") == "create" and hold.reason in {"native_call_error", "readback_not_object", "native_id_unavailable"}:
+                    if operation.get("action") == "create" and hold.status == "setup_incomplete":
                         applied.append(self._failure_receipt(plan, operation, "setup_incomplete", hold.reason))
                     raise
                 except Exception:
@@ -160,12 +178,10 @@ class CodexRoleHubRunner:
             if not isinstance(cwd, str) or not cwd:
                 raise RunnerHold("partial_hold", "cwd_unproven")
             result = self._call("thread/start", {"cwd": cwd})
-            if not isinstance(result, dict):
-                raise RunnerHold("setup_incomplete", "thread_start_no_receipt")
-            native_id = result.get("threadId") or result.get("id")
-            if not isinstance(native_id, str) or not native_id:
-                raise RunnerHold("setup_incomplete", "native_id_unavailable")
+            metadata = self._decode_thread(result, expected_cwd=cwd, reason_prefix="thread_start")
+            native_id = metadata["id"]
             self.native_ids[key] = native_id
+            self.native_cwds[native_id] = cwd
             self.role_native[op["role"]] = native_id
             created = True
         elif action == "reuse":

--- a/scripts/test_codex_rolehub_runner.py
+++ b/scripts/test_codex_rolehub_runner.py
@@ -21,13 +21,13 @@ class FakeRPC:
             return {"threads": [{"id": k, "name": v["name"]} for k, v in self.threads.items()]}
         if method == "thread/start":
             tid = f"t{self.next_id}"; self.next_id += 1
-            self.threads[tid] = {"name": ""}
-            return {"threadId": tid}
+            self.threads[tid] = {"name": "", "cwd": params["cwd"]}
+            return {"thread": {"id": tid, "cwd": params["cwd"], "name": ""}}
         if method == "thread/read":
             tid = params["threadId"]
             if tid not in self.threads:
                 raise RuntimeError("foreign")
-            return {"id": tid, "name": self.threads[tid]["name"], "turns": [{"message": "secret"}]}
+            return {"thread": {"id": tid, "cwd": self.threads[tid]["cwd"], "name": self.threads[tid]["name"], "turns": [{"message": "secret"}]}}
         if method == "thread/name/set":
             self.threads[params["threadId"]]["name"] = params["name"]
             return {"ok": True}
@@ -89,6 +89,29 @@ class RunnerTests(unittest.TestCase):
         result = CodexRoleHubRunner(Broken(), runtime_id="rt-1").apply(plan(op()))
         self.assertEqual(result["status"], "setup_incomplete")
         self.assertEqual(result["operations"][0]["status"], "setup_incomplete")
+
+    def test_nested_start_requires_thread_metadata(self):
+        class MissingThread(FakeRPC):
+            def __call__(self, method, params):
+                if method == "thread/start":
+                    return {"thread": {"id": "t1", "name": ""}}
+                return super().__call__(method, params)
+        result = CodexRoleHubRunner(MissingThread(), runtime_id="rt-1").apply(plan(op()))
+        self.assertEqual(result["status"], "setup_incomplete")
+        self.assertEqual(result["operations"][0]["status"], "setup_incomplete")
+        self.assertNotIn("threadId", str(result))
+
+    def test_nested_read_rejects_foreign_cwd(self):
+        class ForeignRead(FakeRPC):
+            def __call__(self, method, params):
+                value = super().__call__(method, params)
+                if method == "thread/read":
+                    value["thread"]["cwd"] = "/foreign"
+                return value
+        rpc = ForeignRead(); runner = CodexRoleHubRunner(rpc, runtime_id="rt-1")
+        result = runner.apply(plan(op()))
+        self.assertEqual(result["status"], "partial_hold")
+        self.assertNotIn("/foreign", str(result))
 
     def test_new_thread_failure_is_setup_incomplete_with_receipt(self):
         class Broken(FakeRPC):


### PR DESCRIPTION
## Summary
- decode Codex app-server 0.133.0 ThreadStartResponse/ThreadReadResponse nested `thread` objects
- validate id, cwd, and name; fail closed on malformed/missing/foreign metadata without echoing raw payloads
- add fake JSON-RPC fixtures for nested responses, missing metadata, and foreign cwd

## Contract
- base: `49db9782acf668b1abe5ce6a5b46d381f66a2e87c`
- allowlist: `scripts/codex_rolehub_runner.py`, `scripts/test_codex_rolehub_runner.py` (schema unchanged)
- no real app-server/native calls; no tiny-ipa, Vault, runtime, main, or release changes

## Verification
- `python3 -m unittest discover -s scripts -p 'test_codex_rolehub_runner.py'` (14 passed)
- `python3 -m py_compile scripts/codex_rolehub_runner.py`
- `git diff --check`
