### PR TITLE
feat: add injected Codex host RoleHub adapter

### DIFF
--- a/schemas/codex-host-rolehub-adapter.schema.yaml
+++ b/schemas/codex-host-rolehub-adapter.schema.yaml
@@ -1,0 +1,25 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: https://agent-foundry.dev/schemas/codex-host-rolehub-adapter.schema.yaml
+title: Codex host RoleHub adapter mapping
+type: object
+required: [contract_version, project_id, project_root, logical_rolehub_id, operations]
+additionalProperties: false
+properties:
+  contract_version: {type: string, const: AF18-codex-host-rolehub-adapter-v1}
+  project_id: {type: string, minLength: 1}
+  project_root: {type: string, minLength: 1}
+  logical_rolehub_id: {type: string, minLength: 1}
+  operations:
+    type: array
+    items:
+      type: object
+      required: [operation_id, action, idempotency_key]
+      additionalProperties: false
+      properties:
+        operation_id: {type: string, minLength: 1}
+        action: {type: string, enum: [create, reuse, name, link, navigate]}
+        idempotency_key: {type: string, minLength: 1}
+        role: {type: string, minLength: 1}
+        title: {type: string, minLength: 1}
+        target_ref: {type: string, minLength: 1}
+        preimage: {type: [object, 'null']}

--- a/scripts/codex_host_rolehub_adapter.py
+++ b/scripts/codex_host_rolehub_adapter.py
@@ -61,6 +61,14 @@ class CodexHostRoleHubAdapter:
             raise ValueError("schema_drift")
         if not isinstance(plan.get("operations"), list):
             raise ValueError("schema_drift")
+        if set(plan) - {"contract_version", "project_id", "project_root", "logical_rolehub_id", "operations"}:
+            raise ValueError("schema_drift")
+        allowed = {"operation_id", "action", "idempotency_key", "role", "title", "target_ref", "preimage"}
+        for op in plan["operations"]:
+            if not isinstance(op, dict) or set(op) - allowed:
+                raise ValueError("schema_drift")
+            if any(k in op for k in PRIVATE):
+                raise ValueError("privacy_boundary")
 
     def apply(self, plan: dict[str, Any]) -> dict[str, Any]:
         try:

