### PR TITLE
[ORCH-02-2] Make SQLite action retries deterministic

### DIFF
--- a/scripts/github_collaboration_helper.py
+++ b/scripts/github_collaboration_helper.py
@@ -9,6 +9,7 @@ generated output, private state, or memory-system records.
 from __future__ import annotations
 
 import argparse
+import datetime as datetime_module
 import html
 import json
 import os
@@ -2293,6 +2294,32 @@ LOCAL_ACTION_REQUIRED_GATES = {
 }
 
 
+def sqlite_action_timestamp_valid(value: Any) -> bool:
+    """Accept only the stable UTC whole-second timestamp used by SQLite actions."""
+    if not isinstance(value, str) or value != value.strip():
+        return False
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", value):
+        return False
+    try:
+        datetime_module.datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError:
+        return False
+    return True
+
+
+def fail_sqlite_action_timestamp(args: argparse.Namespace) -> None:
+    payload = {
+        "status": "hold",
+        "error": "sqlite_action_timestamp_invalid",
+        "mutation_performed": False,
+    }
+    if getattr(args, "json", False):
+        print_json_or_text(payload, True)
+    else:
+        print("sqlite_action_timestamp_invalid: explicit UTC whole-second timestamp required", file=sys.stderr)
+    raise SystemExit(6)
+
+
 def normalize_local_action_collection(data: Any) -> tuple[list[dict[str, Any]], list[str]]:
     if isinstance(data, dict) and "actions" in data:
         data = data["actions"]
@@ -2556,6 +2583,8 @@ def cmd_local_ledger_action_apply(args: argparse.Namespace) -> None:
         values, action_errors = normalize_local_action_collection(actions)
         if action_errors or not values:
             fail("sqlite_action_invalid", "; ".join(action_errors + ([] if values else ["at least one approved local action is required"])))
+        if any(not sqlite_action_timestamp_valid(item.get("occurred_at")) for item in values):
+            fail_sqlite_action_timestamp(args)
         values = [local_action_event(item) for item in values]
         result = sqlite_local_action_batch(args.projects_root, args.project_id, values)
         print_json_or_text(result, args.json)

