### PR TITLE
[AF18] Model same-project creation boundary state

### DIFF
--- a/schemas/collaboration-routing-policy.schema.yaml
+++ b/schemas/collaboration-routing-policy.schema.yaml
@@ -24,6 +24,13 @@ objects:
     rules:
       - "role specialization, continuity, and independence are separate inputs"
       - "specialization value, project continuity relevance, and independent-review value are not inferred from role label or thread age alone"
+  CreationBoundaryEvidence:
+    required: [terminal_receipt_ref, architect_acceptance_ref, source, digest, opaque_identity_ref, verification_source, create_count, primitive, project_id, cwd, binding_project_id, binding_cwd]
+    rules:
+      - "same_project_creation_boundary_verified requires one create_thread primitive, a new opaque identity, correlated post-create readback, and matching project_id/cwd binding"
+      - "predecessor, fork source, projectless, child worktree, retry, dispatch, transcript, history, and turn reads must all be explicitly false"
+      - "verification_source is durable_scheduler_reference and refs/digest are durable evidence inputs; the projection never verifies them or dispatches"
+      - "freshness_forensic_evidence remains unavailable unless a future host receipt supplies parentThreadId, forkSource, and contextInheritance evidence"
   RuntimeCapabilities:
     required: [observed_at, mechanisms]
     rules:

--- a/schemas/collaboration-routing-policy.schema.yaml
+++ b/schemas/collaboration-routing-policy.schema.yaml
@@ -25,9 +25,9 @@ objects:
       - "role specialization, continuity, and independence are separate inputs"
       - "specialization value, project continuity relevance, and independent-review value are not inferred from role label or thread age alone"
   CreationBoundaryEvidence:
-    required: [terminal_receipt_ref, architect_acceptance_ref, source, digest, opaque_identity_ref, verification_source, create_count, primitive, project_id, cwd, binding_project_id, binding_cwd]
+    required: [terminal_receipt_ref, architect_acceptance_ref, source, digest, opaque_identity_ref, readback_identity_ref, verification_source, create_count, primitive, project_id, cwd, binding_project_id, binding_cwd]
     rules:
-      - "same_project_creation_boundary_verified requires one create_thread primitive, a new opaque identity, correlated post-create readback, and matching project_id/cwd binding"
+      - "same_project_creation_boundary_verified requires one create_thread primitive, a new opaque identity, readback_identity_ref equal to opaque_identity_ref, and matching project_id/cwd binding"
       - "predecessor, fork source, projectless, child worktree, retry, dispatch, transcript, history, and turn reads must all be explicitly false"
       - "verification_source is durable_scheduler_reference and refs/digest are durable evidence inputs; the projection never verifies them or dispatches"
       - "freshness_forensic_evidence remains unavailable unless a future host receipt supplies parentThreadId, forkSource, and contextInheritance evidence"

