### PR TITLE
[AF18-12C] Diagnose pinned thread/start contract

### DIFF
--- a/schemas/codex-rolehub-runner.schema.yaml
+++ b/schemas/codex-rolehub-runner.schema.yaml
@@ -9,6 +9,38 @@ properties:
   project_id: {type: string, minLength: 1}
   logical_rolehub_id: {type: string, minLength: 1}
   runtime_id: {type: string, minLength: 1}
+  protocol_contract:
+    type: object
+    additionalProperties: false
+    required: [cli_version, protocol_variant, start_method, start_request, start_response, read_method, read_request]
+    properties:
+      cli_version: {type: string, const: codex-cli 0.133.0}
+      protocol_variant: {type: string, const: v2}
+      start_method: {type: string, const: thread/start}
+      start_request:
+        type: object
+        additionalProperties: false
+        required: [required_fields, optional_fields]
+        properties:
+          required_fields: {type: array, const: [cwd]}
+          optional_fields: {type: array, items: {type: string}, uniqueItems: true}
+      start_response:
+        type: object
+        additionalProperties: false
+        required: [required_fields, extraction_path]
+        properties:
+          required_fields: {type: array, const: [approvalPolicy, approvalsReviewer, cwd, model, modelProvider, sandbox, thread]}
+          extraction_path: {type: string, const: thread}
+          thread_required: {type: array, const: [id, cwd]}
+          thread_optional: {type: array, const: [name]}
+      read_method: {type: string, const: thread/read}
+      read_request:
+        type: object
+        additionalProperties: false
+        required: [required_fields, include_turns]
+        properties:
+          required_fields: {type: array, items: {type: string}, const: [threadId]}
+          include_turns: {type: boolean, const: false}
   capability_evidence:
     type: object
     additionalProperties: false

