### PR TITLE
AF18 #499 classify Codex project/thread bindings

### DIFF
--- a/schemas/collaboration-routing-policy.schema.yaml
+++ b/schemas/collaboration-routing-policy.schema.yaml
@@ -61,6 +61,13 @@ objects:
       - "invalid input, failed write, failed validation/readback, or fingerprint mismatch preserves the prior effective state and shows one recovery action"
       - "read-only inspection and dry-run preview perform no writes"
       - "new Agent Foundry role task creation prefers project-scoped Codex tasks under local-eb6e22ec0d00ef785d687022be1b433d when creating a new role task"
+  ProjectBindingObservation:
+    required: [project_kind, context_mode, identity, target, fresh_context, runtime_owned_proof]
+    rules:
+      - "project_kind distinguishes local_folder_project, git_repository_project, git_worktree_project, fork_inherited_context, and projectless_fresh_context"
+      - "same-project fresh requires exact project_id, project_root, cwd, fresh_context=true, and runtime-owned proof"
+      - "fork and projectless contexts are held and are never reported as same-project fresh"
+      - "a non-Git local folder without runtime-owned proof is held as held_same_project_fresh_unavailable and requires Human UI fallback"
   OverrideGrant:
     required: [active, scope, expires_after_work_unit, reset_required]
     rules:

--- a/schemas/collaboration-routing-policy.schema.yaml
+++ b/schemas/collaboration-routing-policy.schema.yaml
@@ -67,7 +67,7 @@ objects:
       - "project_kind distinguishes local_folder_project, git_repository_project, git_worktree_project, fork_inherited_context, and projectless_fresh_context"
       - "same-project fresh requires exact project_id, project_root, cwd, fresh_context=true, and runtime-owned proof"
       - "fork and projectless contexts are held and are never reported as same-project fresh"
-      - "a non-Git local folder without runtime-owned proof is held as held_same_project_fresh_unavailable and requires Human UI fallback"
+      - "caller-supplied runtime_owned_proof is never trusted by Core; without trusted host readback every same-project fresh classification remains held_runtime_proof_unverified or held_same_project_fresh_unavailable"
   OverrideGrant:
     required: [active, scope, expires_after_work_unit, reset_required]
     rules:

--- a/scripts/plan_codex_route_adapter.py
+++ b/scripts/plan_codex_route_adapter.py
@@ -50,6 +50,13 @@ FORBIDDEN_RECEIPT_KEYS = {"prompt", "body", "message", "messages", "content", "t
 ROLEHUB_TERMINAL_FAILURE = {"partial_hold", "rolled_back", "rollback_incomplete"}
 ROLEHUB_TERMINAL = ROLEHUB_TERMINAL_FAILURE | {"ready"}
 ROLEHUB_SCHEMA_VALIDATION_FAILURE = "ROLEHUB_SCHEMA_VALIDATION_FAILED"
+PROJECT_BINDING_KINDS = {
+    "local_folder_project",
+    "git_repository_project",
+    "git_worktree_project",
+    "fork_inherited_context",
+    "projectless_fresh_context",
+}
 
 
 def fail(message: str) -> None:
@@ -280,6 +287,60 @@ def project_role_operation(root: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def project_binding_classification(root: dict[str, Any]) -> dict[str, Any]:
+    """Classify a host-reported project/thread binding without calling the host."""
+    observation = root.get("project_binding_observation")
+    if not isinstance(observation, dict):
+        fail("project_binding_observation must be an object")
+    kind = observation.get("project_kind")
+    context = observation.get("context_mode")
+    identity = observation.get("identity")
+    target = observation.get("target")
+    runtime_proof = observation.get("runtime_owned_proof") is True
+    reasons: list[str] = []
+    if kind not in PROJECT_BINDING_KINDS:
+        reasons.append("project_kind is missing or unknown")
+    if context not in {"fresh", "fork", "projectless"}:
+        reasons.append("context_mode must be fresh, fork, or projectless")
+    if not isinstance(identity, dict) or not isinstance(target, dict):
+        reasons.append("exact project identity, root, and cwd are required")
+        identity = identity if isinstance(identity, dict) else {}
+        target = target if isinstance(target, dict) else {}
+    for field in ("project_id", "project_root", "cwd"):
+        if not isinstance(identity.get(field), str) or not identity[field]:
+            reasons.append(f"identity.{field} is missing")
+        if not isinstance(target.get(field), str) or not target[field]:
+            reasons.append(f"target.{field} is missing")
+        elif isinstance(identity.get(field), str) and identity[field] != target[field]:
+            reasons.append(f"target {field} does not match selected project")
+    if observation.get("fresh_context") is not True:
+        reasons.append("fresh_context proof is absent")
+    if context == "fork" or kind == "fork_inherited_context":
+        state, reason = "held_inherited_context_rejected", "fork inherits predecessor history"
+    elif context == "projectless" or kind == "projectless_fresh_context":
+        state, reason = "held_projectless_fallback_rejected", "projectless fresh context loses selected project binding"
+    elif reasons:
+        state, reason = "held_project_binding_mismatch", "exact project identity/root/cwd/freshness proof is incomplete"
+    elif kind == "local_folder_project" and not runtime_proof:
+        state, reason = "held_same_project_fresh_unavailable", "non-Git local-folder API support is not runtime-proven; Human UI fallback required"
+    elif not runtime_proof:
+        state, reason = "held_same_project_fresh_unavailable", "runtime-owned create proof is unavailable"
+    else:
+        state, reason = "same_project_fresh_ready", "metadata proves fresh context and exact selected project binding"
+    return {
+        "adapter": "codex",
+        "state": state,
+        "project_kind": kind if kind in PROJECT_BINDING_KINDS else "unknown",
+        "context_mode": context if context in {"fresh", "fork", "projectless"} else "unknown",
+        "runtime_owned_proof": runtime_proof,
+        "attention": reasons + [reason],
+        "human_ui_fallback_required": state == "held_same_project_fresh_unavailable" and kind == "local_folder_project",
+        "mutation_performed": False,
+        "dispatch_performed": False,
+        "next_action": "Use the supported Human UI path; do not fall back to fork or projectless." if state == "held_same_project_fresh_unavailable" else "Keep the request held until exact binding evidence is available." if state != "same_project_fresh_ready" else "A separately authorized host apply may proceed; this classification performed no call.",
+    }
+
+
 def project_rolehub(root: dict[str, Any]) -> dict[str, Any]:
     """Validate a portable RoleHub projection without invoking a native API."""
     if root.get("contract_version") != "AF18-rolehub-adapter-v1":
@@ -444,6 +505,8 @@ def project_rolehub(root: dict[str, Any]) -> dict[str, Any]:
 
 
 def project(root: dict[str, Any]) -> dict[str, Any]:
+    if "project_binding_observation" in root:
+        return project_binding_classification(root)
     if "rolehub_identity" in root:
         return project_rolehub(root)
     if "role_operation" in root:

--- a/scripts/plan_codex_route_adapter.py
+++ b/scripts/plan_codex_route_adapter.py
@@ -326,7 +326,8 @@ def project_binding_classification(root: dict[str, Any]) -> dict[str, Any]:
     elif not runtime_proof:
         state, reason = "held_same_project_fresh_unavailable", "runtime-owned create proof is unavailable"
     else:
-        state, reason = "same_project_fresh_ready", "metadata proves fresh context and exact selected project binding"
+        # A caller-supplied boolean is not trusted host readback.
+        state, reason = "held_runtime_proof_unverified", "runtime_owned_proof is caller-supplied; trusted host readback is required"
     return {
         "adapter": "codex",
         "state": state,
@@ -337,7 +338,7 @@ def project_binding_classification(root: dict[str, Any]) -> dict[str, Any]:
         "human_ui_fallback_required": state == "held_same_project_fresh_unavailable" and kind == "local_folder_project",
         "mutation_performed": False,
         "dispatch_performed": False,
-        "next_action": "Use the supported Human UI path; do not fall back to fork or projectless." if state == "held_same_project_fresh_unavailable" else "Keep the request held until exact binding evidence is available." if state != "same_project_fresh_ready" else "A separately authorized host apply may proceed; this classification performed no call.",
+        "next_action": "Use the supported Human UI path; do not fall back to fork or projectless." if state == "held_same_project_fresh_unavailable" else "Keep the request held until a trusted host adapter supplies readback; this classifier performed no call.",
     }
 
 

--- a/scripts/test_codex_route_adapter.py
+++ b/scripts/test_codex_route_adapter.py
@@ -135,7 +135,7 @@ def main() -> int:
     expect("non-git-invalid-arguments-hold", code == 0 and output["state"] == "held_same_project_fresh_unavailable" and output["human_ui_fallback_required"] is True and output["mutation_performed"] is False and output["dispatch_performed"] is False, output, errors)
     for kind in ("git_repository_project", "git_worktree_project"):
         code, output = run(binding(kind, runtime=True))
-        expect(f"{kind}-fresh-ready", code == 0 and output["state"] == "same_project_fresh_ready" and output["mutation_performed"] is False, output, errors)
+        expect(f"{kind}-runtime-proof-unverified", code == 0 and output["state"] == "held_runtime_proof_unverified" and output["mutation_performed"] is False and output["dispatch_performed"] is False, output, errors)
     code, output = run(binding("fork_inherited_context", "fork", runtime=True))
     expect("fork-inherited-held", code == 0 and output["state"] == "held_inherited_context_rejected" and output["dispatch_performed"] is False, output, errors)
     code, output = run(binding("projectless_fresh_context", "projectless", runtime=True))
@@ -153,6 +153,9 @@ def main() -> int:
     forged = binding(runtime=True); forged["project_binding_observation"]["runtime_owned_proof"] = False
     code, output = run(forged)
     expect("missing-runtime-proof-held", code == 0 and output["state"] == "held_same_project_fresh_unavailable", output, errors)
+    claimed_ready = binding("git_repository_project", runtime=True)
+    code, output = run(claimed_ready)
+    expect("forged-runtime-proof-never-ready", code == 0 and output["state"] == "held_runtime_proof_unverified" and output["mutation_performed"] is False and output["dispatch_performed"] is False, output, errors)
 
     base = input_for(portable("subagent"))
     code, output = run(base)

--- a/scripts/test_codex_route_adapter.py
+++ b/scripts/test_codex_route_adapter.py
@@ -87,6 +87,19 @@ def input_for(portable_plan: dict, observation: dict | None = None, adapter_enve
     }
 
 
+def binding(kind: str = "local_folder_project", context: str = "fresh", *, runtime: bool = False) -> dict:
+    return {
+        "project_binding_observation": {
+            "project_kind": kind,
+            "context_mode": context,
+            "identity": {"project_id": "git-seres", "project_root": "/projects/git.seres.cn", "cwd": "/projects/git.seres.cn"},
+            "target": {"project_id": "git-seres", "project_root": "/projects/git.seres.cn", "cwd": "/projects/git.seres.cn"},
+            "fresh_context": True,
+            "runtime_owned_proof": runtime,
+        }
+    }
+
+
 def provenance_recovery(output: dict, status: str) -> bool:
     conversation = output["conversation_projection"]
     return (
@@ -118,6 +131,29 @@ def expect(name: str, condition: bool, detail: object, errors: list[str]) -> Non
 
 def main() -> int:
     errors: list[str] = []
+    code, output = run(binding())
+    expect("non-git-invalid-arguments-hold", code == 0 and output["state"] == "held_same_project_fresh_unavailable" and output["human_ui_fallback_required"] is True and output["mutation_performed"] is False and output["dispatch_performed"] is False, output, errors)
+    for kind in ("git_repository_project", "git_worktree_project"):
+        code, output = run(binding(kind, runtime=True))
+        expect(f"{kind}-fresh-ready", code == 0 and output["state"] == "same_project_fresh_ready" and output["mutation_performed"] is False, output, errors)
+    code, output = run(binding("fork_inherited_context", "fork", runtime=True))
+    expect("fork-inherited-held", code == 0 and output["state"] == "held_inherited_context_rejected" and output["dispatch_performed"] is False, output, errors)
+    code, output = run(binding("projectless_fresh_context", "projectless", runtime=True))
+    expect("projectless-held", code == 0 and output["state"] == "held_projectless_fallback_rejected" and output["mutation_performed"] is False, output, errors)
+    mismatch = binding(runtime=True); mismatch["project_binding_observation"]["target"]["cwd"] = "/projects/git.seres.cn/worktree"
+    code, output = run(mismatch)
+    expect("child-root-mismatch-held", code == 0 and output["state"] == "held_project_binding_mismatch", output, errors)
+    for field in ("project_id", "project_root", "cwd"):
+        missing = binding(runtime=True); missing["project_binding_observation"]["identity"].pop(field)
+        code, output = run(missing)
+        expect(f"missing-{field}-held", code == 0 and output["state"] == "held_project_binding_mismatch", output, errors)
+    stale = binding(runtime=True); stale["project_binding_observation"]["fresh_context"] = False
+    code, output = run(stale)
+    expect("missing-freshness-held", code == 0 and output["state"] == "held_project_binding_mismatch", output, errors)
+    forged = binding(runtime=True); forged["project_binding_observation"]["runtime_owned_proof"] = False
+    code, output = run(forged)
+    expect("missing-runtime-proof-held", code == 0 and output["state"] == "held_same_project_fresh_unavailable", output, errors)
+
     base = input_for(portable("subagent"))
     code, output = run(base)
     expect("runtime-capture-unavailable", code == 0 and provenance_recovery(output, "unknown") and output["schema_provenance"]["evidence_ref_status"] == "unverified", output, errors)

--- a/workflows/github-collaboration-helper.md
+++ b/workflows/github-collaboration-helper.md
@@ -163,7 +163,10 @@ Before a host creates a successor thread, classify a metadata-only
 `git_repository_project`, `git_worktree_project`, `fork_inherited_context`, and
 `projectless_fresh_context`. A same-project fresh result is valid only when
 `project_id`, `project_root`, and `cwd` match exactly, `fresh_context` is true,
-and runtime-owned creation proof is present. Forks hold as
+and trusted host readback is present. Core never treats a caller-supplied
+`runtime_owned_proof: true` boolean as trusted and therefore never emits a
+ready result; only a future trusted host adapter may emit
+`same_project_fresh_verified`. Forks hold as
 `held_inherited_context_rejected`; projectless results hold as
 `held_projectless_fallback_rejected`; missing or mismatched identity holds as
 `held_project_binding_mismatch`. A non-Git local folder without runtime-owned

--- a/workflows/github-collaboration-helper.md
+++ b/workflows/github-collaboration-helper.md
@@ -156,6 +156,22 @@ It proposes no real tool call: all adapter output reports
 hooks, custom agents, policy records, runtime installation, and telemetry stay
 outside this pilot.
 
+### Codex project/thread binding classification
+
+Before a host creates a successor thread, classify a metadata-only
+`project_binding_observation`. The classifier distinguishes `local_folder_project`,
+`git_repository_project`, `git_worktree_project`, `fork_inherited_context`, and
+`projectless_fresh_context`. A same-project fresh result is valid only when
+`project_id`, `project_root`, and `cwd` match exactly, `fresh_context` is true,
+and runtime-owned creation proof is present. Forks hold as
+`held_inherited_context_rejected`; projectless results hold as
+`held_projectless_fallback_rejected`; missing or mismatched identity holds as
+`held_project_binding_mismatch`. A non-Git local folder without runtime-owned
+proof holds as `held_same_project_fresh_unavailable` and explicitly requires a
+Human UI fallback. This is classification only: it makes no host call and must
+report both mutation and dispatch as false. Desktop UI success must never be
+used as evidence that the connector supports the same request.
+
 ## User-Facing Entry Points
 
 Agents should expose these as natural-language workflows rather than requiring


### PR DESCRIPTION
## Summary

Implements the Core-only #499 classification/fail-closed contract. This does not call Codex host APIs or claim to repair the non-Git connector.

## Scope

- classify local-folder, Git repository/worktree, fork-inherited, and projectless contexts;
- require exact project id/root/cwd, fresh-context proof, and runtime-owned proof for same-project fresh;
- hold fork, projectless, mismatched identity, and unproven non-Git local-folder creation;
- add metadata-only negative fixtures and preserve mutation/dispatch false;
- document that Desktop UI success does not prove connector support.

## Verification

- `python3 scripts/test_codex_route_adapter.py`
- `python3 -m py_compile scripts/plan_codex_route_adapter.py`
- `git diff --check`

Exact base: `3e360dcf16c1875c3c2f3e181b3f8cb57171b32f`
Exact head: `1894614`

No merge or #499 closure requested. Route this exact head through independent Reviewer -> Tester -> Architect.