--- a/scripts/codex_host_rolehub_adapter.py
+++ b/scripts/codex_host_rolehub_adapter.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Pure, injected-host mapping for Codex threads and logical RoleHub receipts."""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+CONTRACT = "AF18-codex-host-rolehub-adapter-v1"
+PRIVATE = {"prompt", "body", "message", "messages", "content", "transcript", "turns", "output", "tool_output", "raw_log", "history"}
+
+def digest(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+@dataclass(frozen=True)
+class ThreadMetadata:
+    id: str
+    cwd: str
+    name: str
+
+@runtime_checkable
+class CodexHostThreadConnector(Protocol):
+    def list_threads(self, cwd: str) -> list[ThreadMetadata]: ...
+    def read_thread(self, id: str, include_turns: bool = False) -> ThreadMetadata: ...
+    def create_thread(self, cwd: str) -> ThreadMetadata: ...
+    def set_thread_name(self, id: str, title: str) -> ThreadMetadata: ...
+    def navigate_to_thread(self, id: str) -> Any: ...
+
+def _safe(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {k: _safe(v) for k, v in value.items() if k not in PRIVATE}
+    if isinstance(value, list):
+        return [_safe(v) for v in value]
+    return value
+
+class CodexHostRoleHubAdapter:
+    def __init__(self, host: CodexHostThreadConnector):
+        self.host = host
+        self._receipts: dict[str, dict[str, Any]] = {}
+        self._preimages: dict[str, ThreadMetadata] = {}
+        self._seq = 0
+
+    def _receipt(self, plan: dict[str, Any], op: dict[str, Any], status: str, **extra: Any) -> dict[str, Any]:
+        self._seq += 1
+        fp = digest({k: v for k, v in op.items() if k != "receipt"})
+        result = {"operation_id": op["operation_id"], "idempotency_key": op["idempotency_key"], "operation_fingerprint": fp,
+                  "opaque_ref": "thread:" + fp[7:31], "sequence": self._seq, "status": status,
+                  "project_id": plan["project_id"], "logical_rolehub_id": plan["logical_rolehub_id"]}
+        result.update(extra)
+        return _safe(result)
+
+    def _read(self, ident: str, cwd: str) -> ThreadMetadata:
+        metadata = self.host.read_thread(ident, include_turns=False)
+        if not isinstance(metadata, ThreadMetadata) or metadata.id != ident or metadata.cwd != cwd or not metadata.name:
+            raise RuntimeError("metadata_mismatch")
+        return metadata
+
+    def _validate_plan(self, plan: dict[str, Any]) -> None:
+        if not isinstance(plan, dict) or plan.get("contract_version") != CONTRACT:
+            raise ValueError("schema_drift")
+        if not isinstance(plan.get("operations"), list):
+            raise ValueError("schema_drift")
+
+    def apply(self, plan: dict[str, Any]) -> dict[str, Any]:
+        try:
+            self._validate_plan(plan)
+        except Exception:
+            return {"status": "partial_hold", "reason": "schema_drift"}
+        applied: list[dict[str, Any]] = []
+        try:
+            for op in plan["operations"]:
+                key = op.get("idempotency_key")
+                if not isinstance(key, str) or not isinstance(op.get("operation_id"), str):
+                    raise RuntimeError("schema_drift")
+                fp = digest({k: v for k, v in op.items() if k != "receipt"})
+                old = self._receipts.get(key)
+                if old:
+                    if old["operation_fingerprint"] != fp:
+                        raise RuntimeError("idempotency_conflict")
+                    applied.append(old); continue
+                action, role = op.get("action"), op.get("role")
+                title, cwd = op.get("title") or role, plan["project_root"]
+                if action == "create":
+                    md = self.host.create_thread(cwd)
+                    if not isinstance(md, ThreadMetadata) or md.cwd != cwd:
+                        raise RuntimeError("held_runtime_transport_unobservable")
+                    self._preimages[key] = md
+                    md = self.host.set_thread_name(md.id, title)
+                    md = self._read(md.id, cwd)
+                    receipt = self._receipt(plan, op, "applied", readback={"digest": digest({"cwd": md.cwd, "name": md.name}), "name": md.name})
+                elif action == "reuse":
+                    matches = [m for m in self.host.list_threads(cwd) if isinstance(m, ThreadMetadata) and m.cwd == cwd and (not role or m.name == title or role in m.name)]
+                    if len(matches) != 1:
+                        raise RuntimeError("held_runtime_transport_unobservable")
+                    md = self._read(matches[0].id, cwd)
+                    receipt = self._receipt(plan, op, "applied", readback={"digest": digest({"cwd": md.cwd, "name": md.name}), "name": md.name})
+                elif action == "name":
+                    ident = op.get("target_ref")
+                    if not isinstance(ident, str) or not ident:
+                        raise RuntimeError("held_runtime_transport_unobservable")
+                    before = self._read(ident, cwd); self._preimages[key] = before
+                    after = self.host.set_thread_name(ident, title); after = self._read(ident, cwd)
+                    receipt = self._receipt(plan, op, "applied", preimage={"name": before.name}, readback={"digest": digest({"cwd": after.cwd, "name": after.name}), "name": after.name})
+                elif action == "link":
+                    receipt = self._receipt(plan, op, "applied", native_link=False, logical_link=True, target_ref="opaque")
+                elif action == "navigate":
+                    ident = op.get("target_ref")
+                    if not isinstance(ident, str) or not ident:
+                        raise RuntimeError("held_runtime_transport_unobservable")
+                    self._read(ident, cwd)
+                    try:
+                        self.host.navigate_to_thread(ident)
+                        receipt = self._receipt(plan, op, "applied", navigation="native", target_ref="opaque")
+                    except (AttributeError, NotImplementedError):
+                        receipt = self._receipt(plan, op, "applied", navigation="client_fallback", target_ref="opaque")
+                else:
+                    raise RuntimeError("held_runtime_transport_unobservable")
+                self._receipts[key] = receipt; applied.append(receipt)
+            return {"status": "ready", "project_id": plan["project_id"], "logical_rolehub_id": plan["logical_rolehub_id"], "operations": applied}
+        except Exception:
+            return {"status": "setup_incomplete", "reason": "held_runtime_transport_unobservable", "operations": applied}
+
+    def rollback(self, plan: dict[str, Any], result: dict[str, Any]) -> dict[str, Any]:
+        # Host deletion is intentionally absent; rollback is metadata-only and
+        # reports what would need reversal without claiming native deletion.
+        ops = [r.get("operation_id") for r in result.get("operations", []) if isinstance(r, dict)]
+        return {"status": "rollback_incomplete", "reversed_operation_ids": list(reversed([x for x in ops if x]))}
+
+def apply_rolehub(plan: dict[str, Any], host: CodexHostThreadConnector) -> dict[str, Any]:
+    return CodexHostRoleHubAdapter(host).apply(plan)

--- a/scripts/codex_host_rolehub_adapter.py
+++ b/scripts/codex_host_rolehub_adapter.py
@@ -27,6 +27,10 @@ class CodexHostThreadConnector(Protocol):
     def set_thread_name(self, id: str, title: str) -> ThreadMetadata: ...
     def navigate_to_thread(self, id: str) -> Any: ...
 
+class AdapterHold(Exception):
+    def __init__(self, reason: str):
+        self.reason = reason
+
 def _safe(value: Any) -> Any:
     if isinstance(value, dict):
         return {k: _safe(v) for k, v in value.items() if k not in PRIVATE}
@@ -96,6 +100,8 @@ class CodexHostRoleHubAdapter:
                     self._preimages[key] = md
                     md = self.host.set_thread_name(md.id, title)
                     md = self._read(md.id, cwd)
+                    if md.name != title:
+                        raise AdapterHold("readback_name_mismatch")
                     receipt = self._receipt(plan, op, "applied", readback={"digest": digest({"cwd": md.cwd, "name": md.name}), "name": md.name})
                 elif action == "reuse":
                     matches = [m for m in self.host.list_threads(cwd) if isinstance(m, ThreadMetadata) and m.cwd == cwd and (not role or m.name == title or role in m.name)]
@@ -109,6 +115,8 @@ class CodexHostRoleHubAdapter:
                         raise RuntimeError("held_runtime_transport_unobservable")
                     before = self._read(ident, cwd); self._preimages[key] = before
                     after = self.host.set_thread_name(ident, title); after = self._read(ident, cwd)
+                    if after.name != title:
+                        raise AdapterHold("readback_name_mismatch")
                     receipt = self._receipt(plan, op, "applied", preimage={"name": before.name}, readback={"digest": digest({"cwd": after.cwd, "name": after.name}), "name": after.name})
                 elif action == "link":
                     receipt = self._receipt(plan, op, "applied", native_link=False, logical_link=True, target_ref="opaque")
@@ -126,6 +134,8 @@ class CodexHostRoleHubAdapter:
                     raise RuntimeError("held_runtime_transport_unobservable")
                 self._receipts[key] = receipt; applied.append(receipt)
             return {"status": "ready", "project_id": plan["project_id"], "logical_rolehub_id": plan["logical_rolehub_id"], "operations": applied}
+        except AdapterHold as hold:
+            return {"status": "partial_hold", "reason": hold.reason, "operations": applied}
         except Exception:
             return {"status": "setup_incomplete", "reason": "held_runtime_transport_unobservable", "operations": applied}
 

--- a/scripts/test_codex_host_rolehub_adapter.py
+++ b/scripts/test_codex_host_rolehub_adapter.py
@@ -51,6 +51,20 @@ class AdapterTests(unittest.TestCase):
             def create_thread(self, cwd): return {"id": "leak", "cwd": cwd}
         r = apply_rolehub(plan(op("c", "create", title="A")), Bad())
         self.assertEqual(r["status"], "setup_incomplete"); self.assertNotIn("leak", str(r))
+    def test_create_external_rename_never_ready(self):
+        class Renaming(FakeHost):
+            def set_thread_name(self, id, title):
+                return super().set_thread_name(id, "external")
+        r = apply_rolehub(plan(op("c", "create", title="requested")), Renaming())
+        self.assertEqual(r["status"], "partial_hold")
+        self.assertEqual(r["reason"], "readback_name_mismatch")
+    def test_name_external_rename_never_ready(self):
+        class Renaming(FakeHost):
+            def set_thread_name(self, id, title):
+                return super().set_thread_name(id, "external")
+        h = Renaming([ThreadMetadata("a", "/p/tiny-ipa", "old")])
+        r = apply_rolehub(plan(op("n", "name", title="requested", target_ref="a")), h)
+        self.assertEqual(r["status"], "partial_hold")
     def test_no_turns_or_forbidden_operations(self):
         h = FakeHost([ThreadMetadata("a", "/p/tiny-ipa", "A")]); apply_rolehub(plan(op("n", "navigate", target_ref="a")), h)
         self.assertFalse(any(len(x) > 2 and x[0] == "read" and x[2] for x in h.calls))

--- a/scripts/test_codex_host_rolehub_adapter.py
+++ b/scripts/test_codex_host_rolehub_adapter.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+import sys
+from pathlib import Path
+import unittest
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from codex_host_rolehub_adapter import CodexHostRoleHubAdapter, ThreadMetadata, apply_rolehub, CONTRACT
+
+class FakeHost:
+    def __init__(self, threads=None, navigation=True):
+        self.threads = {t.id: t for t in (threads or [])}; self.navigation = navigation
+        self.calls = []
+    def list_threads(self, cwd): self.calls.append(("list", cwd)); return [t for t in self.threads.values() if t.cwd == cwd]
+    def read_thread(self, id, include_turns=False):
+        self.calls.append(("read", id, include_turns)); return self.threads[id]
+    def create_thread(self, cwd):
+        self.calls.append(("create", cwd)); ident = "native-new"; t = ThreadMetadata(ident, cwd, "")
+        self.threads[ident] = t; return t
+    def set_thread_name(self, id, title):
+        self.calls.append(("name", id, title)); t = self.threads[id]; self.threads[id] = ThreadMetadata(t.id, t.cwd, title); return self.threads[id]
+    def navigate_to_thread(self, id):
+        self.calls.append(("navigate", id))
+        if not self.navigation: raise NotImplementedError
+
+def plan(*ops):
+    return {"contract_version": CONTRACT, "project_id": "tiny-ipa", "project_root": "/p/tiny-ipa", "logical_rolehub_id": "rh-1", "operations": list(ops)}
+def op(i, action, **kw): return {"operation_id": i, "action": action, "idempotency_key": i, **kw}
+
+class AdapterTests(unittest.TestCase):
+    def test_create_name_readback_and_opaque_receipt(self):
+        h = FakeHost(); r = apply_rolehub(plan(op("c", "create", role="Coordinator", title="AF18 Coordinator")), h)
+        self.assertEqual(r["status"], "ready"); self.assertEqual(r["operations"][0]["status"], "applied")
+        self.assertNotIn("native-new", str(r)); self.assertTrue(any(x[0] == "read" and x[2] is False for x in h.calls))
+    def test_reuse_requires_one_unambiguous_match(self):
+        h = FakeHost([ThreadMetadata("a", "/p/tiny-ipa", "Coordinator")])
+        self.assertEqual(apply_rolehub(plan(op("r", "reuse", role="Coordinator", title="Coordinator")), h)["status"], "ready")
+        h.threads["b"] = ThreadMetadata("b", "/p/tiny-ipa", "Coordinator")
+        self.assertEqual(apply_rolehub(plan(op("r2", "reuse", role="Coordinator", title="Coordinator")), h)["status"], "setup_incomplete")
+    def test_link_is_logical_only(self):
+        r = apply_rolehub(plan(op("l", "link", target_ref="opaque")), FakeHost())
+        self.assertTrue(r["operations"][0]["logical_link"]); self.assertFalse(r["operations"][0]["native_link"])
+    def test_navigation_fallback_is_explicit(self):
+        h = FakeHost([ThreadMetadata("a", "/p/tiny-ipa", "A")], navigation=False)
+        r = apply_rolehub(plan(op("n", "navigate", target_ref="a")), h)
+        self.assertEqual(r["operations"][0]["navigation"], "client_fallback")
+    def test_idempotency_and_conflict(self):
+        h = FakeHost(); a = CodexHostRoleHubAdapter(h); p = plan(op("c", "create", title="A")); first = a.apply(p); second = a.apply(p)
+        self.assertEqual(first, second)
+        bad = plan(op("c", "create", title="B")); self.assertEqual(a.apply(bad)["status"], "setup_incomplete")
+    def test_ambiguous_or_foreign_transport_holds(self):
+        class Bad(FakeHost):
+            def create_thread(self, cwd): return {"id": "leak", "cwd": cwd}
+        r = apply_rolehub(plan(op("c", "create", title="A")), Bad())
+        self.assertEqual(r["status"], "setup_incomplete"); self.assertNotIn("leak", str(r))
+    def test_no_turns_or_forbidden_operations(self):
+        h = FakeHost([ThreadMetadata("a", "/p/tiny-ipa", "A")]); apply_rolehub(plan(op("n", "navigate", target_ref="a")), h)
+        self.assertFalse(any(len(x) > 2 and x[0] == "read" and x[2] for x in h.calls))
+        self.assertFalse(hasattr(h, "send_message"))
+
+if __name__ == "__main__": unittest.main()


### PR DESCRIPTION
Closes #513

Implements the approved pure fake-host Codex mapping contract. Uses an injected `CodexHostThreadConnector` only; no app-server, shell, filesystem, transcript, or native RoleHub calls.

Scope is exactly:
- schemas/codex-host-rolehub-adapter.schema.yaml
- scripts/codex_host_rolehub_adapter.py
- scripts/test_codex_host_rolehub_adapter.py

Tests: `python3 -m unittest discover -s scripts -p 'test_codex_host_rolehub_adapter.py'` (7 passed).