--- a/scripts/codex_rolehub_runner.py
+++ b/scripts/codex_rolehub_runner.py
@@ -27,6 +27,97 @@ ALLOWED_METHODS = {"initialize", "initialized", "thread/list", "thread/read", "t
 FORBIDDEN_METHODS = {"history", "turn/list", "thread/archive", "thread/delete", "turn/start", "shell", "filesystem", "config", "plugin", "mcp"}
 PRIVATE_KEYS = {"prompt", "body", "message", "messages", "content", "transcript", "turns", "tool_output", "raw_log"}
 
+# This is a static, checked-in description of the codex-cli 0.133.0 v2
+# app-server contract.  It is data for diagnosis, not a transport client.
+START_CONTRACT = {
+    "cli_version": "codex-cli 0.133.0",
+    "protocol_variant": "v2",
+    "start_method": "thread/start",
+    "start_request": {
+        "required": ["cwd"],
+        "optional": [
+            "approvalPolicy", "approvalsReviewer", "baseInstructions", "config",
+            "developerInstructions", "sandbox", "serviceName", "ephemeral",
+            "sessionStartSource", "personality", "model", "modelProvider",
+            "serviceTier", "threadSource",
+        ],
+    },
+    "start_response": {
+        "required": ["approvalPolicy", "approvalsReviewer", "cwd", "model", "modelProvider", "sandbox", "thread"],
+        "extract": "thread",
+        # The protocol requires id/cwd for correlation; name is optional and
+        # may be null in the upstream Thread object.
+        "thread_required": ["id", "cwd"],
+        "thread_optional": ["name"],
+    },
+    "read_method": "thread/read",
+    "read_request": {"required": ["threadId"], "optional": ["includeTurns"], "includeTurns": False},
+    "correlation": ["thread.id", "thread.cwd"],
+}
+
+
+def diagnose_thread_start_contract(sample: Any) -> dict[str, Any]:
+    """Validate a captured, metadata-only protocol sample without I/O.
+
+    The sample is intentionally a plain fixture: callers must provide the
+    static contract evidence and sanitized response objects.  No app-server,
+    filesystem, transcript, or raw error access occurs here.
+    """
+    safe = {"status": "held_start_contract_unresolved", "contract": "AF18-codex-rolehub-runner-v1"}
+    def hold(reason: str, status: str = "held_start_contract_unresolved") -> dict[str, Any]:
+        safe["status"], safe["reason"] = status, reason
+        return safe
+    if not isinstance(sample, dict):
+        return hold("sample_not_object")
+    if sample.get("cli_version") != START_CONTRACT["cli_version"] or sample.get("protocol_variant") != START_CONTRACT["protocol_variant"]:
+        return hold("version_or_protocol_mismatch")
+    if sample.get("start_method") != START_CONTRACT["start_method"] or sample.get("read_method") != START_CONTRACT["read_method"]:
+        return hold("method_mismatch")
+    request = sample.get("start_request")
+    if not isinstance(request, dict) or not isinstance(request.get("cwd"), str) or not request["cwd"]:
+        return hold("start_required_cwd_missing")
+    allowed_request = set(START_CONTRACT["start_request"]["required"] + START_CONTRACT["start_request"]["optional"])
+    if set(request) - allowed_request or any(not isinstance(k, str) for k in request):
+        return hold("start_request_unknown_field")
+    string_fields = allowed_request - {"config", "ephemeral"}
+    if any(field in request and not isinstance(request[field], str) for field in string_fields):
+        return hold("start_request_type_error")
+    if "config" in request and not isinstance(request["config"], dict):
+        return hold("start_request_type_error")
+    if "ephemeral" in request and not isinstance(request["ephemeral"], bool):
+        return hold("start_request_type_error")
+    response = sample.get("start_response")
+    if not isinstance(response, dict):
+        return hold("start_response_missing", "setup_incomplete")
+    if response.get("protocol_error") is True or "error" in response:
+        return hold("protocol_error", "setup_incomplete")
+    allowed_response = set(START_CONTRACT["start_response"]["required"] + ["serviceTier", "instructionSources", "reasoningEffort"])
+    if set(response) - allowed_response:
+        return hold("start_response_unknown_field", "setup_incomplete")
+    required = START_CONTRACT["start_response"]["required"]
+    if any(field not in response for field in required):
+        return hold("start_response_required_missing", "setup_incomplete")
+    thread = response.get("thread")
+    if not isinstance(thread, dict) or not isinstance(thread.get("id"), str) or not thread["id"]:
+        return hold("nested_thread_id_missing", "setup_incomplete")
+    if not isinstance(thread.get("cwd"), str) or ("name" in thread and thread["name"] is not None and not isinstance(thread["name"], str)):
+        return hold("nested_thread_metadata_type_error", "setup_incomplete")
+    if not isinstance(thread.get("cwd"), str) or thread["cwd"] != request["cwd"]:
+        return hold("foreign_cwd", "setup_incomplete")
+    read = sample.get("readback")
+    if not isinstance(read, dict) or not isinstance(read.get("thread"), dict):
+        return hold("readback_missing", "setup_incomplete")
+    read_thread = read["thread"]
+    if read_thread.get("id") != thread["id"] or read_thread.get("cwd") != request["cwd"]:
+        return hold("readback_correlation_mismatch", "setup_incomplete")
+    safe.update({"status": "ready", "method": START_CONTRACT["start_method"], "response_path": "thread", "opaque_ref": "native:" + digest(thread["id"])[8:32]})
+    return safe
+
+
+# Short alias for callers that use the contract's noun rather than the RPC
+# method name.
+diagnose_start_contract = diagnose_thread_start_contract
+
 
 class RunnerHold(Exception):
     def __init__(self, status: str, reason: str):

--- a/scripts/test_codex_rolehub_runner.py
+++ b/scripts/test_codex_rolehub_runner.py
@@ -2,7 +2,7 @@
 import copy
 import unittest
 
-from codex_rolehub_runner import CodexRoleHubRunner
+from codex_rolehub_runner import CodexRoleHubRunner, START_CONTRACT, diagnose_thread_start_contract
 
 
 class FakeRPC:
@@ -45,6 +45,47 @@ def op(action="create", key="k1", role="Coordinator", **kwargs):
 
 
 class RunnerTests(unittest.TestCase):
+    def start_sample(self):
+        thread = {"id": "t1", "cwd": "/tmp/tiny-ipa", "name": "Coordinator"}
+        response = {field: ("x" if field not in {"cwd", "thread"} else ("/tmp/tiny-ipa" if field == "cwd" else thread)) for field in START_CONTRACT["start_response"]["required"]}
+        return {"cli_version": "codex-cli 0.133.0", "protocol_variant": "v2", "start_method": "thread/start", "read_method": "thread/read", "start_request": {"cwd": "/tmp/tiny-ipa"}, "start_response": response, "readback": {"thread": copy.deepcopy(thread)}}
+
+    def test_static_start_contract_valid_and_privacy_safe(self):
+        sample = self.start_sample(); sample["start_response"]["turns"] = [{"prompt": "secret"}]
+        result = diagnose_thread_start_contract(sample)
+        self.assertEqual(result["status"], "setup_incomplete")
+        self.assertNotIn("secret", str(result))
+
+    def test_static_start_contract_valid(self):
+        self.assertEqual(diagnose_thread_start_contract(self.start_sample())["status"], "ready")
+
+    def test_static_contract_missing_required_and_unknown_type(self):
+        sample = self.start_sample(); del sample["start_request"]["cwd"]
+        self.assertEqual(diagnose_thread_start_contract(sample)["reason"], "start_required_cwd_missing")
+        sample = self.start_sample(); sample["start_request"]["cwd"] = 7
+        self.assertEqual(diagnose_thread_start_contract(sample)["reason"], "start_required_cwd_missing")
+        sample = self.start_sample(); sample["start_request"]["unexpected"] = True
+        self.assertEqual(diagnose_thread_start_contract(sample)["reason"], "start_request_unknown_field")
+
+    def test_static_contract_protocol_and_response_failures(self):
+        sample = self.start_sample(); sample["protocol_variant"] = "v1"
+        self.assertEqual(diagnose_thread_start_contract(sample)["reason"], "version_or_protocol_mismatch")
+        sample = self.start_sample(); sample["start_response"] = {"error": {"message": "secret"}}
+        result = diagnose_thread_start_contract(sample)
+        self.assertEqual(result["reason"], "protocol_error"); self.assertNotIn("secret", str(result))
+        sample = self.start_sample(); del sample["start_response"]["thread"]
+        self.assertEqual(diagnose_thread_start_contract(sample)["reason"], "start_response_required_missing")
+        sample = self.start_sample(); sample["start_response"]["thread"]["id"] = None
+        self.assertEqual(diagnose_thread_start_contract(sample)["reason"], "nested_thread_id_missing")
+
+    def test_static_contract_correlation_and_readback(self):
+        sample = self.start_sample(); sample["start_response"]["thread"]["cwd"] = "/foreign"
+        self.assertEqual(diagnose_thread_start_contract(sample)["reason"], "foreign_cwd")
+        sample = self.start_sample(); sample["readback"]["thread"]["id"] = "other"
+        self.assertEqual(diagnose_thread_start_contract(sample)["reason"], "readback_correlation_mismatch")
+        sample = self.start_sample(); sample.pop("readback")
+        self.assertEqual(diagnose_thread_start_contract(sample)["reason"], "readback_missing")
+
     def test_preflight_and_create_name_readback(self):
         rpc = FakeRPC(); runner = CodexRoleHubRunner(rpc, runtime_id="rt-1")
         self.assertEqual(runner.preflight()["status"], "ready")


### PR DESCRIPTION
## Scope

Implements the Architect-accepted #510 diagnostic contract from base `b608d5ac6338afeeea5b9af83dd0ee3dfd1f506b`.

- Adds a checked-in codex-cli 0.133.0/v2 static `thread/start` and `thread/read` contract.
- Adds pure metadata-only `diagnose_thread_start_contract` validation with privacy-safe fixed reasons.
- Distinguishes unresolved version/method/request contract from setup-incomplete response/readback evidence.
- Covers required/optional fields, unknown/type errors, protocol errors, nested/missing response, missing id, foreign cwd, missing/mismatched readback, and private payload non-disclosure.

No app-server/native calls, #506 retry, tiny-ipa access, transcript/history/raw output, Vault/runtime/main/release mutation. Allowlist is exactly the three files in the issue contract.

Tests: `python3 scripts/test_codex_rolehub_runner.py`; `python3 scripts/test_bounded_collaboration_onboarding.py`; `python3 -m py_compile scripts/codex_rolehub_runner.py`.