--- a/scripts/test_sqlite_collaboration_workflow.py
+++ b/scripts/test_sqlite_collaboration_workflow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -21,6 +22,22 @@ from sqlite_collaboration_workflow import (
 
 def event(event_id: str, event_type: str = "assignment", owner: str = "implementer") -> dict:
     return {"event_id": event_id, "event_type": event_type, "occurred_at": "2026-01-01T00:00:00Z", "work_item": {"id": "issue:1"}, "actor_role": "architect", "confidence": "observed", "payload": {"owner_role": owner}}
+
+
+def run_sqlite_action(root: Path, project_id: str, action_path: Path) -> subprocess.CompletedProcess[str]:
+    script = Path(__file__).resolve().parents[1] / "scripts" / "github_collaboration_helper.py"
+    return subprocess.run(
+        [sys.executable, str(script), "local-ledger-action-apply", "--ledger-backend", "sqlite", "--projects-root", str(root), "--project-id", project_id, "--action-json", str(action_path), "--json"],
+        text=True,
+        capture_output=True,
+        check=False,
+        cwd=script.parents[1],
+        env={**os.environ, "PYTHONPATH": str(script.parent)},
+    )
+
+
+def cli_action(action_id: str, *, occurred_at: object = "2026-01-01T00:00:00Z", owner: str = "implementer") -> dict:
+    return {"action_id": action_id, "action_type": "assignment", "occurred_at": occurred_at, "work_item": {"id": "issue:1"}, "approved_by_role": "agent", "payload": {"owner_role": owner}}
 
 
 def main() -> int:
@@ -73,6 +90,56 @@ def main() -> int:
         assert corrupt_action["status"] == "hold" and corrupt_action["reason"] == "integrity"
         assert authority.stat().st_mtime_ns == before_mtime
         assert sidecars_before == {suffix: Path(str(authority) + suffix).exists() for suffix in ("-wal", "-shm")}
+
+        # SQLite action timestamps are validated before authority resolution or
+        # any writable open.  Invalid input must not create a project or sidecars.
+        invalid_root = Path(tmp) / "invalid-action"
+        invalid_action = Path(tmp) / "invalid-action.json"
+        invalid_action.write_text(json.dumps(cli_action("invalid", occurred_at="2026-01-01T00:00:00.000Z")), encoding="utf-8")
+        invalid_run = run_sqlite_action(invalid_root, "00000000-0000-0000-0000-000000000000", invalid_action)
+        assert invalid_run.returncode == 6
+        invalid_output = invalid_run.stdout + invalid_run.stderr
+        assert "sqlite_action_timestamp_invalid" in invalid_output and "2026-01-01" not in invalid_output
+        assert "mutation_performed" in invalid_output and "true" not in invalid_output.lower()
+        assert not invalid_root.exists()
+
+        action_root = Path(tmp) / "cli-actions"
+        onboard = fresh_onboarding(action_root, "repo", "example/tiny-ipa")
+        action_pid = onboard["project_id"]
+        action_path = Path(tmp) / "action.json"
+        action_path.write_text(json.dumps(cli_action("cli-action")), encoding="utf-8")
+        first_run = run_sqlite_action(action_root, action_pid, action_path)
+        assert first_run.returncode == 0, (first_run.stdout, first_run.stderr)
+        first_doc = json.loads(first_run.stdout)
+        assert first_doc["status"] == "ok" and first_doc["appended_count"] == 1 and first_doc["duplicate_count"] == 0
+        db_path = action_root / action_pid / "collaboration.db"
+        db_mtime = db_path.stat().st_mtime_ns
+        sidecars = {suffix: Path(str(db_path) + suffix).exists() for suffix in ("-wal", "-shm")}
+        retry_run = run_sqlite_action(action_root, action_pid, action_path)
+        assert retry_run.returncode == 0, (retry_run.stdout, retry_run.stderr)
+        retry_doc = json.loads(retry_run.stdout)
+        assert retry_doc["status"] == "ok" and retry_doc["appended_count"] == 0 and retry_doc["duplicate_count"] == 1
+        changed_timestamp = Path(tmp) / "changed-timestamp.json"
+        changed_timestamp.write_text(json.dumps(cli_action("cli-action", occurred_at="2026-01-01T00:00:01Z")), encoding="utf-8")
+        changed_run = run_sqlite_action(action_root, action_pid, changed_timestamp)
+        assert changed_run.returncode == 6
+        changed_doc = json.loads(changed_run.stdout)
+        assert changed_doc["status"] == "hold" and changed_doc["reason"] == "conflict" and changed_doc["mutation_performed"] is False
+        changed_business = Path(tmp) / "changed-business.json"
+        changed_business.write_text(json.dumps(cli_action("cli-action", owner="reviewer")), encoding="utf-8")
+        business_run = run_sqlite_action(action_root, action_pid, changed_business)
+        assert business_run.returncode == 6
+        business_doc = json.loads(business_run.stdout)
+        assert business_doc["status"] == "hold" and business_doc["reason"] == "conflict" and business_doc["mutation_performed"] is False
+        invalid_existing = Path(tmp) / "invalid-existing.json"
+        invalid_existing.write_text(json.dumps(cli_action("invalid-existing", occurred_at="2026-01-01T00:00:00+00:00")), encoding="utf-8")
+        invalid_before_mtime = db_path.stat().st_mtime_ns
+        invalid_before_sidecars = {suffix: Path(str(db_path) + suffix).exists() for suffix in ("-wal", "-shm")}
+        invalid_existing_run = run_sqlite_action(action_root, action_pid, invalid_existing)
+        assert invalid_existing_run.returncode == 6
+        assert "sqlite_action_timestamp_invalid" in invalid_existing_run.stdout and "00:00+00:00" not in invalid_existing_run.stdout
+        assert db_path.stat().st_mtime_ns == invalid_before_mtime
+        assert invalid_before_sidecars == {suffix: Path(str(db_path) + suffix).exists() for suffix in ("-wal", "-shm")}
         print(json.dumps({"status": "ok", "project_id": pid, "events": 2}))
     return 0
 


### PR DESCRIPTION
## ORCH-02 timestamp repair

Fixes the adopter-dogfood finding from #530: SQLite local actions now require an explicit canonical UTC whole-second occurred_at before authority resolution/open, making identical retries idempotent while preserving divergent conflict holds.

Base: 8fb0f256f14d1d61787444b4ffcb3888f0fcf366
Head: 2a71aa81c00658ac482f1897e5451a1a0d35001d

Allowlist:
- scripts/github_collaboration_helper.py
- scripts/test_sqlite_collaboration_workflow.py

Contract: https://github.com/farmerhunter/agent-foundry/issues/528#issuecomment-5237717149
Architect: https://github.com/farmerhunter/agent-foundry/issues/528#issuecomment-5237816902
Reviewer: https://github.com/farmerhunter/agent-foundry/issues/528#issuecomment-5237781203
Tester: https://github.com/farmerhunter/agent-foundry/issues/528#issuecomment-5237804247