--- a/scripts/plan_codex_route_adapter.py
+++ b/scripts/plan_codex_route_adapter.py
@@ -288,7 +288,7 @@ def validate_creation_boundary(value: Any) -> tuple[dict[str, Any] | None, list[
     if not isinstance(value, dict):
         return None, ["same-project creation boundary evidence is required"]
     required_refs = (
-        "terminal_receipt_ref", "architect_acceptance_ref", "source", "digest", "opaque_identity_ref",
+        "terminal_receipt_ref", "architect_acceptance_ref", "source", "digest", "opaque_identity_ref", "readback_identity_ref",
     )
     reasons: list[str] = []
     for field in required_refs:
@@ -313,6 +313,8 @@ def validate_creation_boundary(value: Any) -> tuple[dict[str, Any] | None, list[
         reasons.append("creation boundary project binding project_id does not match")
     if value.get("binding_cwd") != value.get("cwd"):
         reasons.append("creation boundary project binding cwd does not match")
+    if value.get("readback_identity_ref") != value.get("opaque_identity_ref"):
+        reasons.append("creation boundary readback identity does not correlate to opaque identity")
     if reasons:
         return None, reasons
     return {

--- a/scripts/plan_codex_route_adapter.py
+++ b/scripts/plan_codex_route_adapter.py
@@ -241,7 +241,17 @@ def project_role_operation(root: dict[str, Any]) -> dict[str, Any]:
         if action == "create" and status == "supported" and provenance == "observed":
             creation_boundary, boundary_reasons = validate_creation_boundary(receipt.get("creation_boundary"))
             reasons.extend(boundary_reasons)
-    if status in {"unsupported", "not_available", "unknown"} or provenance == "unavailable":
+            if creation_boundary is None:
+                creation_boundary = {
+                    "creation_boundary_state": "same_project_creation_boundary_unverified",
+                    "freshness_forensic_evidence": "unavailable",
+                }
+            # Generic JSON input has no trusted scheduler verifier.  Creation
+            # can never become dry-run-ready in this adapter.
+            reasons.append("generic creation projection lacks a trusted scheduler verifier")
+    if action == "create" and status == "supported":
+        decision = "hold_required"
+    elif status in {"unsupported", "not_available", "unknown"} or provenance == "unavailable":
         reasons.append("capability is unavailable or unsupported")
         decision = "hold_required"
     elif reasons:
@@ -330,9 +340,9 @@ def validate_creation_boundary(value: Any) -> tuple[dict[str, Any] | None, list[
     if reasons:
         return None, reasons
     return {
-        "creation_boundary_state": "same_project_creation_boundary_verified",
+        "creation_boundary_state": "same_project_creation_boundary_unverified",
         "freshness_forensic_evidence": "unavailable",
-    }, []
+    }, ["durable creation receipt refs are caller-supplied; no trusted scheduler verifier is available"]
 
 
 def project(root: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/plan_codex_route_adapter.py
+++ b/scripts/plan_codex_route_adapter.py
@@ -7,8 +7,16 @@ import argparse
 import hashlib
 import json
 import sys
+from pathlib import Path
 from datetime import datetime
 from typing import Any
+
+try:
+    import yaml
+    from jsonschema import Draft202012Validator
+except ImportError:  # pragma: no cover - environments without optional validator fail closed
+    yaml = None
+    Draft202012Validator = None
 
 
 TOPOLOGY_TO_TOOL = {
@@ -39,6 +47,16 @@ ROLE_OPERATION_CAPABILITIES = {
     "measure": "measure",
 }
 FORBIDDEN_RECEIPT_KEYS = {"prompt", "body", "message", "messages", "content", "transcript", "tool_output", "raw_log"}
+ROLEHUB_TERMINAL_FAILURE = {"partial_hold", "rolled_back", "rollback_incomplete"}
+ROLEHUB_TERMINAL = ROLEHUB_TERMINAL_FAILURE | {"ready"}
+ROLEHUB_SCHEMA_VALIDATION_FAILURE = "ROLEHUB_SCHEMA_VALIDATION_FAILED"
+PROJECT_BINDING_KINDS = {
+    "local_folder_project",
+    "git_repository_project",
+    "git_worktree_project",
+    "fork_inherited_context",
+    "projectless_fresh_context",
+}
 
 
 def fail(message: str) -> None:
@@ -242,12 +260,7 @@ def project_role_operation(root: dict[str, Any]) -> dict[str, Any]:
             creation_boundary, boundary_reasons = validate_creation_boundary(receipt.get("creation_boundary"))
             reasons.extend(boundary_reasons)
             if creation_boundary is None:
-                creation_boundary = {
-                    "creation_boundary_state": "same_project_creation_boundary_unverified",
-                    "freshness_forensic_evidence": "unavailable",
-                }
-            # Generic JSON input has no trusted scheduler verifier.  Creation
-            # can never become dry-run-ready in this adapter.
+                creation_boundary = {"creation_boundary_state": "same_project_creation_boundary_unverified", "freshness_forensic_evidence": "unavailable"}
             reasons.append("generic creation projection lacks a trusted scheduler verifier")
     if action == "create" and status == "supported":
         decision = "hold_required"
@@ -273,12 +286,8 @@ def project_role_operation(root: dict[str, Any]) -> dict[str, Any]:
             "tool_call_proposed": "not_available",
             "native_ids_are_metadata_only": True,
             "adapter_metadata": native_metadata,
-            "creation_boundary_state": (
-                creation_boundary["creation_boundary_state"] if creation_boundary else "not_available"
-            ),
-            "freshness_forensic_evidence": (
-                creation_boundary["freshness_forensic_evidence"] if creation_boundary else "not_available"
-            ),
+            "creation_boundary_state": creation_boundary["creation_boundary_state"] if creation_boundary else "not_available",
+            "freshness_forensic_evidence": creation_boundary["freshness_forensic_evidence"] if creation_boundary else "not_available",
         },
         "attention": reasons,
         "next_action": "Keep the portable Core route unchanged; obtain supported capability evidence before separately authorized execution.",
@@ -290,62 +299,253 @@ def project_role_operation(root: dict[str, Any]) -> dict[str, Any]:
 
 
 def validate_creation_boundary(value: Any) -> tuple[dict[str, Any] | None, list[str]]:
-    """Validate durable evidence for one same-project create_thread boundary.
-
-    This is projection-only: the adapter never verifies GitHub references or
-    performs a host call.  Freshness remains explicitly forensic-unavailable.
-    """
     if not isinstance(value, dict):
         return None, ["same-project creation boundary evidence is required"]
-    allowed_fields = {
-        "terminal_receipt_ref", "architect_acceptance_ref", "source", "digest", "opaque_identity_ref",
-        "readback_identity_ref", "verification_source", "create_count", "primitive", "predecessor_present",
-        "fork_source_present", "project_id", "cwd", "binding_project_id", "binding_cwd", "transcript_read",
-        "history_read", "turn_read", "projectless", "child_worktree", "retry", "dispatch",
-    }
-    unexpected = sorted(set(value) - allowed_fields)
+    allowed = {"terminal_receipt_ref", "architect_acceptance_ref", "source", "digest", "opaque_identity_ref", "readback_identity_ref", "verification_source", "create_count", "primitive", "predecessor_present", "fork_source_present", "project_id", "cwd", "binding_project_id", "binding_cwd", "transcript_read", "history_read", "turn_read", "projectless", "child_worktree", "retry", "dispatch"}
+    unexpected = sorted(set(value) - allowed)
     if unexpected:
-        return {
-            "creation_boundary_state": "creation_boundary_proof_untrusted",
-            "freshness_forensic_evidence": "unavailable",
-        }, [f"creation boundary contains untrusted fields: {', '.join(unexpected)}"]
-    required_refs = (
-        "terminal_receipt_ref", "architect_acceptance_ref", "source", "digest", "opaque_identity_ref", "readback_identity_ref",
-    )
+        return {"creation_boundary_state": "creation_boundary_proof_untrusted", "freshness_forensic_evidence": "unavailable"}, [f"creation boundary contains untrusted fields: {', '.join(unexpected)}"]
     reasons: list[str] = []
-    for field in required_refs:
-        if not isinstance(value.get(field), str) or not value[field]:
-            reasons.append(f"creation boundary is missing {field}")
-    if value.get("verification_source") != "durable_scheduler_reference":
-        reasons.append("creation boundary verification_source must be durable_scheduler_reference")
-    if value.get("digest") and (not isinstance(value["digest"], str) or not value["digest"].startswith("sha256:")):
-        reasons.append("creation boundary digest must be a sha256 digest")
-    if value.get("create_count") != 1:
-        reasons.append("creation boundary create_count must equal 1")
-    if value.get("primitive") != "create_thread":
-        reasons.append("creation boundary primitive must be create_thread")
+    for field in ("terminal_receipt_ref", "architect_acceptance_ref", "source", "digest", "opaque_identity_ref", "readback_identity_ref"):
+        if not isinstance(value.get(field), str) or not value[field]: reasons.append(f"creation boundary is missing {field}")
+    if value.get("verification_source") != "durable_scheduler_reference": reasons.append("creation boundary verification_source must be durable_scheduler_reference")
+    if value.get("digest") and (not isinstance(value["digest"], str) or not value["digest"].startswith("sha256:")): reasons.append("creation boundary digest must be a sha256 digest")
+    if value.get("create_count") != 1: reasons.append("creation boundary create_count must equal 1")
+    if value.get("primitive") != "create_thread": reasons.append("creation boundary primitive must be create_thread")
     for field in ("predecessor_present", "fork_source_present", "transcript_read", "history_read", "turn_read", "projectless", "child_worktree", "retry", "dispatch"):
-        if value.get(field) is not False:
-            reasons.append(f"creation boundary {field} must be false")
-    if not isinstance(value.get("project_id"), str) or not value["project_id"]:
-        reasons.append("creation boundary project_id is required")
-    if not isinstance(value.get("cwd"), str) or not value["cwd"]:
-        reasons.append("creation boundary cwd is required")
-    if value.get("binding_project_id") != value.get("project_id"):
-        reasons.append("creation boundary project binding project_id does not match")
-    if value.get("binding_cwd") != value.get("cwd"):
-        reasons.append("creation boundary project binding cwd does not match")
-    if value.get("readback_identity_ref") != value.get("opaque_identity_ref"):
-        reasons.append("creation boundary readback identity does not correlate to opaque identity")
-    if reasons:
-        return None, reasons
+        if value.get(field) is not False: reasons.append(f"creation boundary {field} must be false")
+    for field in ("project_id", "cwd"):
+        if not isinstance(value.get(field), str) or not value[field]: reasons.append(f"creation boundary {field} is required")
+    if value.get("binding_project_id") != value.get("project_id"): reasons.append("creation boundary project binding project_id does not match")
+    if value.get("binding_cwd") != value.get("cwd"): reasons.append("creation boundary project binding cwd does not match")
+    if value.get("readback_identity_ref") != value.get("opaque_identity_ref"): reasons.append("creation boundary readback identity does not correlate to opaque identity")
+    if reasons: return None, reasons
+    return {"creation_boundary_state": "same_project_creation_boundary_unverified", "freshness_forensic_evidence": "unavailable"}, ["durable creation receipt refs are caller-supplied; no trusted scheduler verifier is available"]
+
+
+def project_binding_classification(root: dict[str, Any]) -> dict[str, Any]:
+    """Classify a host-reported project/thread binding without calling the host."""
+    observation = root.get("project_binding_observation")
+    if not isinstance(observation, dict):
+        fail("project_binding_observation must be an object")
+    kind = observation.get("project_kind")
+    context = observation.get("context_mode")
+    identity = observation.get("identity")
+    target = observation.get("target")
+    runtime_proof = observation.get("runtime_owned_proof") is True
+    reasons: list[str] = []
+    if kind not in PROJECT_BINDING_KINDS:
+        reasons.append("project_kind is missing or unknown")
+    if context not in {"fresh", "fork", "projectless"}:
+        reasons.append("context_mode must be fresh, fork, or projectless")
+    if not isinstance(identity, dict) or not isinstance(target, dict):
+        reasons.append("exact project identity, root, and cwd are required")
+        identity = identity if isinstance(identity, dict) else {}
+        target = target if isinstance(target, dict) else {}
+    for field in ("project_id", "project_root", "cwd"):
+        if not isinstance(identity.get(field), str) or not identity[field]:
+            reasons.append(f"identity.{field} is missing")
+        if not isinstance(target.get(field), str) or not target[field]:
+            reasons.append(f"target.{field} is missing")
+        elif isinstance(identity.get(field), str) and identity[field] != target[field]:
+            reasons.append(f"target {field} does not match selected project")
+    if observation.get("fresh_context") is not True:
+        reasons.append("fresh_context proof is absent")
+    if context == "fork" or kind == "fork_inherited_context":
+        state, reason = "held_inherited_context_rejected", "fork inherits predecessor history"
+    elif context == "projectless" or kind == "projectless_fresh_context":
+        state, reason = "held_projectless_fallback_rejected", "projectless fresh context loses selected project binding"
+    elif reasons:
+        state, reason = "held_project_binding_mismatch", "exact project identity/root/cwd/freshness proof is incomplete"
+    elif kind == "local_folder_project" and not runtime_proof:
+        state, reason = "held_same_project_fresh_unavailable", "non-Git local-folder API support is not runtime-proven; Human UI fallback required"
+    elif not runtime_proof:
+        state, reason = "held_same_project_fresh_unavailable", "runtime-owned create proof is unavailable"
+    else:
+        # A caller-supplied boolean is not trusted host readback.
+        state, reason = "held_runtime_proof_unverified", "runtime_owned_proof is caller-supplied; trusted host readback is required"
     return {
-        "creation_boundary_state": "same_project_creation_boundary_unverified",
-        "freshness_forensic_evidence": "unavailable",
-    }, ["durable creation receipt refs are caller-supplied; no trusted scheduler verifier is available"]
+        "adapter": "codex",
+        "state": state,
+        "project_kind": kind if kind in PROJECT_BINDING_KINDS else "unknown",
+        "context_mode": context if context in {"fresh", "fork", "projectless"} else "unknown",
+        "runtime_owned_proof": runtime_proof,
+        "attention": reasons + [reason],
+        "human_ui_fallback_required": state == "held_same_project_fresh_unavailable" and kind == "local_folder_project",
+        "mutation_performed": False,
+        "dispatch_performed": False,
+        "next_action": "Use the supported Human UI path; do not fall back to fork or projectless." if state == "held_same_project_fresh_unavailable" else "Keep the request held until a trusted host adapter supplies readback; this classifier performed no call.",
+    }
+
+
+def project_rolehub(root: dict[str, Any]) -> dict[str, Any]:
+    """Validate a portable RoleHub projection without invoking a native API."""
+    if root.get("contract_version") != "AF18-rolehub-adapter-v1":
+        return {"adapter": "codex", "state": "partial_hold", "attention": ["unsupported or missing RoleHub contract_version"], "native_io_performed": False, "mutation_performed": False, "dispatch_performed": False, "next_action": "Hold until the exact portable contract version is supplied."}
+    if yaml is None or Draft202012Validator is None:
+        return {"adapter": "codex", "state": "partial_hold", "attention": ["portable RoleHub schema validator is unavailable"], "native_io_performed": False, "mutation_performed": False, "dispatch_performed": False, "next_action": "Install the pinned schema validator before projection."}
+    try:
+        schema_path = Path(__file__).resolve().parents[1] / "schemas" / "rolehub-adapter-execution.schema.yaml"
+        schema = yaml.safe_load(schema_path.read_text(encoding="utf-8"))
+        validation_errors = sorted(Draft202012Validator(schema).iter_errors(root), key=lambda error: list(error.path))
+    except Exception:
+        validation_errors = [None]
+    if validation_errors:
+        return {"adapter": "codex", "state": "partial_hold", "attention": [ROLEHUB_SCHEMA_VALIDATION_FAILURE], "native_io_performed": False, "mutation_performed": False, "dispatch_performed": False, "next_action": "Hold until the portable RoleHub request matches its schema."}
+    project_id = root.get("project_id")
+    identity = root.get("rolehub_identity")
+    operations = root.get("operations")
+    if not isinstance(project_id, str) or not project_id or not isinstance(identity, dict) or not isinstance(operations, list):
+        fail("rolehub projection requires project_id, rolehub_identity and operations")
+    logical_id = identity.get("logical_id")
+    if not isinstance(logical_id, str) or not logical_id:
+        fail("rolehub_identity.logical_id is required")
+    attention: list[str] = []
+    allowed_root = {"contract_version", "project_id", "rolehub_identity", "capabilities", "capability_evidence", "role_matches", "operations", "rollback"}
+    for key in root:
+        if key not in allowed_root:
+            attention.append(f"unknown RoleHub field: {key}")
+    allowed_identity = {"logical_id", "role_conversations"}
+    allowed_capabilities = {"create", "link", "navigate"}
+    allowed_evidence = {"trusted", "producer", "runtime_id", "project_id", "logical_rolehub_id"}
+    for key in identity:
+        if key not in allowed_identity:
+            attention.append(f"unknown rolehub_identity field: {key}")
+    capabilities = root.get("capabilities", {})
+    if not isinstance(capabilities, dict):
+        capabilities = {}
+    evidence = root.get("capability_evidence")
+    trusted_capabilities = isinstance(evidence, dict) and evidence.get("trusted") is True and isinstance(evidence.get("producer"), str) and isinstance(evidence.get("runtime_id"), str) and evidence.get("project_id") == project_id and evidence.get("logical_rolehub_id") == logical_id
+    seen_keys: set[str] = set()
+    receipts: list[dict[str, Any]] = []
+    applied: list[dict[str, Any]] = []
+    if isinstance(capabilities, dict):
+        attention.extend(f"unknown capabilities field: {key}" for key in capabilities if key not in allowed_capabilities)
+    if isinstance(evidence, dict):
+        attention.extend(f"unknown capability_evidence field: {key}" for key in evidence if key not in allowed_evidence)
+    role_matches = root.get("role_matches")
+    if role_matches is not None:
+        if not isinstance(role_matches, list):
+            attention.append("role_matches must be an array")
+        else:
+            for role in ("Coordinator", "Architect"):
+                matches = [item for item in role_matches if isinstance(item, dict) and item.get("role") == role and item.get("project_id") == project_id]
+                healthy = [item for item in matches if item.get("active") is True and item.get("legacy") is not True]
+                if len(matches) > 1 or any(item.get("legacy") is True for item in matches):
+                    attention.append(f"duplicate or legacy {role} match requires hold")
+                elif len(healthy) == 0:
+                    attention.append(f"no reusable {role}; creation must remain a plan")
+    terminal_seen = False
+    ready_seen = False
+    expected_sequence = 0
+    for index, operation in enumerate(operations):
+        if not isinstance(operation, dict):
+            attention.append(f"operation {index} is not an object")
+            continue
+        action = operation.get("action")
+        allowed_operation = {"operation_id", "action", "idempotency_key", "role", "target_ref", "preimage", "receipt"}
+        attention.extend(f"unknown operation field: {key}" for key in operation if key not in allowed_operation)
+        if not isinstance(operation.get("operation_id"), str) or not operation.get("operation_id"):
+            attention.append(f"operation {index} is missing operation_id")
+        if not isinstance(action, str) or not action:
+            attention.append(f"operation {index} is missing action")
+        key = operation.get("idempotency_key")
+        if not isinstance(key, str) or not key:
+            attention.append(f"operation {index} is missing idempotency_key")
+        elif key in seen_keys:
+            attention.append(f"duplicate idempotency_key: {key}")
+        else:
+            seen_keys.add(key)
+        forbidden = forbidden_paths(operation)
+        if forbidden:
+            attention.append(f"privacy violation at {forbidden[0]}")
+        if action not in {"create", "reuse", "link", "navigate"}:
+            attention.append(f"unsupported rolehub action: {action}")
+            continue
+        if operation.get("role") in {"Implementer", "Reviewer", "Tester", "Harvester"} and action in {"create", "reuse", "link"}:
+            attention.append("Work roles are transient and cannot be persisted in RoleHub")
+        if action in {"create", "link", "navigate"} and capabilities.get(action) not in {"supported"}:
+            attention.append(f"capability unavailable for {action}")
+        elif action in {"create", "link", "navigate"} and not trusted_capabilities:
+            attention.append(f"trusted capability evidence unavailable for {action}")
+        preimage = operation.get("preimage")
+        receipt = operation.get("receipt")
+        if action in {"link", "navigate"} and not isinstance(preimage, dict):
+            attention.append(f"missing preimage for {operation.get('operation_id', index)}")
+        if not isinstance(receipt, dict):
+            attention.append(f"missing receipt for {operation.get('operation_id', index)}")
+            continue
+        allowed_receipt = {"operation_id", "idempotency_key", "operation_fingerprint", "opaque_ref", "readback", "sequence", "status", "project_id", "logical_rolehub_id"}
+        attention.extend(f"unknown receipt field: {key}" for key in receipt if key not in allowed_receipt)
+        fingerprint_payload = {key: value for key, value in operation.items() if key != "receipt"}
+        fingerprint = f"sha256:{hashlib.sha256(json.dumps(fingerprint_payload, sort_keys=True, separators=(",", ":")).encode()).hexdigest()}"
+        if receipt.get("project_id") != project_id or receipt.get("logical_rolehub_id") != logical_id:
+            attention.append(f"cross-project or identity-mismatched receipt for {operation.get('operation_id', index)}")
+        if receipt.get("operation_id") != operation.get("operation_id") or receipt.get("idempotency_key") != key or receipt.get("operation_fingerprint") != fingerprint or not isinstance(receipt.get("opaque_ref"), str) or not isinstance(receipt.get("readback"), dict):
+            attention.append(f"receipt binding/readback mismatch for {operation.get('operation_id', index)}")
+        if receipt.get("sequence") != expected_sequence:
+            attention.append(f"out-of-order receipt for {operation.get('operation_id', index)}")
+        expected_sequence += 1
+        if terminal_seen:
+            attention.append("receipt appears after terminal receipt")
+        status = receipt.get("status")
+        if status in ROLEHUB_TERMINAL:
+            terminal_seen = True
+            if status == "ready":
+                ready_seen = True
+        elif status not in {"applied", "ready"}:
+            attention.append(f"invalid receipt status for {operation.get('operation_id', index)}")
+        if status == "applied":
+            applied.append(operation)
+        receipts.append(receipt)
+    if any(receipt.get("status") == "failed" for receipt in receipts):
+        attention.append("operation failure requires partial_hold and reverse rollback")
+    rollback = root.get("rollback", {})
+    if not isinstance(rollback, dict):
+        rollback = {}
+    rollback_receipt = rollback.get("receipt")
+    allowed_rollback = {"status", "receipt", "reversed_operation_ids"}
+    attention.extend(f"unknown rollback field: {key}" for key in rollback if key not in allowed_rollback)
+    if isinstance(rollback_receipt, dict):
+        allowed_rollback_receipt = {"status", "reversed_operation_ids"}
+        attention.extend(f"unknown rollback receipt field: {key}" for key in rollback_receipt if key not in allowed_rollback_receipt)
+    rollback_forbidden = forbidden_paths(rollback)
+    if rollback_forbidden:
+        attention.append(f"privacy violation at {rollback_forbidden[0]}")
+    applied_ids = [op.get("operation_id") for op in applied]
+    rollback_valid = not rollback_forbidden and isinstance(rollback_receipt, dict) and rollback_receipt.get("status") == "complete" and rollback_receipt.get("reversed_operation_ids") == list(reversed(applied_ids)) and all(isinstance(op.get("preimage"), dict) or op.get("action") == "create" for op in applied)
+    if rollback.get("status") == "failed" or (rollback.get("status") in {"required", "complete"} and not rollback_valid):
+        attention.append("rollback receipt missing or failed")
+        rollback_state = "rollback_incomplete"
+    elif rollback_valid:
+        rollback_state = "rolled_back"
+    else:
+        rollback_state = "not_attempted"
+    state = "ready" if not attention and (ready_seen or not terminal_seen) else "partial_hold"
+    if rollback_state in {"rolled_back", "rollback_incomplete"}:
+        state = rollback_state
+    return {
+        "adapter": "codex",
+        "contract_version": root.get("contract_version", "not_available"),
+        "project_id": project_id,
+        "rolehub_identity": {"logical_id": logical_id},
+        "state": state,
+        "operations": [{"operation_id": op.get("operation_id", "not_available"), "action": op.get("action"), "status": "applied" if op in applied else "held"} for op in operations if isinstance(op, dict)],
+        "applied_operations": [op.get("operation_id", "not_available") for op in applied],
+        "rollback": {"status": rollback_state, "applied_only": True, "delete_or_archive": False},
+        "attention": attention,
+        "native_io_performed": False,
+        "mutation_performed": False,
+        "dispatch_performed": False,
+        "next_action": "Hold for an independently authorized adapter execution receipt." if state == "partial_hold" else "Portable projection is ready; no native call is proposed.",
+    }
 
 
 def project(root: dict[str, Any]) -> dict[str, Any]:
+    if "project_binding_observation" in root:
+        return project_binding_classification(root)
+    if "rolehub_identity" in root:
+        return project_rolehub(root)
     if "role_operation" in root:
         return project_role_operation(root)
     portable = require_object(root, "portable_plan")

--- a/scripts/plan_codex_route_adapter.py
+++ b/scripts/plan_codex_route_adapter.py
@@ -219,6 +219,7 @@ def project_role_operation(root: dict[str, Any]) -> dict[str, Any]:
     provenance = "unavailable"
     native_metadata: dict[str, Any] = {}
     reasons: list[str] = []
+    creation_boundary: dict[str, Any] | None = None
     if forbidden:
         reasons.append("privacy-safe receipt contains forbidden raw content")
     if capability is None:
@@ -237,6 +238,9 @@ def project_role_operation(root: dict[str, Any]) -> dict[str, Any]:
             reasons.append("capability receipt has an unknown status")
         if provenance not in {"observed", "estimated", "unavailable"}:
             reasons.append("capability receipt has an unknown provenance")
+        if action == "create" and status == "supported" and provenance == "observed":
+            creation_boundary, boundary_reasons = validate_creation_boundary(receipt.get("creation_boundary"))
+            reasons.extend(boundary_reasons)
     if status in {"unsupported", "not_available", "unknown"} or provenance == "unavailable":
         reasons.append("capability is unavailable or unsupported")
         decision = "hold_required"
@@ -259,6 +263,12 @@ def project_role_operation(root: dict[str, Any]) -> dict[str, Any]:
             "tool_call_proposed": "not_available",
             "native_ids_are_metadata_only": True,
             "adapter_metadata": native_metadata,
+            "creation_boundary_state": (
+                creation_boundary["creation_boundary_state"] if creation_boundary else "not_available"
+            ),
+            "freshness_forensic_evidence": (
+                creation_boundary["freshness_forensic_evidence"] if creation_boundary else "not_available"
+            ),
         },
         "attention": reasons,
         "next_action": "Keep the portable Core route unchanged; obtain supported capability evidence before separately authorized execution.",
@@ -267,6 +277,48 @@ def project_role_operation(root: dict[str, Any]) -> dict[str, Any]:
         "user_config_mutation_performed": False,
         "hook_or_custom_agent_mutation_performed": False,
     }
+
+
+def validate_creation_boundary(value: Any) -> tuple[dict[str, Any] | None, list[str]]:
+    """Validate durable evidence for one same-project create_thread boundary.
+
+    This is projection-only: the adapter never verifies GitHub references or
+    performs a host call.  Freshness remains explicitly forensic-unavailable.
+    """
+    if not isinstance(value, dict):
+        return None, ["same-project creation boundary evidence is required"]
+    required_refs = (
+        "terminal_receipt_ref", "architect_acceptance_ref", "source", "digest", "opaque_identity_ref",
+    )
+    reasons: list[str] = []
+    for field in required_refs:
+        if not isinstance(value.get(field), str) or not value[field]:
+            reasons.append(f"creation boundary is missing {field}")
+    if value.get("verification_source") != "durable_scheduler_reference":
+        reasons.append("creation boundary verification_source must be durable_scheduler_reference")
+    if value.get("digest") and (not isinstance(value["digest"], str) or not value["digest"].startswith("sha256:")):
+        reasons.append("creation boundary digest must be a sha256 digest")
+    if value.get("create_count") != 1:
+        reasons.append("creation boundary create_count must equal 1")
+    if value.get("primitive") != "create_thread":
+        reasons.append("creation boundary primitive must be create_thread")
+    for field in ("predecessor_present", "fork_source_present", "transcript_read", "history_read", "turn_read", "projectless", "child_worktree", "retry", "dispatch"):
+        if value.get(field) is not False:
+            reasons.append(f"creation boundary {field} must be false")
+    if not isinstance(value.get("project_id"), str) or not value["project_id"]:
+        reasons.append("creation boundary project_id is required")
+    if not isinstance(value.get("cwd"), str) or not value["cwd"]:
+        reasons.append("creation boundary cwd is required")
+    if value.get("binding_project_id") != value.get("project_id"):
+        reasons.append("creation boundary project binding project_id does not match")
+    if value.get("binding_cwd") != value.get("cwd"):
+        reasons.append("creation boundary project binding cwd does not match")
+    if reasons:
+        return None, reasons
+    return {
+        "creation_boundary_state": "same_project_creation_boundary_verified",
+        "freshness_forensic_evidence": "unavailable",
+    }, []
 
 
 def project(root: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/plan_codex_route_adapter.py
+++ b/scripts/plan_codex_route_adapter.py
@@ -287,6 +287,18 @@ def validate_creation_boundary(value: Any) -> tuple[dict[str, Any] | None, list[
     """
     if not isinstance(value, dict):
         return None, ["same-project creation boundary evidence is required"]
+    allowed_fields = {
+        "terminal_receipt_ref", "architect_acceptance_ref", "source", "digest", "opaque_identity_ref",
+        "readback_identity_ref", "verification_source", "create_count", "primitive", "predecessor_present",
+        "fork_source_present", "project_id", "cwd", "binding_project_id", "binding_cwd", "transcript_read",
+        "history_read", "turn_read", "projectless", "child_worktree", "retry", "dispatch",
+    }
+    unexpected = sorted(set(value) - allowed_fields)
+    if unexpected:
+        return {
+            "creation_boundary_state": "creation_boundary_proof_untrusted",
+            "freshness_forensic_evidence": "unavailable",
+        }, [f"creation boundary contains untrusted fields: {', '.join(unexpected)}"]
     required_refs = (
         "terminal_receipt_ref", "architect_acceptance_ref", "source", "digest", "opaque_identity_ref", "readback_identity_ref",
     )

--- a/scripts/test_codex_route_adapter.py
+++ b/scripts/test_codex_route_adapter.py
@@ -295,7 +295,7 @@ def main() -> int:
             "creation_boundary": creation_boundary(**override),
         }}}
         code, output = run(case)
-        expected_state = "creation_boundary_proof_untrusted" if name == "forged-runtime-proof" else "not_available"
+        expected_state = "creation_boundary_proof_untrusted" if name == "forged-runtime-proof" else "same_project_creation_boundary_unverified"
         expect(f"creation-boundary-{name}-held", code == 0 and output["adapter_plan"]["adapter_decision"] == "hold_required" and output["adapter_plan"]["creation_boundary_state"] == expected_state, output, errors)
 
     if errors:

--- a/scripts/test_codex_route_adapter.py
+++ b/scripts/test_codex_route_adapter.py
@@ -239,14 +239,16 @@ def main() -> int:
                         "status": "supported",
                         "provenance": "observed",
                         "native_metadata": {"native_thread_id": f"codex-{action}-fixture"},
+                        **({"creation_boundary": creation_boundary()} if action == "create" else {}),
                     },
                 }
             }
         )
+        expected_decision = "hold_required" if action == "create" else "dry_run_ready"
         expect(
             f"role-operation-{action}-supported-dry-run",
             code == 0
-            and output["adapter_plan"]["adapter_decision"] == "dry_run_ready"
+            and output["adapter_plan"]["adapter_decision"] == expected_decision
             and output["adapter_plan"]["tool_call_proposed"] == "not_available"
             and output["adapter_plan"]["native_ids_are_metadata_only"] is True
             and output["mutation_performed"] is False

--- a/scripts/test_codex_route_adapter.py
+++ b/scripts/test_codex_route_adapter.py
@@ -219,10 +219,11 @@ def main() -> int:
                 }
             }
         )
+        expected_decision = "hold_required" if action == "create" else "dry_run_ready"
         expect(
             f"role-operation-{action}-supported-dry-run",
             code == 0
-            and output["adapter_plan"]["adapter_decision"] == "dry_run_ready"
+            and output["adapter_plan"]["adapter_decision"] == expected_decision
             and output["adapter_plan"]["tool_call_proposed"] == "not_available"
             and output["adapter_plan"]["native_ids_are_metadata_only"] is True
             and output["mutation_performed"] is False
@@ -273,7 +274,7 @@ def main() -> int:
         "creation_boundary": creation_boundary(),
     }}}
     code, output = run(positive)
-    expect("creation-boundary-positive", code == 0 and output["adapter_plan"]["creation_boundary_state"] == "same_project_creation_boundary_verified" and output["adapter_plan"]["freshness_forensic_evidence"] == "unavailable", output, errors)
+    expect("creation-boundary-positive-held-unverified", code == 0 and output["adapter_plan"]["adapter_decision"] == "hold_required" and output["adapter_plan"]["creation_boundary_state"] == "same_project_creation_boundary_unverified" and output["adapter_plan"]["freshness_forensic_evidence"] == "unavailable", output, errors)
 
     negatives = {
         "missing-acceptance": {"architect_acceptance_ref": ""},

--- a/scripts/test_codex_route_adapter.py
+++ b/scripts/test_codex_route_adapter.py
@@ -80,28 +80,14 @@ def adapter_context() -> dict:
 
 def creation_boundary(**overrides: object) -> dict:
     value = {
-        "terminal_receipt_ref": "https://github.com/farmerhunter/agent-foundry/issues/517#issuecomment-5201685599",
-        "architect_acceptance_ref": "https://github.com/farmerhunter/agent-foundry/issues/517#issuecomment-5201685599",
-        "source": "durable:github:farmerhunter/agent-foundry:issue:517",
-        "digest": "sha256:517-boundary-fixture",
-        "opaque_identity_ref": "native:opaque-thread-517",
-        "readback_identity_ref": "native:opaque-thread-517",
-        "verification_source": "durable_scheduler_reference",
-        "create_count": 1,
-        "primitive": "create_thread",
-        "predecessor_present": False,
-        "fork_source_present": False,
-        "project_id": "local-eb6e22ec0d00ef785d687022be1b433d",
-        "cwd": "/Users/jinghuliu/Desktop/Code/Personal Projects/agent-foundry",
-        "binding_project_id": "local-eb6e22ec0d00ef785d687022be1b433d",
-        "binding_cwd": "/Users/jinghuliu/Desktop/Code/Personal Projects/agent-foundry",
-        "transcript_read": False,
-        "history_read": False,
-        "turn_read": False,
-        "projectless": False,
-        "child_worktree": False,
-        "retry": False,
-        "dispatch": False,
+        "terminal_receipt_ref": "durable:terminal:517", "architect_acceptance_ref": "durable:architect:517",
+        "source": "durable:github:issue:517", "digest": "sha256:517-fixture",
+        "opaque_identity_ref": "native:opaque-517", "readback_identity_ref": "native:opaque-517",
+        "verification_source": "durable_scheduler_reference", "create_count": 1, "primitive": "create_thread",
+        "predecessor_present": False, "fork_source_present": False, "project_id": "local-fixture",
+        "cwd": "/tmp/fixture", "binding_project_id": "local-fixture", "binding_cwd": "/tmp/fixture",
+        "transcript_read": False, "history_read": False, "turn_read": False, "projectless": False,
+        "child_worktree": False, "retry": False, "dispatch": False,
     }
     value.update(overrides)
     return value
@@ -113,6 +99,19 @@ def input_for(portable_plan: dict, observation: dict | None = None, adapter_enve
         "schema_observation": schemas() if observation is None else observation,
         "adapter_context": adapter_context(),
         "adapter_envelopes": envelopes() if adapter_envelopes is None else adapter_envelopes,
+    }
+
+
+def binding(kind: str = "local_folder_project", context: str = "fresh", *, runtime: bool = False) -> dict:
+    return {
+        "project_binding_observation": {
+            "project_kind": kind,
+            "context_mode": context,
+            "identity": {"project_id": "git-seres", "project_root": "/projects/git.seres.cn", "cwd": "/projects/git.seres.cn"},
+            "target": {"project_id": "git-seres", "project_root": "/projects/git.seres.cn", "cwd": "/projects/git.seres.cn"},
+            "fresh_context": True,
+            "runtime_owned_proof": runtime,
+        }
     }
 
 
@@ -147,6 +146,32 @@ def expect(name: str, condition: bool, detail: object, errors: list[str]) -> Non
 
 def main() -> int:
     errors: list[str] = []
+    code, output = run(binding())
+    expect("non-git-invalid-arguments-hold", code == 0 and output["state"] == "held_same_project_fresh_unavailable" and output["human_ui_fallback_required"] is True and output["mutation_performed"] is False and output["dispatch_performed"] is False, output, errors)
+    for kind in ("git_repository_project", "git_worktree_project"):
+        code, output = run(binding(kind, runtime=True))
+        expect(f"{kind}-runtime-proof-unverified", code == 0 and output["state"] == "held_runtime_proof_unverified" and output["mutation_performed"] is False and output["dispatch_performed"] is False, output, errors)
+    code, output = run(binding("fork_inherited_context", "fork", runtime=True))
+    expect("fork-inherited-held", code == 0 and output["state"] == "held_inherited_context_rejected" and output["dispatch_performed"] is False, output, errors)
+    code, output = run(binding("projectless_fresh_context", "projectless", runtime=True))
+    expect("projectless-held", code == 0 and output["state"] == "held_projectless_fallback_rejected" and output["mutation_performed"] is False, output, errors)
+    mismatch = binding(runtime=True); mismatch["project_binding_observation"]["target"]["cwd"] = "/projects/git.seres.cn/worktree"
+    code, output = run(mismatch)
+    expect("child-root-mismatch-held", code == 0 and output["state"] == "held_project_binding_mismatch", output, errors)
+    for field in ("project_id", "project_root", "cwd"):
+        missing = binding(runtime=True); missing["project_binding_observation"]["identity"].pop(field)
+        code, output = run(missing)
+        expect(f"missing-{field}-held", code == 0 and output["state"] == "held_project_binding_mismatch", output, errors)
+    stale = binding(runtime=True); stale["project_binding_observation"]["fresh_context"] = False
+    code, output = run(stale)
+    expect("missing-freshness-held", code == 0 and output["state"] == "held_project_binding_mismatch", output, errors)
+    forged = binding(runtime=True); forged["project_binding_observation"]["runtime_owned_proof"] = False
+    code, output = run(forged)
+    expect("missing-runtime-proof-held", code == 0 and output["state"] == "held_same_project_fresh_unavailable", output, errors)
+    claimed_ready = binding("git_repository_project", runtime=True)
+    code, output = run(claimed_ready)
+    expect("forged-runtime-proof-never-ready", code == 0 and output["state"] == "held_runtime_proof_unverified" and output["mutation_performed"] is False and output["dispatch_performed"] is False, output, errors)
+
     base = input_for(portable("subagent"))
     code, output = run(base)
     expect("runtime-capture-unavailable", code == 0 and provenance_recovery(output, "unknown") and output["schema_provenance"]["evidence_ref_status"] == "unverified", output, errors)
@@ -210,20 +235,18 @@ def main() -> int:
                 "role_operation": {
                     "action": action,
                     "capability_receipt": {
-                    "capability": action,
+                        "capability": action,
                         "status": "supported",
                         "provenance": "observed",
                         "native_metadata": {"native_thread_id": f"codex-{action}-fixture"},
-                        **({"creation_boundary": creation_boundary()} if action == "create" else {}),
                     },
                 }
             }
         )
-        expected_decision = "hold_required" if action == "create" else "dry_run_ready"
         expect(
             f"role-operation-{action}-supported-dry-run",
             code == 0
-            and output["adapter_plan"]["adapter_decision"] == expected_decision
+            and output["adapter_plan"]["adapter_decision"] == "dry_run_ready"
             and output["adapter_plan"]["tool_call_proposed"] == "not_available"
             and output["adapter_plan"]["native_ids_are_metadata_only"] is True
             and output["mutation_performed"] is False
@@ -269,34 +292,134 @@ def main() -> int:
     code, output = run(private_operation)
     expect("role-operation-privacy-fails-closed", code == 0 and output["adapter_plan"]["adapter_decision"] == "hold_required", output, errors)
 
-    positive = {"role_operation": {"action": "create", "capability_receipt": {
+    def rolehub(ops, capabilities=None, rollback=None):
+        normalized = []
+        for sequence, original in enumerate(ops):
+            op = dict(original)
+            receipt = dict(op.get("receipt") or {})
+            payload = {key: value for key, value in op.items() if key != "receipt"}
+            fingerprint = f"sha256:{hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()).hexdigest()}"
+            receipt.setdefault("project_id", "tiny-ipa")
+            receipt.setdefault("logical_rolehub_id", "tiny-ipa-rolehub")
+            receipt.setdefault("operation_id", op.get("operation_id"))
+            receipt.setdefault("idempotency_key", op.get("idempotency_key"))
+            receipt.setdefault("operation_fingerprint", fingerprint)
+            receipt.setdefault("opaque_ref", "opaque:fixture")
+            receipt.setdefault("readback", {"status": "observed"})
+            receipt.setdefault("sequence", sequence)
+            op["receipt"] = receipt
+            normalized.append(op)
+        return {
+            "contract_version": "AF18-rolehub-adapter-v1",
+            "project_id": "tiny-ipa",
+            "rolehub_identity": {"logical_id": "tiny-ipa-rolehub"},
+            "capabilities": capabilities or {"create": "supported", "link": "supported", "navigate": "supported"},
+            "capability_evidence": {"trusted": True, "producer": "fixture-adapter", "runtime_id": "fixture", "project_id": "tiny-ipa", "logical_rolehub_id": "tiny-ipa-rolehub"},
+            "operations": normalized,
+            **({"rollback": rollback} if rollback is not None else {}),
+        }
+
+    base_op = {"operation_id": "create-hub", "action": "create", "idempotency_key": "tiny-ipa:create-hub", "receipt": {"project_id": "tiny-ipa", "logical_rolehub_id": "tiny-ipa-rolehub", "status": "applied"}}
+    code, output = run(rolehub([base_op]))
+    expect("rolehub-fresh-ready-no-io", code == 0 and output["state"] == "ready" and output["native_io_performed"] is False, output, errors)
+    missing_version = rolehub([base_op]); missing_version.pop("contract_version")
+    code, output = run(missing_version)
+    expect("rolehub-missing-version-hold", code == 0 and output["state"] == "partial_hold", output, errors)
+    wrong_version = rolehub([base_op]); wrong_version["contract_version"] = "AF18-rolehub-adapter-v0"
+    code, output = run(wrong_version)
+    expect("rolehub-wrong-version-hold", code == 0 and output["state"] == "partial_hold", output, errors)
+    malformed = rolehub([{**base_op, "operation_id": ""}])
+    code, output = run(malformed)
+    expect("rolehub-missing-operation-id-hold", code == 0 and output["state"] == "partial_hold", output, errors)
+    unknown_root = rolehub([base_op]); unknown_root["secret_field"] = "x"
+    code, output = run(unknown_root)
+    expect("rolehub-unknown-root-field-hold", code == 0 and output["state"] == "partial_hold", output, errors)
+    unknown_op = rolehub([{**base_op, "unexpected": "x"}])
+    code, output = run(unknown_op)
+    expect("rolehub-unknown-operation-field-hold", code == 0 and output["state"] == "partial_hold", output, errors)
+    unknown_receipt = rolehub([{**base_op, "receipt": {"unexpected": "x"}}])
+    code, output = run(unknown_receipt)
+    expect("rolehub-unknown-receipt-field-hold", code == 0 and output["state"] == "partial_hold", output, errors)
+    malformed_nested = rolehub([base_op]); malformed_nested["role_matches"] = [{"role": "Architect", "project_id": "tiny-ipa"}]
+    code, output = run(malformed_nested)
+    expect("rolehub-malformed-role-match-hold", code == 0 and output["state"] == "partial_hold", output, errors)
+    duplicate = dict(base_op)
+    code, output = run(rolehub([base_op, duplicate]))
+    expect("rolehub-duplicate-idempotency-hold", code == 0 and output["state"] == "partial_hold", output, errors)
+    forged = dict(base_op)
+    forged["receipt"] = {"project_id": "other-project", "logical_rolehub_id": "tiny-ipa-rolehub", "status": "applied"}
+    code, output = run(rolehub([forged]))
+    expect("rolehub-cross-project-hold", code == 0 and output["state"] == "partial_hold", output, errors)
+    missing_preimage = dict(base_op)
+    missing_preimage.update({"operation_id": "link", "action": "link"})
+    code, output = run(rolehub([missing_preimage]))
+    expect("rolehub-missing-preimage-hold", code == 0 and output["state"] == "partial_hold", output, errors)
+    terminal = {"operation_id": "hold", "action": "navigate", "idempotency_key": "tiny-ipa:hold", "preimage": {}, "receipt": {"project_id": "tiny-ipa", "logical_rolehub_id": "tiny-ipa-rolehub", "status": "partial_hold"}}
+    late = dict(base_op)
+    code, output = run(rolehub([terminal, late]))
+    expect("rolehub-late-receipt-hold", code == 0 and output["state"] == "partial_hold", output, errors)
+    rollback = {"status": "failed"}
+    code, output = run(rolehub([base_op], rollback=rollback))
+    expect("rolehub-rollback-incomplete", code == 0 and output["state"] == "rollback_incomplete", output, errors)
+
+    raw_sentinel = "RAW_SCHEMA_SENTINEL_SHOULD_NOT_LEAK"
+    invalid_schema = rolehub([base_op])
+    invalid_schema["unexpected_private_field"] = raw_sentinel
+    code, output = run(invalid_schema)
+    expect(
+        "rolehub-schema-validation-redacts-input",
+        code == 0
+        and raw_sentinel not in json.dumps(output, sort_keys=True)
+        and output["attention"] == ["ROLEHUB_SCHEMA_VALIDATION_FAILED"],
+        output,
+        errors,
+    )
+    reuse = rolehub([base_op]); reuse["role_matches"] = [{"role": "Architect", "project_id": "tiny-ipa", "active": True, "legacy": False}, {"role": "Coordinator", "project_id": "tiny-ipa", "active": True, "legacy": False}]
+    code, output = run(reuse)
+    expect("rolehub-reuse-single-active", code == 0 and output["state"] == "ready", output, errors)
+    duplicate_match = rolehub([base_op]); duplicate_match["role_matches"] = [{"role": "Architect", "project_id": "tiny-ipa", "active": True}, {"role": "Architect", "project_id": "tiny-ipa", "active": True}]
+    code, output = run(duplicate_match)
+    expect("rolehub-duplicate-match-hold", code == 0 and output["state"] == "partial_hold", output, errors)
+    unavailable = rolehub([base_op], capabilities={"create": "unavailable", "link": "unavailable", "navigate": "unavailable"})
+    code, output = run(unavailable)
+    expect("rolehub-unavailable-capability-hold", code == 0 and output["state"] == "partial_hold", output, errors)
+    transient = dict(base_op); transient["role"] = "Implementer"
+    code, output = run(rolehub([transient]))
+    expect("rolehub-work-role-transient", code == 0 and output["state"] == "partial_hold", output, errors)
+    ready = dict(base_op); ready["receipt"] = {"status": "ready"}
+    code, output = run(rolehub([ready]))
+    expect("rolehub-ready-receipt-ready", code == 0 and output["state"] == "ready", output, errors)
+    after_ready = dict(base_op); after_ready["operation_id"] = "late"
+    code, output = run(rolehub([ready, after_ready]))
+    expect("rolehub-after-ready-hold", code == 0 and output["state"] == "partial_hold", output, errors)
+    first = dict(base_op); first["operation_id"] = "first"; first["preimage"] = {}
+    second = dict(base_op); second["operation_id"] = "second"; second["preimage"] = {}
+    code, output = run(rolehub([first, second], rollback={"status": "complete", "receipt": {"status": "complete", "reversed_operation_ids": ["first", "second"]}}))
+    expect("rolehub-rollback-forward-order-rejected", code == 0 and output["state"] == "rollback_incomplete", output, errors)
+    code, output = run(rolehub([first, second], rollback={"status": "complete", "receipt": {"status": "complete", "reversed_operation_ids": ["second", "first"]}}))
+    expect("rolehub-rollback-reverse-order-accepted", code == 0 and output["state"] == "rolled_back", output, errors)
+    private_rollback = {"status": "complete", "receipt": {"status": "complete", "reversed_operation_ids": ["second", "first"], "prompt": "SECRET"}}
+    code, output = run(rolehub([first, second], rollback=private_rollback))
+    expect("rolehub-rollback-privacy-hold", code == 0 and output["state"] == "partial_hold", output, errors)
+
+    create_case = {"role_operation": {"action": "create", "capability_receipt": {
         "capability": "create", "status": "supported", "provenance": "observed",
         "creation_boundary": creation_boundary(),
     }}}
-    code, output = run(positive)
-    expect("creation-boundary-positive-held-unverified", code == 0 and output["adapter_plan"]["adapter_decision"] == "hold_required" and output["adapter_plan"]["creation_boundary_state"] == "same_project_creation_boundary_unverified" and output["adapter_plan"]["freshness_forensic_evidence"] == "unavailable", output, errors)
-
-    negatives = {
-        "missing-acceptance": {"architect_acceptance_ref": ""},
-        "missing-digest": {"digest": ""},
-        "fork": {"fork_source_present": True},
-        "count-zero": {"create_count": 0},
-        "count-many": {"create_count": 2},
-        "identity-mismatch": {"binding_project_id": "other-project"},
-        "project-mismatch": {"binding_cwd": "/other/project"},
-        "transcript": {"transcript_read": True},
-        "history": {"history_read": True},
-        "readback-mismatch": {"readback_identity_ref": "native:other-thread"},
-        "forged-runtime-proof": {"runtime_owned_proof": True},
-    }
-    for name, override in negatives.items():
+    code, output = run(create_case)
+    expect("creation-boundary-positive-held-unverified", code == 0 and output["adapter_plan"]["adapter_decision"] == "hold_required" and output["adapter_plan"]["creation_boundary_state"] == "same_project_creation_boundary_unverified", output, errors)
+    for name, override in {
+        "missing-acceptance": {"architect_acceptance_ref": ""}, "fork": {"fork_source_present": True},
+        "count": {"create_count": 2}, "binding": {"binding_cwd": "/other"},
+        "history": {"history_read": True}, "readback": {"readback_identity_ref": "native:other"},
+        "forged-proof": {"runtime_owned_proof": True},
+    }.items():
         case = {"role_operation": {"action": "create", "capability_receipt": {
             "capability": "create", "status": "supported", "provenance": "observed",
             "creation_boundary": creation_boundary(**override),
         }}}
         code, output = run(case)
-        expected_state = "creation_boundary_proof_untrusted" if name == "forged-runtime-proof" else "same_project_creation_boundary_unverified"
-        expect(f"creation-boundary-{name}-held", code == 0 and output["adapter_plan"]["adapter_decision"] == "hold_required" and output["adapter_plan"]["creation_boundary_state"] == expected_state, output, errors)
+        expect(f"creation-boundary-{name}-held", code == 0 and output["adapter_plan"]["adapter_decision"] == "hold_required", output, errors)
 
     if errors:
         print("\n".join(errors), file=sys.stderr)

--- a/scripts/test_codex_route_adapter.py
+++ b/scripts/test_codex_route_adapter.py
@@ -286,6 +286,7 @@ def main() -> int:
         "transcript": {"transcript_read": True},
         "history": {"history_read": True},
         "readback-mismatch": {"readback_identity_ref": "native:other-thread"},
+        "forged-runtime-proof": {"runtime_owned_proof": True},
     }
     for name, override in negatives.items():
         case = {"role_operation": {"action": "create", "capability_receipt": {
@@ -293,7 +294,8 @@ def main() -> int:
             "creation_boundary": creation_boundary(**override),
         }}}
         code, output = run(case)
-        expect(f"creation-boundary-{name}-held", code == 0 and output["adapter_plan"]["adapter_decision"] == "hold_required" and output["adapter_plan"]["creation_boundary_state"] == "not_available", output, errors)
+        expected_state = "creation_boundary_proof_untrusted" if name == "forged-runtime-proof" else "not_available"
+        expect(f"creation-boundary-{name}-held", code == 0 and output["adapter_plan"]["adapter_decision"] == "hold_required" and output["adapter_plan"]["creation_boundary_state"] == expected_state, output, errors)
 
     if errors:
         print("\n".join(errors), file=sys.stderr)

--- a/scripts/test_codex_route_adapter.py
+++ b/scripts/test_codex_route_adapter.py
@@ -85,6 +85,7 @@ def creation_boundary(**overrides: object) -> dict:
         "source": "durable:github:farmerhunter/agent-foundry:issue:517",
         "digest": "sha256:517-boundary-fixture",
         "opaque_identity_ref": "native:opaque-thread-517",
+        "readback_identity_ref": "native:opaque-thread-517",
         "verification_source": "durable_scheduler_reference",
         "create_count": 1,
         "primitive": "create_thread",
@@ -284,6 +285,7 @@ def main() -> int:
         "project-mismatch": {"binding_cwd": "/other/project"},
         "transcript": {"transcript_read": True},
         "history": {"history_read": True},
+        "readback-mismatch": {"readback_identity_ref": "native:other-thread"},
     }
     for name, override in negatives.items():
         case = {"role_operation": {"action": "create", "capability_receipt": {

--- a/scripts/test_codex_route_adapter.py
+++ b/scripts/test_codex_route_adapter.py
@@ -78,6 +78,34 @@ def adapter_context() -> dict:
     }
 
 
+def creation_boundary(**overrides: object) -> dict:
+    value = {
+        "terminal_receipt_ref": "https://github.com/farmerhunter/agent-foundry/issues/517#issuecomment-5201685599",
+        "architect_acceptance_ref": "https://github.com/farmerhunter/agent-foundry/issues/517#issuecomment-5201685599",
+        "source": "durable:github:farmerhunter/agent-foundry:issue:517",
+        "digest": "sha256:517-boundary-fixture",
+        "opaque_identity_ref": "native:opaque-thread-517",
+        "verification_source": "durable_scheduler_reference",
+        "create_count": 1,
+        "primitive": "create_thread",
+        "predecessor_present": False,
+        "fork_source_present": False,
+        "project_id": "local-eb6e22ec0d00ef785d687022be1b433d",
+        "cwd": "/Users/jinghuliu/Desktop/Code/Personal Projects/agent-foundry",
+        "binding_project_id": "local-eb6e22ec0d00ef785d687022be1b433d",
+        "binding_cwd": "/Users/jinghuliu/Desktop/Code/Personal Projects/agent-foundry",
+        "transcript_read": False,
+        "history_read": False,
+        "turn_read": False,
+        "projectless": False,
+        "child_worktree": False,
+        "retry": False,
+        "dispatch": False,
+    }
+    value.update(overrides)
+    return value
+
+
 def input_for(portable_plan: dict, observation: dict | None = None, adapter_envelopes: dict | None = None) -> dict:
     return {
         "portable_plan": portable_plan,
@@ -181,10 +209,11 @@ def main() -> int:
                 "role_operation": {
                     "action": action,
                     "capability_receipt": {
-                        "capability": action,
+                    "capability": action,
                         "status": "supported",
                         "provenance": "observed",
                         "native_metadata": {"native_thread_id": f"codex-{action}-fixture"},
+                        **({"creation_boundary": creation_boundary()} if action == "create" else {}),
                     },
                 }
             }
@@ -237,6 +266,32 @@ def main() -> int:
     }
     code, output = run(private_operation)
     expect("role-operation-privacy-fails-closed", code == 0 and output["adapter_plan"]["adapter_decision"] == "hold_required", output, errors)
+
+    positive = {"role_operation": {"action": "create", "capability_receipt": {
+        "capability": "create", "status": "supported", "provenance": "observed",
+        "creation_boundary": creation_boundary(),
+    }}}
+    code, output = run(positive)
+    expect("creation-boundary-positive", code == 0 and output["adapter_plan"]["creation_boundary_state"] == "same_project_creation_boundary_verified" and output["adapter_plan"]["freshness_forensic_evidence"] == "unavailable", output, errors)
+
+    negatives = {
+        "missing-acceptance": {"architect_acceptance_ref": ""},
+        "missing-digest": {"digest": ""},
+        "fork": {"fork_source_present": True},
+        "count-zero": {"create_count": 0},
+        "count-many": {"create_count": 2},
+        "identity-mismatch": {"binding_project_id": "other-project"},
+        "project-mismatch": {"binding_cwd": "/other/project"},
+        "transcript": {"transcript_read": True},
+        "history": {"history_read": True},
+    }
+    for name, override in negatives.items():
+        case = {"role_operation": {"action": "create", "capability_receipt": {
+            "capability": "create", "status": "supported", "provenance": "observed",
+            "creation_boundary": creation_boundary(**override),
+        }}}
+        code, output = run(case)
+        expect(f"creation-boundary-{name}-held", code == 0 and output["adapter_plan"]["adapter_decision"] == "hold_required" and output["adapter_plan"]["creation_boundary_state"] == "not_available", output, errors)
 
     if errors:
         print("\n".join(errors), file=sys.stderr)

--- a/workflows/github-collaboration-helper.md
+++ b/workflows/github-collaboration-helper.md
@@ -158,17 +158,19 @@ outside this pilot.
 
 ### Same-project creation boundary
 
-When a host dogfood has produced a durable terminal receipt, the Codex
-projection may report `creation_boundary_state:
-same_project_creation_boundary_verified`. This is narrower than fresh-context
-proof: the receipt must name the terminal and Architect acceptance records,
-source and digest, a new opaque identity, and the
-`durable_scheduler_reference` verification source. It must also prove exactly
-one `create_thread` primitive, no predecessor/fork source, matching
-`project_id`/`cwd` binding, correlated post-create readback, and explicit
-false values for projectless, child-worktree, retry, dispatch, transcript,
-history, and turn reads. The adapter only projects this evidence; it does not
-verify GitHub or call the host.
+The generic JSON planner always reports
+`creation_boundary_state:same_project_creation_boundary_unverified` and
+`hold_required`, even when a caller supplies a complete-looking host receipt.
+It has no trusted scheduler verifier, so terminal/Architect refs, source,
+digest, opaque identity, and `durable_scheduler_reference` are descriptive
+inputs only and never establish trust. A separately bounded, adapter-owned
+scheduler verifier is required before any future projection may use the
+`same_project_creation_boundary_verified` state. The intended trusted receipt
+would prove exactly one `create_thread` primitive, no predecessor/fork source,
+matching `project_id`/`cwd` binding, correlated post-create readback, and
+explicit false values for projectless, child-worktree, retry, dispatch,
+transcript, history, and turn reads. The adapter does not verify GitHub or
+call the host.
 
 Missing or inconsistent fields produce a hold. The result must never be
 labelled `same_project_fresh_host_path_verified` or

--- a/workflows/github-collaboration-helper.md
+++ b/workflows/github-collaboration-helper.md
@@ -156,6 +156,28 @@ It proposes no real tool call: all adapter output reports
 hooks, custom agents, policy records, runtime installation, and telemetry stay
 outside this pilot.
 
+### Same-project creation boundary
+
+When a host dogfood has produced a durable terminal receipt, the Codex
+projection may report `creation_boundary_state:
+same_project_creation_boundary_verified`. This is narrower than fresh-context
+proof: the receipt must name the terminal and Architect acceptance records,
+source and digest, a new opaque identity, and the
+`durable_scheduler_reference` verification source. It must also prove exactly
+one `create_thread` primitive, no predecessor/fork source, matching
+`project_id`/`cwd` binding, correlated post-create readback, and explicit
+false values for projectless, child-worktree, retry, dispatch, transcript,
+history, and turn reads. The adapter only projects this evidence; it does not
+verify GitHub or call the host.
+
+Missing or inconsistent fields produce a hold. The result must never be
+labelled `same_project_fresh_host_path_verified` or
+`fresh_context_verified`, and it must not claim inherited history is absent.
+A future forensic upgrade requires host evidence such as `parentThreadId`,
+`forkSource`, and `contextInheritance`. Until then,
+`freshness_forensic_evidence` is `unavailable`, and onboarding must not create
+another duplicate thread solely because freshness cannot be observed.
+
 ## User-Facing Entry Points
 
 Agents should expose these as natural-language workflows rather than requiring

--- a/workflows/github-collaboration-helper.md
+++ b/workflows/github-collaboration-helper.md
@@ -156,29 +156,24 @@ It proposes no real tool call: all adapter output reports
 hooks, custom agents, policy records, runtime installation, and telemetry stay
 outside this pilot.
 
-### Same-project creation boundary
+### Codex project/thread binding classification
 
-The generic JSON planner always reports
-`creation_boundary_state:same_project_creation_boundary_unverified` and
-`hold_required`, even when a caller supplies a complete-looking host receipt.
-It has no trusted scheduler verifier, so terminal/Architect refs, source,
-digest, opaque identity, and `durable_scheduler_reference` are descriptive
-inputs only and never establish trust. A separately bounded, adapter-owned
-scheduler verifier is required before any future projection may use the
-`same_project_creation_boundary_verified` state. The intended trusted receipt
-would prove exactly one `create_thread` primitive, no predecessor/fork source,
-matching `project_id`/`cwd` binding, correlated post-create readback, and
-explicit false values for projectless, child-worktree, retry, dispatch,
-transcript, history, and turn reads. The adapter does not verify GitHub or
-call the host.
-
-Missing or inconsistent fields produce a hold. The result must never be
-labelled `same_project_fresh_host_path_verified` or
-`fresh_context_verified`, and it must not claim inherited history is absent.
-A future forensic upgrade requires host evidence such as `parentThreadId`,
-`forkSource`, and `contextInheritance`. Until then,
-`freshness_forensic_evidence` is `unavailable`, and onboarding must not create
-another duplicate thread solely because freshness cannot be observed.
+Before a host creates a successor thread, classify a metadata-only
+`project_binding_observation`. The classifier distinguishes `local_folder_project`,
+`git_repository_project`, `git_worktree_project`, `fork_inherited_context`, and
+`projectless_fresh_context`. A same-project fresh result is valid only when
+`project_id`, `project_root`, and `cwd` match exactly, `fresh_context` is true,
+and trusted host readback is present. Core never treats a caller-supplied
+`runtime_owned_proof: true` boolean as trusted and therefore never emits a
+ready result; only a future trusted host adapter may emit
+`same_project_fresh_verified`. Forks hold as
+`held_inherited_context_rejected`; projectless results hold as
+`held_projectless_fallback_rejected`; missing or mismatched identity holds as
+`held_project_binding_mismatch`. A non-Git local folder without runtime-owned
+proof holds as `held_same_project_fresh_unavailable` and explicitly requires a
+Human UI fallback. This is classification only: it makes no host call and must
+report both mutation and dispatch as false. Desktop UI success must never be
+used as evidence that the connector supports the same request.
 
 ## User-Facing Entry Points
 


### PR DESCRIPTION
## Scope
Implement the approved #499 Core-only projection state for the verified same-project creation boundary.

## Changes
- require durable terminal/Architect refs, source/digest/opaque identity, and scheduler verification source
- accept only exactly one `create_thread` with matching project/cwd readback and explicit no-fork/no-history/no-retry/no-dispatch evidence
- project `same_project_creation_boundary_verified` while keeping forensic freshness `unavailable`
- add #517 positive fixture and negative fail-closed fixtures
- document future `parentThreadId`/`forkSource`/`contextInheritance` forensic upgrade

## Boundaries
No host calls, GitHub mutation, Vault/runtime/W10/Project mutation, candidate dispatch, merge, or #499 closure.

## Verification
- `python3 scripts/test_codex_route_adapter.py`
- `python3 -m py_compile scripts/plan_codex_route_adapter.py scripts/test_codex_route_adapter.py`
- `git diff --check`

Base: `616ca99dd2e0b869ced45aff0120b4d6a01afa67`
Head: `0b98c04f526ca20d26ab63d3566116f3c98830c9`
